### PR TITLE
Only run test action on push/pull against the master branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
 name: test
 jobs:
   test:


### PR DESCRIPTION
The test action was run on all pushes and on all pull requests. This meant that the action was run twice on internal pull requests.

This update restricts the action to pushes on the master branch (and to pull requests against master).

Same as discussion in https://github.com/w3c/browser-specs/pull/216