### PR TITLE
Check missing dfns in extended IDL names

### DIFF
--- a/src/cli/check-missing-dfns.js
+++ b/src/cli/check-missing-dfns.js
@@ -130,8 +130,16 @@ function matchCSSDfn(expected, actual) {
  * @return {Array} An array of expected definitions
  */
 function getExpectedDfnsFromIdl(idl = {}) {
+  // Parse IDL names that the spec defines
   const idlNames = Object.values(idl.idlNames || {});
-  return idlNames.map(name => getExpectedDfnsFromIdlDesc(name)).flat();
+  let expected = idlNames.map(name => getExpectedDfnsFromIdlDesc(name)).flat();
+
+  // Parse members of IDL names that the spec extends
+  const idlExtendedNames = Object.values(idl.idlExtendedNames || {});
+  expected = expected.concat(idlExtendedNames.map(extended =>
+      extended.map(name => getExpectedDfnsFromIdlDesc(name, { excludeRoot: true })))
+    .flat(2));
+  return expected;
 }
 
 
@@ -288,10 +296,10 @@ function getExpectedDfnFromIdlDesc(idl, parentIdl) {
  *   `idlparsed` extract.
  * @return {Array} An array of expected definitions
  */
-function getExpectedDfnsFromIdlDesc(idl) {
+function getExpectedDfnsFromIdlDesc(idl, {excludeRoot} = {excludeRoot: false}) {
   const res = [];
   const parentIdl = idl;
-  const idlToProcess = [idl];
+  const idlToProcess = excludeRoot ? [] : [idl];
 
   switch (idl.type) {
     case 'enum':


### PR DESCRIPTION
Make the `check-missing-dfns.js` script check interface members for IDL names that specs extend (parsing the `idlExtendedNames` property).

This adds a few false positives in the HTML spec (which has a few `partial interface` fragments), and a warning in the WebRTC spec for `addTrack`.

Fixes #497.