### PR TITLE
Add config file to enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '10:00'
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Not sure why Dependabot used to run without it when Reffy was under my account, but the presence of a `dependabot.yml` file now seems required to enable Dependabot.