### PR TITLE
Integrate dfns and external links analyzes in anomalies reports

### DIFF
--- a/reffy.js
+++ b/reffy.js
@@ -71,7 +71,7 @@ program
     let refStudy = perspectives[perspective].refStudy;
     let reportFolder = perspectives[perspective].reportFolder ||
       'reports/' + perspective;
-    let crawlReport = path.join(reportFolder, 'crawl.json');
+    let crawlReport = path.join(reportFolder, 'index.json');
     let studyReport = path.join(reportFolder, 'study.json');
 
     let promise = Promise.resolve();
@@ -89,8 +89,14 @@ program
         break;
 
       case 'study':
+        const options = {};
+        if (perspective === 'ed') {
+          const trFolder = perspectives.tr.reportFolder || 'reports/tr';
+          const trReport = path.join(trFolder, 'index.json');
+          options.trResults = trReport;
+        }
         promise = promise
-          .then(_ => studyCrawl(crawlReport))
+          .then(_ => studyCrawl(crawlReport, options))
           .then(results => {
             fs.writeFileSync(path.join(reportFolder, 'study.json'),
               JSON.stringify(results, null, 2));

--- a/src/cli/check-specs.js
+++ b/src/cli/check-specs.js
@@ -75,7 +75,7 @@ async function checkSpecs(speclist, refCrawl, options) {
         results: crawl
     };
     const mergedReport = await mergeCrawlResults(report, refCrawl);
-    const study = await studyCrawl(mergedReport, specs);
+    const study = await studyCrawl(mergedReport, { include: specs });
     return study;
 }
 


### PR DESCRIPTION
This update completes the study tool to integrate recently added checks to the final JSON report, adding:

- `missingDfns`: an object with `css` and `idl` properties that contain the results of running the `check-missing-dfns.js` tool.
- `xrefs`: an object with several properties that contain the results of running the `study-backrefs.js` tool. The final report does not contain the `unknownSpecs` because they are not anomalies of the spec but rather signals potential needs to complete browser-specs.

The tools mentioned had to be slightly updated to be integrated in the study tool.

The `generate-report.js` tool has also been updated to report the new anomalies, but note that they have not been integrated in the diff reports for now.

Fixes #447.