### PR TITLE
Fix name for undefined.idl files

### DIFF
--- a/src/cli/generate-idlnames.js
+++ b/src/cli/generate-idlnames.js
@@ -339,7 +339,7 @@ async function saveIdlNamesFragments(names, folder) {
   }
 
   await createFolderIfNeeded(folder);
-  await Promise.all(Object.values(names).map(idl => {
+  await Promise.all(Object.entries(names).map(([name, idl]) => {
     const res = [];
     if (idl.defined) {
       res.push(serializeNode(idl.defined));
@@ -347,7 +347,7 @@ async function saveIdlNamesFragments(names, folder) {
     if (idl.extended) {
       idl.extended.map(node => res.push(serializeNode(node)));
     }
-    const filename = path.join(folder, idl.name + '.idl');
+    const filename = path.join(folder, name + '.idl');
     return fs.promises.writeFile(filename, res.join('\n\n'));
   }));
 }


### PR DESCRIPTION
The code could produce files named `undefined.idl` in the `idlnames` folder when it bumped on a partial definition for which the base definition does not exist in the crawl.

Ideally, these situations should never happen. They do in practice when a spec cannot be crawled e.g. for transient network issues or because it contains invalid IDL.

Note that the code was already correct for the `idlnamesparsed` folder.

Fixes #537.