### PR TITLE
Fix backrefs analyser crash when spec has no links

### DIFF
--- a/src/cli/study-backrefs.js
+++ b/src/cli/study-backrefs.js
@@ -291,7 +291,7 @@ function studyBackrefs(edResults, trResults = []) {
   }
 
   edResults.forEach(spec => {
-    Object.keys(spec.links)
+    Object.keys(spec.links || {})
       .filter(matchSpecUrl)
       .forEach(link => {
         let shortname;


### PR DESCRIPTION
If crawling a spec fails for some reason (e.g. a network error), the resulting crawl report will have no links, and thus no links extract will be created. In turn, that means that the spec will have no `links` property in `index.json`.

The backrefs analyser expected the `links` property to be set to an array (be it empty). This update handles the case when the property is not set at all.