### PR TITLE
When reffy.mjs has an error, log it.

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -365,6 +365,9 @@ async function processSpecification(spec, callback, args, counter) {
             await isReady();
         });
 
+        page.on('pageerror', err => {
+            console.error(err);
+        });
 
         // Expose additional functions defined in src/browserlib/ to the
         // browser context, under a window.reffy namespace, so that processing


### PR DESCRIPTION
Without this, it was hard to debug mistakes in `reffy.mjs` and its dependencies. There could be better ways to do it.