### PR TITLE
Prepare transfer to w3c organization

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 François Daoust
+Copyright (c) 2020 World Wide Web Consortium
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The crawler reads parameters from the `config.json` file. Optional parameters:
 
 Authors so far are [François Daoust](https://github.com/tidoust/) and [Dominique Hazaël-Massieux](https://github.com/dontcallmedom/).
 
-Additional ideas, bugs and/or code contributions are most welcome. Create [issues on GitHub](https://github.com/tidoust/reffy/issues) as needed!
+Additional ideas, bugs and/or code contributions are most welcome. Create [issues on GitHub](https://github.com/w3c/reffy/issues) as needed!
 
 
 ## Licensing

--- a/builds/browser.js
+++ b/builds/browser.js
@@ -2779,7 +2779,7 @@ for more information.`;
 
   function extractDefinitions (spec, idToHeading = {}) {
     const definitionsSelector = [
-      // re data-lt, see https://github.com/tidoust/reffy/issues/336#issuecomment-650339747
+      // re data-lt, see https://github.com/w3c/reffy/issues/336#issuecomment-650339747
       'dfn[id]:not([data-lt=""])',
       'h2[id][data-dfn-type]:not([data-lt=""])',
       'h3[id][data-dfn-type]:not([data-lt=""])',

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "W3C/WHATWG spec dependencies exploration companion. Features a short set of tools to study spec references as well as WebIDL term definitions and references found in W3C specifications.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tidoust/reffy.git"
+    "url": "https://github.com/w3c/reffy.git"
   },
   "bugs": {
-    "url": "https://github.com/tidoust/reffy/issues"
+    "url": "https://github.com/w3c/reffy/issues"
   },
   "author": {
     "name": "tidoust",

--- a/src/browserlib/extract-dfns.js
+++ b/src/browserlib/extract-dfns.js
@@ -125,7 +125,7 @@ function definitionMapper(el, idToHeading) {
 
 export default function (spec, idToHeading = {}) {
   const definitionsSelector = [
-    // re data-lt, see https://github.com/tidoust/reffy/issues/336#issuecomment-650339747
+    // re data-lt, see https://github.com/w3c/reffy/issues/336#issuecomment-650339747
     'dfn[id]:not([data-lt=""])',
     'h2[id][data-dfn-type]:not([data-lt=""])',
     'h3[id][data-dfn-type]:not([data-lt=""])',

--- a/src/templates/report-perissue-template.html
+++ b/src/templates/report-perissue-template.html
@@ -31,7 +31,7 @@
   $include-before$
   $endfor$
   <h1>Reffy crawl report (per issue)</h1>
-  <p><a href="https://github.com/tidoust/reffy">Reffy</a> is a <i>spec exploration tool</i>. It crawls a list of specifications to study the WebIDL content, the links that they contain, and the references that these specifications contain.</p>
+  <p><a href="https://github.com/w3c/reffy">Reffy</a> is a <i>spec exploration tool</i>. It crawls a list of specifications to study the WebIDL content, the links that they contain, and the references that these specifications contain.</p>
   $body$
   $for(include-after)$
   $include-after$

--- a/src/templates/report-template.html
+++ b/src/templates/report-template.html
@@ -39,7 +39,7 @@
       $endif$
     </header>
   $endif$
-  <p><a href="https://github.com/tidoust/reffy">Reffy</a> is a <i>spec exploration tool</i>. It crawls a list of specifications to study the WebIDL content, the links that they contain, and the references that these specifications contain.</p>
+  <p><a href="https://github.com/w3c/reffy">Reffy</a> is a <i>spec exploration tool</i>. It crawls a list of specifications to study the WebIDL content, the links that they contain, and the references that these specifications contain.</p>
   <p>
     <label for="filter">View</label>
     <select name="filter" id="filter">

--- a/w3c.json
+++ b/w3c.json
@@ -1,0 +1,4 @@
+{
+  "contacts": ["dontcallmedom", "tidoust"],
+  "repo-type": "tool"
+}


### PR DESCRIPTION
Updates all reference to `tidoust/reffy` across files, updates copyright notice and adds a `w3c.json` file.

See #449.

To be merged right after the transfer has taken place.