### PR TITLE
Default to dfn when dfn-for doesn't match an IDL name in HTML spec

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -320,7 +320,7 @@ function preProcessHTML() {
     }
 
     //throw "Cannot match " + containerid + " to a known IDL name (" + id + ")";
-    return {type: "unknown", _for: containerid +  " with " + id};
+    return {type: "dfn", _for: containerid +  " with " + id};
   }
 
   const headingSelector = [


### PR DESCRIPTION
Otherwise hide valid definitions as reported in https://github.com/w3c/respec/issues/3441