### PR TITLE
Add generated IDL attribute names to CSS properties

### DIFF
--- a/src/cli/crawl-specs.js
+++ b/src/cli/crawl-specs.js
@@ -32,13 +32,17 @@ const path = require('path');
 const specs = require('browser-specs');
 const webidlParser = require('./parse-webidl');
 const cssDfnParser = require('../lib/css-grammar-parser');
-const fetch = require('../lib/util').fetch;
-const requireFromWorkingDirectory = require('../lib/util').requireFromWorkingDirectory;
-const completeWithAlternativeUrls = require('../lib/util').completeWithAlternativeUrls;
-const isLatestLevelThatPasses = require('../lib/util').isLatestLevelThatPasses;
-const processSpecification = require('../lib/util').processSpecification;
-const { setupBrowser, teardownBrowser } = require('../lib/util');
 const { generateIdlNames, saveIdlNames } = require('./generate-idlnames');
+const {
+    completeWithAlternativeUrls,
+    fetch,
+    getGeneratedIDLNamesByCSSProperty,
+    isLatestLevelThatPasses,
+    processSpecification,
+    requireFromWorkingDirectory,
+    setupBrowser,
+    teardownBrowser
+} = require('../lib/util');
 
 /**
  * Flattens an array
@@ -129,7 +133,7 @@ async function crawlSpec(spec, crawlOptions) {
             }
         });
 
-        // Parse extracted CSS definitions
+        // Parse extracted CSS definitions and add generated IDL attribute names
         Object.entries(result.css.properties || {}).forEach(([prop, dfn]) => {
             if (dfn.value || dfn.newValues) {
                 try {
@@ -139,6 +143,7 @@ async function crawlSpec(spec, crawlOptions) {
                     dfn.valueParseError = e.message;
                 }
             }
+            dfn.styleDeclaration = getGeneratedIDLNamesByCSSProperty(prop);
         });
         Object.entries(result.css.descriptors || {}).forEach(([desc, dfn]) => {
             if (dfn.value) {

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -584,6 +584,56 @@ async function expandCrawlResult(crawl, baseFolder) {
 }
 
 
+/**
+ * Retrieves the list of IDL attribute names that the CSS property generates
+ * per the CSSOM spec, see:
+ * https://drafts.csswg.org/cssom/#ref-for-css-property-to-idl-attribute
+ *
+ * @function
+ * @param {String} property CSS property name
+ * @return {Array(String)} An array of IDL attribute names
+ */
+function getGeneratedIDLNamesByCSSProperty(property) {
+    const res = [];
+
+    // Converts a CSS property to an IDL attribute name per the CSSOM spec:
+    // https://drafts.csswg.org/cssom/#css-property-to-idl-attribute
+    function cssPropertyToIDLAttribute(property, lowercaseFirst) {
+        let output = '';
+        let uppercaseNext = false;
+        if (lowercaseFirst) {
+            property = property.substr(1);
+        }
+        for (const c of property) {
+            if (c === '-') {
+                uppercaseNext = true;
+            } else if (uppercaseNext) {
+                uppercaseNext = false;
+                output += c.toUpperCase();
+            } else {
+                output += c;
+            }
+        }
+        return output;
+    }
+
+    // Add camel-cased attribute
+    res.push(cssPropertyToIDLAttribute(property, false));
+
+    // Add webkit-cased attribute if needed
+    if (property.startsWith('-webkit-')) {
+        res.push(cssPropertyToIDLAttribute(property, true));
+    }
+
+    // Add dashed attribute if needed
+    if (property.includes('-')) {
+        res.push(property);
+    }
+
+    return res.sort();
+};
+
+
 module.exports = {
     fetch,
     requireFromWorkingDirectory,
@@ -593,5 +643,6 @@ module.exports = {
     processSingleSpecification,
     completeWithAlternativeUrls,
     isLatestLevelThatPasses,
-    expandCrawlResult
+    expandCrawlResult,
+    getGeneratedIDLNamesByCSSProperty
 };

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -591,11 +591,11 @@ async function expandCrawlResult(crawl, baseFolder) {
  *
  * @function
  * @param {String} property CSS property name
- * @return {Array(String)} An array of IDL attribute names
+ * @return {Array(String)} An array of IDL attribute names, dashed attribute
+ *   first, then camel-cased attribute if different, then webkit-cased attribute
+ *   name if needed
  */
 function getGeneratedIDLNamesByCSSProperty(property) {
-    const res = [];
-
     // Converts a CSS property to an IDL attribute name per the CSSOM spec:
     // https://drafts.csswg.org/cssom/#css-property-to-idl-attribute
     function cssPropertyToIDLAttribute(property, lowercaseFirst) {
@@ -617,20 +617,21 @@ function getGeneratedIDLNamesByCSSProperty(property) {
         return output;
     }
 
-    // Add camel-cased attribute
-    res.push(cssPropertyToIDLAttribute(property, false));
+    // Start with dashed attribute
+    const res = [property];
+
+    // Add camel-cased attribute if different
+    const camelCased = cssPropertyToIDLAttribute(property, false);
+    if (camelCased !== property) {
+        res.push(camelCased);
+    }
 
     // Add webkit-cased attribute if needed
     if (property.startsWith('-webkit-')) {
         res.push(cssPropertyToIDLAttribute(property, true));
     }
 
-    // Add dashed attribute if needed
-    if (property.includes('-')) {
-        res.push(property);
-    }
-
-    return res.sort();
+    return res;
 };
 
 

--- a/tests/util.js
+++ b/tests/util.js
@@ -95,7 +95,7 @@ describe('getGeneratedIDLNamesByCSSProperty', () => {
       ['-webkit-background-clip', 'WebkitBackgroundClip', 'webkitBackgroundClip']);
   });
 
-  it('returns the camel-cased attribute name for "display"', () => {
+  it('returns just the name for "display"', () => {
     assert.deepEqual(
       getGeneratedIDLNamesByCSSProperty('display'),
       ['display']);

--- a/tests/util.js
+++ b/tests/util.js
@@ -1,7 +1,10 @@
 const { assert } = require('chai');
 
 const specs = require('browser-specs');
-const { isLatestLevelThatPasses } = require('../src/lib/util');
+const {
+  getGeneratedIDLNamesByCSSProperty,
+  isLatestLevelThatPasses
+} = require('../src/lib/util');
 
 describe('isLatestLevelThatPasses', () => {
   function getSpecAtLevel(level, flags) {
@@ -75,5 +78,26 @@ describe('isLatestLevelThatPasses', () => {
       specs.find(s => (s.shortname === spec.seriesNext) &&
         (s.seriesComposition === 'full')));
     assert.isTrue(isLatestLevelThatPasses(spec, specs, s => s === spec));
+  });
+});
+
+
+describe('getGeneratedIDLNamesByCSSProperty', () => {
+  it('returns the camel-cased and dashed attribute names for "touch-action"', () => {
+    assert.deepEqual(
+      getGeneratedIDLNamesByCSSProperty('touch-action'),
+      ['touch-action', 'touchAction']);
+  });
+
+  it('returns the camel-cased, webkit-cased and dashed attribute names for "-webkit-background-clip"', () => {
+    assert.deepEqual(
+      getGeneratedIDLNamesByCSSProperty('-webkit-background-clip'),
+      ['-webkit-background-clip', 'WebkitBackgroundClip', 'webkitBackgroundClip']);
+  });
+
+  it('returns the camel-cased attribute name for "display"', () => {
+    assert.deepEqual(
+      getGeneratedIDLNamesByCSSProperty('display'),
+      ['display']);
   });
 });


### PR DESCRIPTION
See related discussion in:
https://github.com/w3c/webref/issues/51

This update adds a `styleDeclaration` property to CSS property definitions in CSS extracts. The property contains the list of IDL attribute names that the CSS property generates per the CSSOM spec on the `CSSStyleDeclaration` interface:
https://drafts.csswg.org/cssom/#ref-for-css-property-to-idl-attribute

The implementation of the CSS property to IDL attribute algorithm was copied over from:
https://github.com/foolip/mdn-bcd-collector/blob/c2126e8f367f08333a0f7b0604e42c8fdc11d182/build.js#L569

Note that the creation of this property is done after the crawl and not directly within the `extract-cssdfn.mjs` logic because that logic only extracts CSS properties that are defined in table, and the crawler completes that list afterwards with CSS properties that are defined in prose (such as those in the compat spec).