### PR TITLE
Remove code needed to annotate idl definitions in HTML spec

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -383,15 +383,6 @@ function preProcessHTML() {
       }
       let m;
 
-      if (el.closest("code.idl")) {
-        // we look if that matches a top-level idl name
-        let idlTerm = idlTree.find(item => item.name === el.textContent);
-        if (idlTerm) {
-          // we split at space to cater for "interface mixin"
-          el.dataset.dfnType = idlTerm.type.split(' ')[0];
-          return;
-        }
-      }
       if ((m = el.id.match(/^attr-([^-]+)-([^-]+)$/))) {
         // e.g. attr-ul-type
         el.dataset.dfnType = 'element-attr';

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -171,15 +171,6 @@ const tests = [
            definedIn: "heading"}],
    spec: "html"
   },
-  {title: "handles HTML spec convention for defining element interfaces",
-   html: '<pre><code class="idl">interface <dfn id="htmlhrelement"><c- g="">HTMLHRElement</c-></dfn> {};</code></pre>',
-   changesToBaseDfn: [{id: "htmlhrelement",
-           access: "public",
-           type: "interface",
-           linkingText: ["HTMLHRElement"],
-           definedIn: "pre"}],
-   spec: "html"
-  },
   {title: "handles finding IDL type across mixins and partial",
    html: '<dfn id="dom-navigator-taintenabled"><code>taintEnabled()</code></dfn>',
    changesToBaseDfn: [{id: "dom-navigator-taintenabled",


### PR DESCRIPTION
Done upstream in https://github.com/whatwg/html/pull/5957

(marked as draft until the PR is merged at which point I'll double check we get the same results in extracted definitions)