### PR TITLE
Add script to generate report on spec links robustness

### DIFF
--- a/src/cli/study-backrefs.js
+++ b/src/cli/study-backrefs.js
@@ -32,6 +32,7 @@ const shortNamesOfOutdatedSpecs = {
 };
 
 const shortnameMap = {
+  "mixedcontent": "mixed-content",
   "powerfulfeatures": "secure-contexts",
   "hr-time-2": "hr-time",
   "csp": "CSP",
@@ -145,11 +146,9 @@ function studyCrawlResults(results) {
               // Ignore links to previous versions
               if (m[1] !== spec.shortname) {
                 recordAnomaly(spec, "datedUrl", l);
-                return;
               }
             } else {
               recordAnomaly(spec, "unknownSpec", l);
-              return;
             }
           }
         }
@@ -158,16 +157,15 @@ function studyCrawlResults(results) {
         } else if (shortNamesOfOutdatedSpecs[shortname]) {
           recordAnomaly(spec, "outdatedSpec", l);
         }
+        if (!shortname) { return ;}
         // self-references might be broken because of ed vs tr
         if (shortname === spec.shortname || shortname === spec.series.shortname) return [];
         let sourceSpec = results.find(s => s.shortname === shortname || s.series.shortname === shortname);
         if (!sourceSpec) {
-          if (!shortNamesOfOutdatedSpecs[shortname] && !shortnameOfNonNormativeDocs.includes(shortname)) {
+          if (shortname && !shortNamesOfOutdatedSpecs[shortname] && !shortnameOfNonNormativeDocs.includes(shortname)) {
             recordUnknownSpec(l, shortname, spec)
           }
           return;
-        } else {
-          
         }
         let headings = sourceSpec.headings || [];
         let dfns = sourceSpec.dfns || [];

--- a/src/cli/study-backrefs.js
+++ b/src/cli/study-backrefs.js
@@ -224,6 +224,13 @@ if (require.main === module) {
   let report = "";
   Object.keys(results).forEach(s => {
     report += `<details><summary><a href="${s}">${results[s].title}</a></summary>\n\n`;
+    if (results[s].brokenLink.length) {
+      report += "Links to anchors that don't exist:\n"
+      results[s].brokenLink.forEach(l => {
+        report += "* " + l + "\n";
+      })
+      report += "\n\n";
+    }
     if (results[s].notDfn.length) {
       report += "Links to anchors that are not definitions or headings:\n"
       results[s].notDfn.forEach(l => {

--- a/src/cli/study-backrefs.js
+++ b/src/cli/study-backrefs.js
@@ -298,7 +298,9 @@ if (require.main === module) {
 
   const results = studyCrawlResults(edCrawlResults.results, trCrawlResults.results);
   let report = "";
-  Object.keys(results).forEach(s => {
+  Object.keys(results)
+    .sort((r1, r2) => results[r1].title.localeCompare(results[r2].title))
+    .forEach(s => {
     report += `<details><summary><a href="${s}">${results[s].title}</a></summary>\n\n`;
     if (results[s].brokenLink.length) {
       report += "Links to anchors that don't exist:\n"

--- a/src/cli/study-backrefs.js
+++ b/src/cli/study-backrefs.js
@@ -2,34 +2,56 @@
 const requireFromWorkingDirectory = require('../lib/util').requireFromWorkingDirectory;
 const canonicalizeUrl = require('../../builds/canonicalize-url').canonicalizeUrl;
 const canonicalizesTo = require('../../builds/canonicalize-url').canonicalizesTo;
+// FIXME
 const computeShortName = require('../../../browser-specs/src/compute-shortname');
 const fs = require("fs");
 
 const matchSpecUrl = url => url.match(/spec.whatwg.org/) || url.match(/www.w3.org\/TR\/[a-z0-9]/) || (url.match(/.github.io/) && ! url.match(/w3c.github.io\/test-results\//));
-const missingSpecs = {};
 
 // TODO
-// dated URLs
-// report outdated shortnames
-// crawl all ids and report broken links
+// report broken links based on crawled ids
 
 // shortnames for specs that should no longer be linked to
 const shortNamesOfOutdatedSpecs = {
+  "html52": "https://html.spec.whatwg.org/",
   "html51": "https://html.spec.whatwg.org/",
   "html5": "https://html.spec.whatwg.org/",
   "html50": "https://html.spec.whatwg.org/",
   "domcore": "https://dom.spec.whatwg.org/",
+  "2dcontext": "https://html.spec.whatwg.org/",
+  "2dcontext2": "https://html.spec.whatwg.org/",
+  "worklets-1": "https://html.spec.whatwg.org/",
+  "workers": "https://html.spec.whatwg.org/",
+  "webstorage": "https://html.spec.whatwg.org/",
+  "custom-elements": "https://html.spec.whatwg.org/",
+  "selectors-api": "https://dom.spec.whatwg.org/",
+  "websockets": "https://html.spec.whatwg.org/",
+  "eventsource": "https://html.spec.whatwg.org/",
+  "webmessaging": "https://html.spec.whatwg.org/",
+  "cors":  "https://fetch.spec.whatwg.org/",
 };
 
 const shortnameMap = {
+  "powerfulfeatures": "secure-contexts",
   "hr-time-2": "hr-time",
   "csp": "CSP",
+  "CSP2": "CSP",
+  "content-security-policy": "CSP",
+  "feature-policy": "permissions-policy",
+  "css2": "CSS21",
+  "css-contain-1": "css-contain",
   "css3-background": "css-backgrounds",
   "css3-break": "css-break",
   "css3-color": "css-color",
+  "css-color-3": "css-color",
+  "css3-align": "css-align",
+  "css3-box": "css-box",
   "css3-flexbox": "css-flexbox",
   "css3-fonts": "css-fonts",
+  "css-fonts-3": "css-fonts",
   "css3-grid-layout": "css-grid",
+  "css-grid-1": "css-grid",
+  "css3-animations": "css-animations",
   "css3-images": "css-images",
   "css3-mediaqueries": "mediaqueries",
   "css3-multicol": "css-multicol",
@@ -39,31 +61,65 @@ const shortnameMap = {
   "css3-regions": "css-regions",
   "css3-speech": "css-speech",
   "css3-syntax": "css-syntax",
+  "css3-transforms": "css-transforms",
+  "css-ui-3": "css-ui",
   "css3-text": "css-text",
   "css3-transitions": "css-transitions",
   "css3-values": "css-values",
   "css3-writing-modes": "css-writing-modes",
+  "css-writing-modes-3": "css-writing-modes",
   "css3-selectors": "selectors",
   "css-selectors-3": "selectors",
+  "selectors-3": "selectors",
   "css-selectors": "selectors",
   "selectors4": "selectors",
-  // error in latest crawl
+  "webdriver1": "webdriver2",
   "webdriver": "webdriver2",
   "resource-timing": "resource-timing-2",
-  "html-aam": "html-aam-1.0"
+  "html-aam": "html-aam-1.0",
+  "ServiceWorker": "service-workers",
+  "BackgroundSync": "background-sync",
+  "InputDeviceCapabilities": "input-device-capabilities",
+  "IntersectionObserver": "intersection-observer",
+  "wasm-core-1": "wasm-core",
+  "pointerevents2": "pointerevents",
+  "input-events-1": "input-events",
+  "accname-aam-1.1": "accname",
+  "core-aam-1.1": "core-aam",
+  "accname-1.1": "accname",
+  "webauthn-1": "webauthn",
+  "resource-timing-1": "resource-timing",
+  "wai-aria-1.1": "wai-aria-1.2"
 };
+
+// TODO: check the link is non-normative (somehow)
+const shortnameOfNonNormativeDocs = [
+  "aria-practices", "rdf11-primer", "discovery-api", "wake-lock-use-cases", "capability-urls", "streamproc", "media-source-testcoverage", "using-aria", "wai-aria-practices-1.1", "sensor-polyfills", "sensors", "design-principles", "security-questionnaire", "css3-preslev", "clreq", "klreq", "typography", "ssml-sayas", "css3-marquee", "spatial-navigation", "ilreq", "css-print", "books", "dpub-pagination", "predefined-counter-styles", "css-2017", "sniffly", "wai-aria-practices-1.2", "wai-aria-implementation", "wai-aria-roadmap", "wai-aria-practices", "webdatabase", "installable-webapps", "motion-sensors", "file-system-api", "media-accessibility-reqs", "webrtc-interop-reports", "webaudio-usecases", "web-audio-perf", "Audio-EQ-Cookbook", "web-intents", "touch-events-extensions", "fingerprinting-guidance", "webrtc-nv-use-cases", "html-design-principles", "storage-partitioning", "jlreq", "accept-encoding-range-test", "security-privacy-questionnaire", "dpub-latinreq"
+];
 
 const report = {};
 
 function recordAnomaly(spec, anomalyType, link) {
-  if (!report[spec]) {
-    report[spec] = {
+  if (!report[spec.url]) {
+    report[spec.url] = {
+      title: spec.title,
       notExported: [],
       notDfn: [],
-      unknownSpec: []
+      outdatedSpec: [],
+      unknownSpec: [],
+      datedUrl: []
     };
   }
-  report[spec][anomalyType].push(link);
+  report[spec.url][anomalyType].push(link);
+}
+
+const missingSpecs = {};
+
+function recordUnknownSpec(link, shortname, spec) {
+  if (!missingSpecs[shortname]) {
+    missingSpecs[shortname] = [];
+  }
+  missingSpecs[shortname].push({link, spec: spec.url});
 }
 
 function studyCrawlResults(results) {
@@ -86,52 +142,58 @@ function studyCrawlResults(results) {
           } catch (e) {
             let m = l.match(/www\.w3\.org\/TR\/[0-9]{4}\/[A-Z]+-(.+)-[0-9]{8}/);
             if (m) {
-              shortname = m[1];
+              // Ignore links to previous versions
+              if (m[1] !== spec.shortname) {
+                recordAnomaly(spec, "datedUrl", l);
+                return;
+              }
             } else {
-              recordAnomaly(spec.url, "unknownSpec", l);
+              recordAnomaly(spec, "unknownSpec", l);
               return;
             }
           }
         }
         if (shortnameMap[shortname]) {
           shortname = shortnameMap[shortname];
+        } else if (shortNamesOfOutdatedSpecs[shortname]) {
+          recordAnomaly(spec, "outdatedSpec", l);
         }
         // self-references might be broken because of ed vs tr
         if (shortname === spec.shortname || shortname === spec.series.shortname) return [];
+        let sourceSpec = results.find(s => s.shortname === shortname || s.series.shortname === shortname);
+        if (!sourceSpec) {
+          if (!shortNamesOfOutdatedSpecs[shortname] && !shortnameOfNonNormativeDocs.includes(shortname)) {
+            recordUnknownSpec(l, shortname, spec)
+          }
+          return;
+        } else {
+          
+        }
+        let headings = sourceSpec.headings || [];
+        let dfns = sourceSpec.dfns || [];
+        if (!dfns.length) {
+          if (fs.existsSync("../webref/ed/dfns/" + shortname + ".json")) {
+            dfns = JSON.parse(fs.readFileSync("../webref/ed/dfns/" + shortname + ".json", "utf-8")).dfns;
+          }
+          if (fs.existsSync("../webref/tr/dfns/" + shortname + ".json")) {
+            dfns = dfns.concat(JSON.parse(fs.readFileSync("../webref/ed/dfns/" + shortname + ".json", "utf-8")).dfns);
+          }
+          if (!dfns.length) {
+            recordUnknownSpec(l, shortname, spec)
+            return;
+          }
+        }
+
         // anchors
         const anchors = spec.links[l];
         for(let anchor of anchors) {
-          let sourceSpec = results.find(s => s.shortname === shortname || s.series.shortname === shortname);
-          if (!sourceSpec) {
-            if (!missingSpecs[shortname]) {
-              //report.push("No data crawled for " + shortname + " referenced in " + spec.url);
-              missingSpecs[shortname] = true;
-            }
-            continue;
-          }
-          let headings = sourceSpec.headings || [];
-          let dfns = sourceSpec.dfns || [];
-          if (!dfns.length) {
-            if (fs.existsSync("../webref/ed/dfns/" + shortname + ".json")) {
-              dfns = JSON.parse(fs.readFileSync("../webref/ed/dfns/" + shortname + ".json", "utf-8")).dfns;
-            }
-            if (fs.existsSync("../webref/tr/dfns/" + shortname + ".json")) {
-              dfns = dfns.concat(JSON.parse(fs.readFileSync("../webref/ed/dfns/" + shortname + ".json", "utf-8")).dfns);
-            }
-            if (!dfns.length) {
-              //report.push("No definitions crawled for " + shortname + " referenced in " + spec.url);
-              missingSpecs[shortname] = true;
-              continue;
-            }
-          }
           let heading = headings.find(h => h.id === anchor);
           let dfn = dfns.find(d => d.id === anchor);
           if (!heading && !dfn) {
-            recordAnomaly(spec.url, "notDfn", l + "#" + anchor);
+            recordAnomaly(spec, "notDfn", l + "#" + anchor);
           }
           if (dfn && dfn.access !== "public") {
-            recordAnomaly(spec.url, "notExported", l  + "#" + anchor);
-
+            recordAnomaly(spec, "notExported", l  + "#" + anchor);
           }
         }
       });
@@ -159,7 +221,7 @@ if (require.main === module) {
   const results = studyCrawlResults(crawlResults.results);
   let report = "";
   Object.keys(results).forEach(s => {
-    report += "<details><summary>" + s + "</summary>\n\n";
+    report += `<details><summary>[${results[s].title}](${s})</summary>\n\n`;
     if (results[s].notDfn.length) {
       report += "Links to anchors that are not definitions or headings:\n"
       results[s].notDfn.forEach(l => {
@@ -174,8 +236,22 @@ if (require.main === module) {
       })
       report += "\n\n";
     }
+    if (results[s].datedUrl.length) {
+      report += "Links to dated TR URLs:\n"
+      results[s].datedUrl.forEach(l => {
+        report += "* " + l + "\n";
+      })
+      report += "\n\n";
+    }
+    if (results[s].outdatedSpec.length) {
+      report += "Links to specs that should no longer be referenced:\n"
+      results[s].outdatedSpec.forEach(l => {
+        report += "* " + l + "\n";
+      })
+      report += "\n\n";
+    }
     if (results[s].unknownSpec.length) {
-      report += "Links to things that look like specs but that aren't recognized in reffy data::\n"
+      report += "Links to things that look like specs but that aren't recognized in reffy data:\n"
       results[s].unknownSpec.forEach(l => {
         report += "* " + l + "\n";
       })
@@ -184,5 +260,5 @@ if (require.main === module) {
     report += "</details>\n";
   });
   console.log(report);
-  console.error(JSON.stringify(Object.keys(missingSpecs).sort(), null, 2));
+  console.error(JSON.stringify(missingSpecs, null, 2));
 }

--- a/src/cli/study-backrefs.js
+++ b/src/cli/study-backrefs.js
@@ -8,13 +8,22 @@ const fs = require("fs");
 const matchSpecUrl = url => url.match(/spec.whatwg.org/) || url.match(/www.w3.org\/TR\/[a-z0-9]/) || (url.match(/.github.io/) && ! url.match(/w3c.github.io\/test-results\//));
 const missingSpecs = {};
 
+// TODO
+// dated URLs
+// report outdated shortnames
+// crawl all ids and report broken links
+
+// shortnames for specs that should no longer be linked to
+const shortNamesOfOutdatedSpecs = {
+  "html51": "https://html.spec.whatwg.org/",
+  "html5": "https://html.spec.whatwg.org/",
+  "html50": "https://html.spec.whatwg.org/",
+  "domcore": "https://dom.spec.whatwg.org/",
+};
+
 const shortnameMap = {
-  "html51": "html",
-  "html5": "html",
-  "html50": "html",
   "hr-time-2": "hr-time",
   "csp": "CSP",
-  "domcore": "dom",
   "css3-background": "css-backgrounds",
   "css3-break": "css-break",
   "css3-color": "css-color",

--- a/src/cli/study-backrefs.js
+++ b/src/cli/study-backrefs.js
@@ -106,6 +106,7 @@ function recordAnomaly(spec, anomalyType, link) {
       title: spec.title,
       notExported: [],
       notDfn: [],
+      brokenLink: [],
       outdatedSpec: [],
       unknownSpec: [],
       datedUrl: []
@@ -169,6 +170,7 @@ function studyCrawlResults(results) {
         }
         let headings = sourceSpec.headings || [];
         let dfns = sourceSpec.dfns || [];
+        let ids = sourceSpec.ids || [];
         if (!dfns.length) {
           if (fs.existsSync("../webref/ed/dfns/" + shortname + ".json")) {
             dfns = JSON.parse(fs.readFileSync("../webref/ed/dfns/" + shortname + ".json", "utf-8")).dfns;
@@ -185,12 +187,14 @@ function studyCrawlResults(results) {
         // anchors
         const anchors = spec.links[l];
         for(let anchor of anchors) {
+          let id = ids.includes(anchor);
           let heading = headings.find(h => h.id === anchor);
           let dfn = dfns.find(d => d.id === anchor);
-          if (!heading && !dfn) {
+          if (!id) {
+            recordAnomaly(spec, "brokenLink", l + "#" + anchor);
+          } else if (!heading && !dfn) {
             recordAnomaly(spec, "notDfn", l + "#" + anchor);
-          }
-          if (dfn && dfn.access !== "public") {
+          } else if (dfn && dfn.access !== "public") {
             recordAnomaly(spec, "notExported", l  + "#" + anchor);
           }
         }

--- a/src/cli/study-backrefs.js
+++ b/src/cli/study-backrefs.js
@@ -221,7 +221,7 @@ if (require.main === module) {
   const results = studyCrawlResults(crawlResults.results);
   let report = "";
   Object.keys(results).forEach(s => {
-    report += `<details><summary>[${results[s].title}](${s})</summary>\n\n`;
+    report += `<details><summary><a href="${s}">${results[s].title}</a></summary>\n\n`;
     if (results[s].notDfn.length) {
       report += "Links to anchors that are not definitions or headings:\n"
       results[s].notDfn.forEach(l => {

--- a/src/cli/study-backrefs.js
+++ b/src/cli/study-backrefs.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+const requireFromWorkingDirectory = require('../lib/util').requireFromWorkingDirectory;
+const canonicalizeUrl = require('../../builds/canonicalize-url').canonicalizeUrl;
+const canonicalizesTo = require('../../builds/canonicalize-url').canonicalizesTo;
+const computeShortName = require('../../../browser-specs/src/compute-shortname');
+const fs = require("fs");
+
+const matchSpecUrl = url => url.match(/spec.whatwg.org/) || url.match(/www.w3.org\/TR\/[a-z0-9]/) || (url.match(/w3c.github.io/) && ! url.match(/w3c.github.io\/test-results\//));
+
+const shortnameMap = {
+  "html51": "html",
+  "html5": "html",
+  "html50": "html",
+  "hr-time-2": "hr-time",
+  "webrtc-pc": "webrtc",
+  "csp": "CSP",
+  "subresource-integrity": "SRI",
+  "mediacapture-image": "image-capture",
+  "mediacapture-main": "mediacapture-streams",
+  "IntersectionObserver": "intersection-observer",
+  "manifest": "appmanifest",
+  "domcore": "dom",
+  "battery": "battery-status",
+  "css3-background": "css-backgrounds",
+  "css3-break": "css-break",
+  "css3-color": "css-color",
+  "css3-flexbox": "css-flexbox",
+  "css3-fonts": "css-fonts",
+  "css3-grid-layout": "css-grid",
+  "css3-images": "css-images",
+  "css3-multicol": "css-multicol",
+  "css3-namespace": "css-namespaces",
+  "css3-page": "css-page",
+  "css3-positioning": "css-position",
+  "css3-regions": "css-regions",
+  "css3-speech": "css-speech",
+  "css3-syntax": "css-syntax",
+  "css3-text": "css-text",
+  "css3-transitions": "css-transitions",
+  "css3-values": "css-values",
+  "css3-writing-modes": "css-writing-modes",
+  "css3-selectors": "selectors",
+  "css-selectors-3": "selectors",
+  "css-selectors": "selectors",
+  "selectors4": "selectors",
+  "ServiceWorker": "service-workers",
+  // error in latest crawl
+  "webdriver": "webdriver2",
+  "resource-timing": "resource-timing-2",
+  "html-aam": "html-aam-1.0"
+};
+
+function studyCrawlResults(results) {
+  return results.map(spec => {
+    return Object.keys(spec.links)
+      .filter(matchSpecUrl)
+      .map(l => {
+        let shortname;
+        const report = [];
+        try {
+          ({shortname} = computeShortName(l));
+        } catch (e) {
+          let m = l.match(/www\.w3\.org\/TR\/[0-9]{4}\/[A-Z]+-(.+)-[0-9]{8}/);
+          if (m) {
+            shortname = m[1];
+          } else {
+            report.push("No shortname found for " + l + " referenced in " + spec.url);
+            return report;
+          }
+        }
+        if (shortnameMap[shortname]) {
+          shortname = shortnameMap[shortname];
+        }
+        // self-references might be broken because of ed vs tr
+        if (shortname === spec.shortname || shortname === spec.series.shortname) return [];
+        // anchors
+        const anchors = spec.links[l];
+        for(let anchor of anchors) {
+          let sourceSpec = results.find(s => s.shortname === shortname || s.series.shortname === shortname);
+          if (!sourceSpec) {
+            report.push("No data crawled for " + shortname + " referenced in " + spec.url);
+            continue;
+          }
+          let headings = sourceSpec.headings || [];
+          let dfns = sourceSpec.dfns;
+          if (!dfns) {
+            if (fs.existsSync("../reffy-reports/ed/dfns/" + shortname + ".json")) {
+              dfns = JSON.parse(fs.readFileSync("../reffy-reports/ed/dfns/" + shortname + ".json", "utf-8")).dfns;
+            } else {
+              report.push("No definitions crawled for " + shortname + " referenced in " + spec.url);
+              continue;
+            }
+          }
+          let heading = headings.find(h => h.id === anchor);
+          let dfn = dfns.find(d => d.id === anchor);
+          if (!heading && !dfn) {
+            report.push("Anchor " + anchor + " of " + shortname + " found in " + spec.url + " is not a definition nor a heading");
+            continue;
+          }
+          if (dfn && dfn.access !== "public") {
+            report.push("Anchor " + anchor + " of " + shortname + " found in " + spec.url + " is not an exported definition");
+          }
+        }
+        return report;
+      })
+  });
+}
+
+
+if (require.main === module) {
+  const crawlResultsPath = process.argv[2];
+
+  if (!crawlResultsPath) {
+    console.error("Required crawl results parameter missing");
+    process.exit(2);
+  }
+
+  let crawlResults;
+  try {
+    crawlResults = requireFromWorkingDirectory(crawlResultsPath);
+  } catch(e) {
+    console.error("Impossible to read " + crawlResultsPath + ": " + e);
+    process.exit(3);
+  }
+
+  const results = studyCrawlResults(crawlResults.results);
+  console.log(JSON.stringify(results, null, 2));
+}

--- a/src/cli/study-backrefs.js
+++ b/src/cli/study-backrefs.js
@@ -1,9 +1,37 @@
 #!/usr/bin/env node
-const requireFromWorkingDirectory = require('../lib/util').requireFromWorkingDirectory;
-const {canonicalizeUrl, canonicalizesTo} = require('../../builds/canonicalize-url');
-const fs = require("fs");
+/**
+ * The backrefs analyzer takes links to a ED crawl folder and a TR crawl folder,
+ * and creates a report that lists, for each spec:
+ *
+ * - Links to anchors that do not exist
+ * - Links to anchors that no longer exist in the ED of the target spec
+ * - Links to anchors that are not definitions or headings
+ * - Links to definitions that are not exported
+ * - Links to dated TR URLs
+ * - Links to specs that should no longer be referenced
+ *
+ * It also flags links that look like specs but that do not appear in the crawl
+ * (most of these should be false positives).
+ *
+ * The backrefs analyzer can be called directly through:
+ *
+ * `node study-backrefs.js [root crawl folder]`
+ *
+ * where `root crawl folder` is the path to the root folder that contains `ed`
+ * and `tr` subfolders. Alternatively, the analyzer may be called with two
+ * arguments, one being the path to the ED crawl folder, another being the path
+ * to the TR crawl folder.
+ *
+ * @module backrefs
+ */
 
-const matchSpecUrl = url => url.match(/spec.whatwg.org/) || url.match(/www.w3.org\/TR\/[a-z0-9]/) || (url.match(/.github.io/) && ! url.match(/w3c.github.io\/test-results\//));
+const {expandCrawlResult, requireFromWorkingDirectory} = require("../lib/util");
+const path = require("path");
+
+const matchSpecUrl = url =>
+  url.match(/spec.whatwg.org/) ||
+  url.match(/www.w3.org\/TR\/[a-z0-9]/) ||
+  (url.match(/.github.io/) && ! url.match(/w3c.github.io\/test-results\//));
 
 /*
  TODO: DRY
@@ -88,46 +116,50 @@ function computeShortname(url) {
 
 // shortnames for specs that should no longer be linked to
 const shortNamesOfOutdatedSpecs = {
-  "html52": "https://html.spec.whatwg.org/",
-  "html51": "https://html.spec.whatwg.org/",
-  "html5": "https://html.spec.whatwg.org/",
-  "html50": "https://html.spec.whatwg.org/",
-  "domcore": "https://dom.spec.whatwg.org/",
   "2dcontext": "https://html.spec.whatwg.org/",
   "2dcontext2": "https://html.spec.whatwg.org/",
-  "worklets-1": "https://html.spec.whatwg.org/",
-  "workers": "https://html.spec.whatwg.org/",
-  "webstorage": "https://html.spec.whatwg.org/",
-  "custom-elements": "https://html.spec.whatwg.org/",
-  "selectors-api": "https://dom.spec.whatwg.org/",
-  "websockets": "https://html.spec.whatwg.org/",
-  "eventsource": "https://html.spec.whatwg.org/",
-  "webmessaging": "https://html.spec.whatwg.org/",
   "cors":  "https://fetch.spec.whatwg.org/",
+  "custom-elements": "https://html.spec.whatwg.org/",
+  "domcore": "https://dom.spec.whatwg.org/",
+  "eventsource": "https://html.spec.whatwg.org/",
+  "html5": "https://html.spec.whatwg.org/",
+  "html50": "https://html.spec.whatwg.org/",
+  "html51": "https://html.spec.whatwg.org/",
+  "html52": "https://html.spec.whatwg.org/",
+  "selectors-api": "https://dom.spec.whatwg.org/",
+  "webmessaging": "https://html.spec.whatwg.org/",
+  "websockets": "https://html.spec.whatwg.org/",
+  "webstorage": "https://html.spec.whatwg.org/",
+  "workers": "https://html.spec.whatwg.org/",
+  "worklets-1": "https://html.spec.whatwg.org/"
 };
 
 const shortnameMap = {
-  "mixedcontent": "mixed-content",
-  "powerfulfeatures": "secure-contexts",
-  "hr-time-2": "hr-time",
+  "accname-1.1": "accname",
+  "accname-aam-1.1": "accname",
+  "BackgroundSync": "background-sync",
+  "content-security-policy": "CSP",
+  "core-aam-1.1": "core-aam",
   "csp": "CSP",
   "CSP2": "CSP",
-  "content-security-policy": "CSP",
-  "feature-policy": "permissions-policy",
-  "css2": "CSS21",
+  "css-color-3": "css-color",
   "css-contain-1": "css-contain",
+  "css-fonts-3": "css-fonts",
+  "css-grid-1": "css-grid",
+  "css-selectors": "selectors",
+  "css-selectors-3": "selectors",
+  "css-ui-3": "css-ui",
+  "css-writing-modes-3": "css-writing-modes",
+  "css2": "CSS21",
+  "css3-align": "css-align",
+  "css3-animations": "css-animations",
   "css3-background": "css-backgrounds",
+  "css3-box": "css-box",
   "css3-break": "css-break",
   "css3-color": "css-color",
-  "css-color-3": "css-color",
-  "css3-align": "css-align",
-  "css3-box": "css-box",
   "css3-flexbox": "css-flexbox",
   "css3-fonts": "css-fonts",
-  "css-fonts-3": "css-fonts",
   "css3-grid-layout": "css-grid",
-  "css-grid-1": "css-grid",
-  "css3-animations": "css-animations",
   "css3-images": "css-images",
   "css3-mediaqueries": "mediaqueries",
   "css3-multicol": "css-multicol",
@@ -135,168 +167,225 @@ const shortnameMap = {
   "css3-page": "css-page",
   "css3-positioning": "css-position",
   "css3-regions": "css-regions",
+  "css3-selectors": "selectors",
   "css3-speech": "css-speech",
   "css3-syntax": "css-syntax",
-  "css3-transforms": "css-transforms",
-  "css-ui-3": "css-ui",
   "css3-text": "css-text",
+  "css3-transforms": "css-transforms",
   "css3-transitions": "css-transitions",
   "css3-values": "css-values",
   "css3-writing-modes": "css-writing-modes",
-  "css-writing-modes-3": "css-writing-modes",
-  "css3-selectors": "selectors",
-  "css-selectors-3": "selectors",
-  "selectors-3": "selectors",
-  "css-selectors": "selectors",
-  "selectors4": "selectors",
-  "webdriver1": "webdriver2",
-  "webdriver": "webdriver2",
-  "resource-timing": "resource-timing-2",
+  "feature-policy": "permissions-policy",
+  "hr-time-2": "hr-time",
   "html-aam": "html-aam-1.0",
-  "ServiceWorker": "service-workers",
-  "BackgroundSync": "background-sync",
+  "input-events-1": "input-events",
   "InputDeviceCapabilities": "input-device-capabilities",
   "IntersectionObserver": "intersection-observer",
-  "wasm-core-1": "wasm-core",
+  "mixedcontent": "mixed-content",
   "pointerevents2": "pointerevents",
-  "input-events-1": "input-events",
-  "accname-aam-1.1": "accname",
-  "core-aam-1.1": "core-aam",
-  "accname-1.1": "accname",
-  "webauthn-1": "webauthn",
+  "powerfulfeatures": "secure-contexts",
+  "resource-timing": "resource-timing-2",
   "resource-timing-1": "resource-timing",
-  "wai-aria-1.1": "wai-aria-1.2"
+  "selectors-3": "selectors",
+  "selectors4": "selectors",
+  "ServiceWorker": "service-workers",
+  "wai-aria-1.1": "wai-aria-1.2",
+  "wasm-core-1": "wasm-core",
+  "webauthn-1": "webauthn",
+  "webdriver": "webdriver2",
+  "webdriver1": "webdriver2"
 };
 
 // TODO: check the link is non-normative (somehow)
 const shortnameOfNonNormativeDocs = [
-  "aria-practices", "rdf11-primer", "discovery-api", "wake-lock-use-cases", "capability-urls", "streamproc", "media-source-testcoverage", "using-aria", "wai-aria-practices-1.1", "sensor-polyfills", "sensors", "design-principles", "security-questionnaire", "css3-preslev", "clreq", "klreq", "typography", "ssml-sayas", "css3-marquee", "spatial-navigation", "ilreq", "css-print", "books", "dpub-pagination", "predefined-counter-styles", "css-2017", "sniffly", "wai-aria-practices-1.2", "wai-aria-implementation", "wai-aria-roadmap", "wai-aria-practices", "webdatabase", "installable-webapps", "motion-sensors", "file-system-api", "media-accessibility-reqs", "webrtc-interop-reports", "webaudio-usecases", "web-audio-perf", "Audio-EQ-Cookbook", "web-intents", "touch-events-extensions", "fingerprinting-guidance", "webrtc-nv-use-cases", "html-design-principles", "storage-partitioning", "jlreq", "accept-encoding-range-test", "security-privacy-questionnaire", "dpub-latinreq"
+    "accept-encoding-range-test",
+  "aria-practices",
+  "Audio-EQ-Cookbook",
+  "books",
+  "capability-urls",
+  "clreq",
+  "css-2017",
+  "css-print",
+  "css3-marquee",
+  "css3-preslev",
+  "design-principles",
+  "discovery-api",
+  "dpub-latinreq",
+  "dpub-pagination",
+  "file-system-api",
+  "fingerprinting-guidance",
+  "html-design-principles",
+  "ilreq",
+  "installable-webapps",
+  "jlreq",
+  "klreq",
+  "media-accessibility-reqs",
+  "media-source-testcoverage",
+  "motion-sensors",
+  "predefined-counter-styles",
+  "rdf11-primer",
+  "security-privacy-questionnaire",
+  "security-questionnaire",
+  "sensor-polyfills",
+  "sensors",
+  "sniffly",
+  "spatial-navigation",
+  "ssml-sayas",
+  "storage-partitioning",
+  "streamproc",
+  "touch-events-extensions",
+  "typography",
+  "using-aria",
+  "wai-aria-implementation",
+  "wai-aria-practices",
+  "wai-aria-practices-1.1",
+  "wai-aria-practices-1.2",
+  "wai-aria-roadmap",
+  "wake-lock-use-cases",
+  "web-audio-perf",
+  "web-intents",
+  "webaudio-usecases",
+  "webdatabase",
+  "webrtc-interop-reports",
+  "webrtc-nv-use-cases"
 ];
 
-const report = {};
-
-function recordAnomaly(spec, anomalyType, link) {
-  if (!report[spec.url]) {
-    report[spec.url] = {
-      title: spec.title,
-      notExported: [],
-      notDfn: [],
-      brokenLink: [],
-      evolvingLink: [],
-      outdatedSpec: [],
-      unknownSpec: [],
-      datedUrl: []
-    };
-  }
-  report[spec.url][anomalyType].push(link);
-}
-
-const missingSpecs = {};
-
-function recordUnknownSpec(link, shortname, spec) {
-  if (!missingSpecs[shortname]) {
-    missingSpecs[shortname] = [];
-  }
-  missingSpecs[shortname].push({link, spec: spec.url});
-}
 
 function studyCrawlResults(edResults, trResults) {
+  const report = {};
+  const missingSpecs = {};
+
+  function recordAnomaly(spec, anomalyType, link) {
+    if (!report[spec.url]) {
+      report[spec.url] = {
+        title: spec.title,
+        notExported: [],
+        notDfn: [],
+        brokenLink: [],
+        evolvingLink: [],
+        outdatedSpec: [],
+        unknownSpec: [],
+        datedUrl: []
+      };
+    }
+    report[spec.url][anomalyType].push(link);
+  }
+
+  function recordUnknownSpec(link, shortname, spec) {
+    if (!missingSpecs[shortname]) {
+      missingSpecs[shortname] = [];
+    }
+    missingSpecs[shortname].push({link, spec: spec.url});
+  }
+
   edResults.forEach(spec => {
     Object.keys(spec.links)
       .filter(matchSpecUrl)
-      .forEach(l => {
+      .forEach(link => {
         let shortname;
-        let nakedLink = l.replace(/#.*$/, '');
+        let nakedLink = link;
         if (nakedLink.endsWith(".html")) {
-          nakedLink = nakedLink.replace(/\/[^/]*\.html/, '/');
+          nakedLink = nakedLink.replace(/\/[^/]*\.html$/, '/');
         }
         if (nakedLink[nakedLink.length - 1] !== '/') {
           nakedLink += '/';
         }
-        shortname = (edResults.find(r => r.url === nakedLink || (r.release && r.release.url === nakedLink) || r.nightly.url === nakedLink || (r.series && nakedLink === 'https://www.w3.org/TR/' + r.series.shortname + '/') ) || {}).shortname;
+        shortname = (edResults.find(r =>
+          r.url === nakedLink ||
+          (r.release && r.release.url === nakedLink) ||
+          r.nightly.url === nakedLink ||
+          (r.series && nakedLink === 'https://www.w3.org/TR/' + r.series.shortname + '/') ) || {}).shortname;
         if (!shortname) {
           try {
-            ({shortname} = computeShortname(l));
+            ({shortname} = computeShortname(link));
+            if (shortnameMap[shortname]) {
+              shortname = shortnameMap[shortname];
+            }
+            else if (shortNamesOfOutdatedSpecs[shortname]) {
+              recordAnomaly(spec, "outdatedSpec", link);
+            }
           } catch (e) {
-            let m = l.match(/www\.w3\.org\/TR\/[0-9]{4}\/[A-Z]+-(.+)-[0-9]{8}/);
+            let m = link.match(/www\.w3\.org\/TR\/[0-9]{4}\/[A-Z]+-(.+)-[0-9]{8}/);
             if (m) {
               // Ignore links to previous versions
               if (m[1] !== spec.shortname) {
-                recordAnomaly(spec, "datedUrl", l);
+                recordAnomaly(spec, "datedUrl", link);
               }
             } else {
-              recordAnomaly(spec, "unknownSpec", l);
+              recordAnomaly(spec, "unknownSpec", link);
             }
           }
         }
-        if (shortnameMap[shortname]) {
-          shortname = shortnameMap[shortname];
-        } else if (shortNamesOfOutdatedSpecs[shortname]) {
-          recordAnomaly(spec, "outdatedSpec", l);
-        }
-        if (!shortname) { return ;}
-        // self-references might be broken because of ed vs tr
-        if (shortname === spec.shortname || shortname === spec.series.shortname) return [];
-        let sourceSpec = edResults.find(s => s.shortname === shortname || s.series.shortname === shortname);
-        let trSourceSpec = trResults.find(s => s.shortname === shortname || s.series.shortname === shortname);
-        if (!sourceSpec) {
-          if (shortname && !shortNamesOfOutdatedSpecs[shortname] && !shortnameOfNonNormativeDocs.includes(shortname)) {
-            recordUnknownSpec(l, shortname, spec)
-          }
+        if (!shortname) {
           return;
         }
+
+        // Make sure that the targeted spec exists in the crawls, or can be
+        // ignored because it is an outdated spec (which will be reported as
+        // such), or because it is an informative spec
+        let sourceSpec = edResults.find(s => s.shortname === shortname || s.series.shortname === shortname);
+        if (!sourceSpec) {
+          if (shortNamesOfOutdatedSpecs[shortname] || shortnameOfNonNormativeDocs.includes(shortname)) {
+            return;
+          }
+          recordUnknownSpec(link, shortname, spec);
+        }
+
+        // Self-references might be broken because of ed vs tr
+        if (shortname === spec.shortname || shortname === spec.series.shortname) {
+          return;
+        }
+
+        let trSourceSpec = trResults.find(s => s.shortname === shortname || s.series.shortname === shortname) || {};
         let headings = sourceSpec.headings || [];
         let dfns = sourceSpec.dfns || [];
         let ids = sourceSpec.ids || [];
 
-        // anchors
-        const anchors = spec.links[l];
-        for(let anchor of anchors) {
-          let id = ids.includes(anchor);
+        // Check anchors
+        const anchors = spec.links[link];
+        for (let anchor of anchors) {
+          let isKnownId = ids.includes(anchor);
           let heading = headings.find(h => h.id === anchor);
           let dfn = dfns.find(d => d.id === anchor);
-          if (!id) {
-            if ((trSourceSpec.ids || []).includes(anchor) && l.match(/w3\.org\/TR\//)) {
-              recordAnomaly(spec, "evolvingLink", l + "#" + anchor);
+          if (!isKnownId) {
+            if ((trSourceSpec.ids || []).includes(anchor) && link.match(/w3\.org\/TR\//)) {
+              recordAnomaly(spec, "evolvingLink", link + "#" + anchor);
             } else {
-              recordAnomaly(spec, "brokenLink", l + "#" + anchor);
+              recordAnomaly(spec, "brokenLink", link + "#" + anchor);
             }
           } else if (!heading && !dfn) {
-            recordAnomaly(spec, "notDfn", l + "#" + anchor);
+            recordAnomaly(spec, "notDfn", link + "#" + anchor);
           } else if (dfn && dfn.access !== "public") {
-            recordAnomaly(spec, "notExported", l  + "#" + anchor);
+            recordAnomaly(spec, "notExported", link  + "#" + anchor);
           }
         }
       });
   });
-  return report;
+  return { report, missingSpecs };
 }
 
 
-if (require.main === module) {
-  const edCrawlResultsPath = process.argv[2];
-  const trCrawlResultsPath = process.argv[3];
-
-  if (!edCrawlResultsPath || !trCrawlResultsPath) {
-    console.error("Paths to crawl results from ED and TR parameter required");
-    process.exit(2);
-  }
-
+async function studyBackrefs(edCrawlResultsPath, trCrawlResultsPath) {
+  // Load the crawl results
   let edCrawlResults, trCrawlResults;
   try {
     edCrawlResults = requireFromWorkingDirectory(edCrawlResultsPath);
   } catch(e) {
-    console.error("Impossible to read " + edCrawlResultsPath + ": " + e);
-    process.exit(3);
+    throw "Impossible to read " + edCrawlResultsPath + ": " + e;
   }
   try {
     trCrawlResults = requireFromWorkingDirectory(trCrawlResultsPath);
   } catch(e) {
-    console.error("Impossible to read " + trCrawlResultsPath + ": " + e);
-    process.exit(3);
+    throw "Impossible to read " + trCrawlResultsPath + ": " + e;
   }
 
-  const results = studyCrawlResults(edCrawlResults.results, trCrawlResults.results);
+  edCrawlResults = await expandCrawlResult(edCrawlResults, edCrawlResultsPath.replace(/index\.json$/, ''));
+  trCrawlResults = await expandCrawlResult(trCrawlResults, trCrawlResultsPath.replace(/index\.json$/, ''));
+
+  return studyCrawlResults(edCrawlResults.results, trCrawlResults.results);
+}
+
+function reportToConsole(results) {
   let report = "";
   Object.keys(results)
     .sort((r1, r2) => results[r1].title.localeCompare(results[r2].title))
@@ -354,5 +443,41 @@ if (require.main === module) {
     report += "</details>\n";
   });
   console.log(report);
-  console.error(JSON.stringify(missingSpecs, null, 2));
+}
+
+
+if (require.main === module) {
+  let edCrawlResultsPath = process.argv[2];
+  let trCrawlResultsPath = process.argv[3];
+
+  if (!edCrawlResultsPath) {
+    console.error('Backrefs analyzer must be called with a paths to crawl results as first parameter');
+    process.exit(2);
+  }
+
+  // If only one argument is provided, consider that it is the path to the
+  // root folder of a crawl results, with "ed" and "tr" subfolders
+  if (!trCrawlResultsPath) {
+    trCrawlResultsPath = path.join(edCrawlResultsPath, 'tr');
+    edCrawlResultsPath = path.join(edCrawlResultsPath, 'ed');
+  }
+
+  // Target the index file if needed
+  if (!edCrawlResultsPath.endsWith('index.json')) {
+    edCrawlResultsPath = path.join(edCrawlResultsPath, 'index.json');
+  }
+  if (!trCrawlResultsPath.endsWith('index.json')) {
+    trCrawlResultsPath = path.join(trCrawlResultsPath, 'index.json');
+  }
+
+  // Analyze the crawl results
+  studyBackrefs(edCrawlResultsPath, trCrawlResultsPath)
+    .then(({report, missingSpecs}) => {
+      reportToConsole(report);
+      console.error(JSON.stringify(missingSpecs, null, 2));
+    })
+    .catch(e => {
+      console.error(e);
+      process.exit(3);
+    });
 }

--- a/src/cli/study-backrefs.js
+++ b/src/cli/study-backrefs.js
@@ -182,6 +182,7 @@ function recordAnomaly(spec, anomalyType, link) {
       notExported: [],
       notDfn: [],
       brokenLink: [],
+      evolvingLink: [],
       outdatedSpec: [],
       unknownSpec: [],
       datedUrl: []
@@ -255,7 +256,11 @@ function studyCrawlResults(edResults, trResults) {
           let heading = headings.find(h => h.id === anchor);
           let dfn = dfns.find(d => d.id === anchor);
           if (!id) {
-            recordAnomaly(spec, "brokenLink", l + "#" + anchor);
+            if ((trSourceSpec.ids || []).includes(anchor) && l.match(/w3\.org\/TR\//)) {
+              recordAnomaly(spec, "evolvingLink", l + "#" + anchor);
+            } else {
+              recordAnomaly(spec, "brokenLink", l + "#" + anchor);
+            }
           } else if (!heading && !dfn) {
             recordAnomaly(spec, "notDfn", l + "#" + anchor);
           } else if (dfn && dfn.access !== "public") {
@@ -298,6 +303,13 @@ if (require.main === module) {
     if (results[s].brokenLink.length) {
       report += "Links to anchors that don't exist:\n"
       results[s].brokenLink.forEach(l => {
+        report += "* " + l + "\n";
+      })
+      report += "\n\n";
+    }
+    if (results[s].evolvingLink.length) {
+      report += "Links to anchors that no longer exist in the editor draft of the target spec:\n"
+      results[s].evolvingLink.forEach(l => {
         report += "* " + l + "\n";
       })
       report += "\n\n";

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -429,7 +429,7 @@ async function expandCrawlResult(crawl, baseFolder) {
             }
         }
 
-        const properties = ['css', 'dfns', 'headings', 'idlparsed', 'links', 'refs'];
+        const properties = ['css', 'dfns', 'headings', 'ids', 'idlparsed', 'links', 'refs'];
         await Promise.all(properties.map(async property => {
             if (!spec[property] || (typeof spec[property] !== 'string')) {
                 return;


### PR DESCRIPTION
close #346 
The report generates list of links that either:
* Link to anchors that don't exist
* Link to anchors that no longer exist in the editor draft of the target spec
* Link to anchors that are not definitions or headings
* Link to definitions that are not exported
* Link to dated TR URLs
* Link to specs that should no longer be referenced

It also flags links that look like specs but that aren't recognized in our crawl (although most of these are false positives afaict).