### PR TITLE
Do not consider delta specs for base CSS/IDL extracts

### DIFF
--- a/src/cli/crawl-specs.js
+++ b/src/cli/crawl-specs.js
@@ -370,7 +370,7 @@ async function saveResults(crawlOptions, data, folder) {
     }
     const specsWithIDL = data.filter(defineIDLContent);
     await Promise.all(data
-        .filter(spec => isLatestLevelThatPasses(spec, data, defineIDLContent))
+        .filter(spec => (spec.seriesComposition !== 'delta') && isLatestLevelThatPasses(spec, data, defineIDLContent))
         .map(spec => saveIdl(spec, spec.series.shortname)));
 
     // Save IDL dumps of delta specs too
@@ -438,7 +438,7 @@ async function saveResults(crawlOptions, data, folder) {
             (Object.keys(spec.css.valuespaces || {}).length > 0));
     }
     await Promise.all(data
-        .filter(spec => isLatestLevelThatPasses(spec, data, defineCSSContent))
+        .filter(spec => (spec.seriesComposition !== 'delta') && isLatestLevelThatPasses(spec, data, defineCSSContent))
         .map(spec => saveCss(spec, spec.series.shortname)));
 
     // Save CSS dumps of delta specs too


### PR DESCRIPTION
CSS/IDL extracts are created for the latest level in the spec's series that contains CSS/IDL definitions. On top of that, they are also created for delta specs.

When a delta spec was the only level in the series definining CSS/IDL, the crawled created two extracts for it: one named after the series shortname and one named after the delta shortname, with only the second one being linked from `index.json`.

This update makes sure that, in such cases, only the extract named after the delta shortname gets produced.

Fixes the bug identified in https://github.com/w3c/webref/pull/83#issuecomment-757758823