### PR TITLE
Remove code to deal with top-level attributes from HTML spec

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -418,12 +418,6 @@ function preProcessHTML() {
         }
         return;
       }
-      if ((m = el.id.match(/^attr-([^-]+)$/))) {
-        el.dataset.dfnType = 'element-attr';
-        // not sure how to encode "every html element"?
-        // el.dataset.dfnFor = 'all HTML elements';
-        return;
-      }
       if ((m = el.id.match(/^handler-([^-]+)$/))) {
         const sharedEventHandlers = ["GlobalEventHandlers", "WindowEventHandlers", "DocumentAndElementEventHandlers"];
         el.dataset.dfnType = 'attribute';


### PR DESCRIPTION
all attributes have already been marked up - removing the code doesn't change the extracted definitions