### PR TITLE
Do not take for granted that TR report exists

### DIFF
--- a/reffy.js
+++ b/reffy.js
@@ -93,7 +93,9 @@ program
         if (perspective === 'ed') {
           const trFolder = perspectives.tr.reportFolder || 'reports/tr';
           const trReport = path.join(trFolder, 'index.json');
-          options.trResults = trReport;
+          if (fs.existsSync(trReport)) {
+            options.trResults = trReport;
+          }
         }
         promise = promise
           .then(_ => studyCrawl(crawlReport, options))


### PR DESCRIPTION
Following previous update to integrate dfns and backrefs analyses in anomalies report (see https://github.com/w3c/reffy/pull/482), the reffy.js CLI takes for granted that the TR report exists when it runs the backrefs analyzer.

Unless one has run the crawler in `tr` mode first, that is not the case (e.g. see [last update action log](https://github.com/w3c/webref/runs/1762174861)). This update runs the backrefs analyzer without the TR report if it cannot find it. When that happens, the backrefs analyzer cannot distinguish between `brokenLinks` and `evolvingLinks`, and reports all such links under `brokenLinks`.

In short, this fixes the current job. Another fix will be needed to generate the `evolvingLinks` info.