### PR TITLE
Use absolute URLs for dfn headings, headings, and ids

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -59,20 +59,21 @@ function definitionMapper(el, idToHeading) {
       break;
   }
 
+  // Compute the absolute URL with fragment
+  // (Note the crawler merges pages of a multi-page spec in the first page
+  // to ease parsing logic, and we want to get back to the URL of the page)
+  const page = el.closest('[data-reffy-page]')?.getAttribute('data-reffy-page');
+  const url = new URL(page ?? window.location.href);
+  url.hash = '#' + el.getAttribute('id');
+  const href = url.toString();
+
   return {
     // ID is the id attribute
+    // (ID may not be unique in a multi-page spec)
     id: el.getAttribute('id'),
 
-    // Compute the absolute URL
-    // (Note the crawler merges pages of a multi-page spec in the first page
-    // to ease parsing logic, and we want to get back to the URL of the page)
-    href: (_ => {
-      const pageWrapper = el.closest('[data-reffy-page]');
-      const url = new URL(pageWrapper ?
-                          pageWrapper.getAttribute('data-reffy-page') : window.location.href);
-      url.hash = '#' + el.getAttribute('id');
-      return url.toString();
-    })(),
+    // Absolute URL with fragment
+    href,
 
     // Linking text is given by the data-lt attribute if present, or it is the
     // textual content
@@ -114,7 +115,7 @@ function definitionMapper(el, idToHeading) {
     ].join(',')),
 
     // Heading under which the term is to be found
-    heading: idToHeading[el.getAttribute('id')],
+    heading: idToHeading[href],
 
     // Enclosing element under which the definition appears. Value can be one of
     // "dt", "pre", "table", "heading", "note", "example", or "prose" (last one

--- a/src/browserlib/extract-headings.mjs
+++ b/src/browserlib/extract-headings.mjs
@@ -2,6 +2,18 @@
  * Extract headings data from documents
 */
 export default function (idToHeading) {
+  // Compute once whether we created a single page version out of multiple pages
+  const isMultipage = !!document.querySelector('[data-reffy-page]');
+
+  function getAbsoluteUrl(node) {
+    const page = isMultipage ?
+      node.closest('[data-reffy-page]')?.getAttribute('data-reffy-page') :
+      null;
+    const url = new URL(page ?? window.location.href);
+    url.hash = '#' + node.id;
+    return url.toString();
+  }
+
   // Headings using the markup convention of the EcmaScript spec
   const esHeadings = [...document.querySelectorAll('emu-clause[id] > h1')].map(n => {
     const headingNumber = n.querySelector(".secnum")?.textContent;
@@ -21,16 +33,19 @@ export default function (idToHeading) {
     // headings not to create a mess in the outline). In practice, this only
     // really happens so far for WHATWG spec titles that (correctly) group the
     // title and subtitle headings in a <hgroup>.
-    const heading = idToHeading[n.id] || {
+    const href = getAbsoluteUrl(n);
+    const heading = idToHeading[href] || {
       id: n.id,
+      href,
       title: n.textContent.trim()
     };
+
     const res = {
       id: heading.id,
+      href: heading.href,
       level: parseInt(n.tagName.slice(1), 10),
       title: heading.title
     };
-
     if (heading.number) {
       res.number = heading.number;
     }

--- a/src/browserlib/extract-headings.mjs
+++ b/src/browserlib/extract-headings.mjs
@@ -1,18 +1,11 @@
+import getAbsoluteUrl from './get-absolute-url.mjs';
+
 /**
  * Extract headings data from documents
 */
 export default function (idToHeading) {
   // Compute once whether we created a single page version out of multiple pages
-  const isMultipage = !!document.querySelector('[data-reffy-page]');
-
-  function getAbsoluteUrl(node) {
-    const page = isMultipage ?
-      node.closest('[data-reffy-page]')?.getAttribute('data-reffy-page') :
-      null;
-    const url = new URL(page ?? window.location.href);
-    url.hash = '#' + node.id;
-    return url.toString();
-  }
+  const singlePage = !document.querySelector('[data-reffy-page]');
 
   // Headings using the markup convention of the EcmaScript spec
   const esHeadings = [...document.querySelectorAll('emu-clause[id] > h1')].map(n => {
@@ -33,7 +26,7 @@ export default function (idToHeading) {
     // headings not to create a mess in the outline). In practice, this only
     // really happens so far for WHATWG spec titles that (correctly) group the
     // title and subtitle headings in a <hgroup>.
-    const href = getAbsoluteUrl(n);
+    const href = getAbsoluteUrl(n, { singlePage });
     const heading = idToHeading[href] || {
       id: n.id,
       href,

--- a/src/browserlib/extract-ids.mjs
+++ b/src/browserlib/extract-ids.mjs
@@ -1,12 +1,28 @@
 /**
- * Extract ids from documents
+ * Extract absolute ids from documents
 */
 export default function () {
-  return [...document.querySelectorAll('*[id]')].map(n => n.id).concat(
+  // Compute once whether we created a single page version out of multiple pages
+  const isMultipage = !!document.querySelector('[data-reffy-page]');
+
+  function getAbsoluteUrl(node) {
+    const page = isMultipage ?
+      node.closest('[data-reffy-page]')?.getAttribute('data-reffy-page') :
+      null;
+    const url = new URL(page ?? window.location.href);
+    url.hash = '#' + node.id;
+    return url.toString();
+  }
+
+  return [...document.querySelectorAll('*[id]')]
+    .map(n => getAbsoluteUrl(n))
+
     // Capture anchors set in <a name> when they're not dup of ids
-    [...document.querySelectorAll('a[name]')]
-      .filter(n => !n.id || n.id !== n.name).map(n => n.name)
-    // We ignore respec- prefixed ids to avoid keeping track of their evolution
+    .concat([...document.querySelectorAll('a[name]')]
+      .filter(n => !n.id || n.id !== n.name).map(n => getAbsoluteUrl(n))
+    )
+
+    // I respec- prefixed ids to avoid keeping track of their evolution
     // They're clearly not meant to be link target in any case
-  ).filter(id => !id.startsWith('respec-'));
+    .filter(id => !id.startsWith('respec-'));
 }

--- a/src/browserlib/extract-ids.mjs
+++ b/src/browserlib/extract-ids.mjs
@@ -22,7 +22,7 @@ export default function () {
       .filter(n => !n.id || n.id !== n.name).map(n => getAbsoluteUrl(n))
     )
 
-    // I respec- prefixed ids to avoid keeping track of their evolution
+    // Ignore respec- prefixed ids to avoid keeping track of their evolution
     // They're clearly not meant to be link target in any case
     .filter(id => !id.startsWith('respec-'));
 }

--- a/src/browserlib/extract-ids.mjs
+++ b/src/browserlib/extract-ids.mjs
@@ -1,25 +1,18 @@
+import getAbsoluteUrl from './get-absolute-url.mjs';
+
 /**
  * Extract absolute ids from documents
 */
 export default function () {
   // Compute once whether we created a single page version out of multiple pages
-  const isMultipage = !!document.querySelector('[data-reffy-page]');
-
-  function getAbsoluteUrl(node) {
-    const page = isMultipage ?
-      node.closest('[data-reffy-page]')?.getAttribute('data-reffy-page') :
-      null;
-    const url = new URL(page ?? window.location.href);
-    url.hash = '#' + node.id;
-    return url.toString();
-  }
+  const singlePage = !document.querySelector('[data-reffy-page]');
 
   return [...document.querySelectorAll('*[id]')]
-    .map(n => getAbsoluteUrl(n))
+    .map(n => getAbsoluteUrl(n, { singlePage }))
 
     // Capture anchors set in <a name> when they're not dup of ids
     .concat([...document.querySelectorAll('a[name]')]
-      .filter(n => !n.id || n.id !== n.name).map(n => getAbsoluteUrl(n))
+      .filter(n => !n.id || n.id !== n.name).map(n => getAbsoluteUrl(n, { singlePage }))
     )
 
     // Ignore respec- prefixed ids to avoid keeping track of their evolution

--- a/src/browserlib/get-absolute-url.mjs
+++ b/src/browserlib/get-absolute-url.mjs
@@ -1,0 +1,17 @@
+/**
+ * Gets the absolute URL with fragment to the given node
+ *
+ * @function
+ * @public
+ * @param {Element} node DOM node to look at. Must have an ID.
+ * @param {Object} options singlePage asserts whether the spec is single page
+ *   or whether that's unknown. Default is false for "unknown".
+ * @return {String} Absolute URL ending with fragment ref
+ */
+export default function (node, { singlePage } = { singlePage: false }) {
+  const page = singlePage ? null :
+    node.closest('[data-reffy-page]')?.getAttribute('data-reffy-page');
+  const url = new URL(page ?? window.location.href);
+  url.hash = '#' + node.id;
+  return url.toString();
+}

--- a/src/browserlib/map-ids-to-headings.mjs
+++ b/src/browserlib/map-ids-to-headings.mjs
@@ -1,4 +1,5 @@
 import createOutline from './create-outline.mjs';
+import getAbsoluteUrl from './get-absolute-url.mjs';
 
 /**
  * Generate a mapping between elements that have an ID and the closest heading
@@ -37,16 +38,7 @@ export default function () {
   const sections = flattenSections(outline);
 
   // Compute once whether we created a single page version out of multiple pages
-  const isMultipage = !!document.querySelector('[data-reffy-page]');
-
-  function getAbsoluteUrl(node) {
-    const page = isMultipage ?
-      node.closest('[data-reffy-page]')?.getAttribute('data-reffy-page') :
-      null;
-    const url = new URL(page ?? window.location.href);
-    url.hash = '#' + node.id;
-    return url.toString();
-  }
+  const singlePage = !document.querySelector('[data-reffy-page]');
 
   const mappingTable = {};
   [...document.querySelectorAll('[id]')].forEach(node => {
@@ -63,17 +55,17 @@ export default function () {
     // Compute the absolute URL with fragment
     // (Note the crawler merges pages of a multi-page spec in the first page
     // to ease parsing logic, and we want to get back to the URL of the page)
-    const nodeid = getAbsoluteUrl(node);
+    const nodeid = getAbsoluteUrl(node, { singlePage });
     let href = nodeid;
 
     if (parentSection) {
       const heading = parentSection.heading;
       let id = heading.id;
-      href = getAbsoluteUrl(heading);
+      href = getAbsoluteUrl(heading, { singlePage });
 
       if (parentSection.root && parentSection.root.hasAttribute('id')) {
         id = parentSection.root.id;
-        href = getAbsoluteUrl(parentSection.root);
+        href = getAbsoluteUrl(parentSection.root, { singlePage });
       }
 
       const trimmedText = heading.textContent.trim();

--- a/tests/crawl-test.json
+++ b/tests/crawl-test.json
@@ -36,7 +36,6 @@
       "idl": ""
     },
     "title": "WOFF2",
-    "elements": [],
     "generator": null,
     "css": {
       "properties": {},
@@ -58,16 +57,18 @@
         "definedIn": "prose"
       }
     ],
+    "elements": [],
     "headings": [
       {
         "id": "bar",
+        "href": "https://w3c.github.io/woff/woff2/page.html#bar",
         "level": 2,
         "title": "Heading in subpage"
       }
     ],
     "ids": [
-      "foo",
-      "bar"
+      "https://w3c.github.io/woff/woff2/#foo",
+      "https://w3c.github.io/woff/woff2/page.html#bar"
     ]
   },
   {
@@ -114,7 +115,6 @@
       "idl": ""
     },
     "title": "No Title",
-    "elements": [],
     "generator": "respec",
     "css": {
       "properties": {},
@@ -137,6 +137,7 @@
         "informative": true,
         "heading": {
           "id": "title",
+          "href": "https://w3c.github.io/mediacapture-output/#title",
           "title": "No Title"
         },
         "definedIn": "pre"
@@ -158,55 +159,74 @@
         "informative": true,
         "heading": {
           "id": "title",
+          "href": "https://w3c.github.io/mediacapture-output/#title",
           "title": "No Title"
         },
         "definedIn": "pre"
       }
     ],
+    "elements": [],
     "headings": [
       {
         "id": "title",
+        "href": "https://w3c.github.io/mediacapture-output/#title",
         "level": 1,
         "title": "No Title"
       },
       {
         "id": "toc",
+        "href": "https://w3c.github.io/mediacapture-output/#toc",
         "level": 2,
         "title": "Table of Contents"
       },
       {
         "id": "references",
+        "href": "https://w3c.github.io/mediacapture-output/#references",
         "level": 2,
         "title": "References",
         "number": "A"
       },
       {
         "id": "informative-references",
+        "href": "https://w3c.github.io/mediacapture-output/#informative-references",
         "level": 3,
         "title": "Informative references",
         "number": "A.1"
       }
     ],
     "ids": [
-      "initialUserConfig",
-      "title",
-      "abstract",
-      "toc",
-      "table-of-contents",
-      "webidl-187362828",
-      "idl-def-foo",
-      "dom-foo",
-      "idl-def-foo-bar",
-      "dom-foo-bar",
-      "references",
-      "a-references",
-      "informative-references",
-      "a-1-informative-references",
-      "bib-html",
-      "bib-webidl",
-      "back-to-top",
-      "dfn-panel-for-dom-foo",
-      "dfn-panel-for-dom-foo-bar"
+      "https://w3c.github.io/mediacapture-output/#respec-ui-styles",
+      "https://w3c.github.io/mediacapture-output/#respec-mainstyle",
+      "https://w3c.github.io/mediacapture-output/#initialUserConfig",
+      "https://w3c.github.io/mediacapture-output/#respec-ui",
+      "https://w3c.github.io/mediacapture-output/#respec-pill",
+      "https://w3c.github.io/mediacapture-output/#respec-menu",
+      "https://w3c.github.io/mediacapture-output/#respec-button-export",
+      "https://w3c.github.io/mediacapture-output/#respec-button-search-specref",
+      "https://w3c.github.io/mediacapture-output/#respec-button-search-definitions",
+      "https://w3c.github.io/mediacapture-output/#respec-button-about-26.8.14",
+      "https://w3c.github.io/mediacapture-output/#respec-pill-error",
+      "https://w3c.github.io/mediacapture-output/#respec-pill-warning",
+      "https://w3c.github.io/mediacapture-output/#title",
+      "https://w3c.github.io/mediacapture-output/#abstract",
+      "https://w3c.github.io/mediacapture-output/#toc",
+      "https://w3c.github.io/mediacapture-output/#table-of-contents",
+      "https://w3c.github.io/mediacapture-output/#webidl-187362828",
+      "https://w3c.github.io/mediacapture-output/#idl-def-foo",
+      "https://w3c.github.io/mediacapture-output/#respec-offender-couldn-t-find-a-match-for-html",
+      "https://w3c.github.io/mediacapture-output/#dom-foo",
+      "https://w3c.github.io/mediacapture-output/#idl-def-foo-bar",
+      "https://w3c.github.io/mediacapture-output/#dom-foo-bar",
+      "https://w3c.github.io/mediacapture-output/#references",
+      "https://w3c.github.io/mediacapture-output/#a-references",
+      "https://w3c.github.io/mediacapture-output/#informative-references",
+      "https://w3c.github.io/mediacapture-output/#a-1-informative-references",
+      "https://w3c.github.io/mediacapture-output/#bib-html",
+      "https://w3c.github.io/mediacapture-output/#bib-webidl",
+      "https://w3c.github.io/mediacapture-output/#back-to-top",
+      "https://w3c.github.io/mediacapture-output/#dfn-panel-for-dom-foo",
+      "https://w3c.github.io/mediacapture-output/#dfn-panel-for-dom-foo-bar",
+      "https://w3c.github.io/mediacapture-output/#respec-dfn-panel"
     ]
   },
   {
@@ -246,7 +266,6 @@
       "idl": ""
     },
     "title": "[No title found for https://w3c.github.io/accelerometer/]",
-    "elements": [],
     "generator": null,
     "css": {
       "properties": {},
@@ -254,6 +273,7 @@
       "valuespaces": {}
     },
     "dfns": [],
+    "elements": [],
     "headings": [],
     "ids": []
   }

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -125,7 +125,7 @@ const tests = [
   },
   {title: "considers definitions in headings",
    html: "<h2 data-dfn-type=dfn id=foo>Foo</h2>",
-   changesToBaseDfn: [{heading: { id: "foo", title: "Foo"}, definedIn: "heading"}]
+   changesToBaseDfn: [{heading: { id: "foo", href: "about:blank#foo", title: "Foo"}, definedIn: "heading"}]
   },
   {title: "ignores elements that aren't <dfn> and headings",
    html: "<span data-dfn-type=dfn id=foo>Foo</span>",
@@ -147,7 +147,7 @@ const tests = [
    html: '<h6 id="parsing-main-inselect"><span class="secno">12.2.6.4.16</span> The "<dfn>in select</dfn>" insertion mode<a href="#parsing-main-inselect" class="self-link"></a></h6>',
    changesToBaseDfn: [{id: "parsing-main-inselect",
            linkingText: ["in select"],
-           heading: { id: "parsing-main-inselect", title: "The \"in select\" insertion mode", number: "12.2.6.4.16"},
+           heading: { id: "parsing-main-inselect", href: "about:blank#parsing-main-inselect", title: "The \"in select\" insertion mode", number: "12.2.6.4.16"},
            definedIn: "heading"}],
    spec: "html"
   },
@@ -333,7 +333,7 @@ const tests = [
       linkingText: ["link"],
       type: "element",
       access: "public",
-      heading: { id: "LinkElement", title: "External style sheets: the effect of the HTML ‘link’ element", number: "6.3"},
+      heading: { id: "LinkElement", href: "about:blank#LinkElement", title: "External style sheets: the effect of the HTML ‘link’ element", number: "6.3"},
       definedIn: "heading"
     }],
     spec: "SVG2"
@@ -396,7 +396,7 @@ When initialize(<var>newItem</var>) is called, the following steps are run:</p>`
       linkingText: ["SVGAnimatedLengthList"],
       type: "interface",
       access: "public",
-      heading: { id: "InterfaceSVGAnimatedLengthList", title: "Interface SVGAnimatedLengthList", number: "4.6.10"},
+      heading: { id: "InterfaceSVGAnimatedLengthList", href: "about:blank#InterfaceSVGAnimatedLengthList", title: "Interface SVGAnimatedLengthList", number: "4.6.10"},
       definedIn: "heading"
     }],
     spec: "SVG2"

--- a/tests/extract-headings.js
+++ b/tests/extract-headings.js
@@ -7,7 +7,7 @@ const testHeadings = [
   {
     title: "extracts a simple heading",
     html: "<h1 id=title>Title</h1>",
-    res: [{id: "title", title: "Title", level: 1}]
+    res: [{id: "title", href: "about:blank#title", title: "Title", level: 1}]
   },
   {
     title: "ignores a heading without id",
@@ -17,7 +17,7 @@ const testHeadings = [
   {
     title: "extracts a heading title without its section number",
     html: "<h2 id=title>2.3 Title</h2>",
-    res: [{id: "title", title: "Title", number: "2.3", level: 2}]
+    res: [{id: "title", href: "about:blank#title", title: "Title", number: "2.3", level: 2}]
   }
 ];
 


### PR DESCRIPTION
Multipage specs were badly supported because the code assumed that local IDs would be unique for the entire document, but that is generally speaking not the case.

This update adds an `href` property with an absolute URL throughout extracts. That was already the case for dfns. This is now also done for headings in dfn extracts and for the headings extracts themselves.

The ids extracts now also use absolute URLs everywhere.

Local IDs still appear in the `id` property.

Fixes #647.

Instead of an absolute URL with an ID, an alternative would be to have a `page` property that contains an absolute URL to the page where the heading is defined (or a relative URL to the base URL of the spec). Net benefit is that the extracts would be smaller in size as putting absolute URLs everywhere basically doubles the size of the extracts. One drawback is that would then be up to the consumer of the data to assemble the absolute URL with fragment. Given that we already had an `href` property for the dfns, I thought it made sense to be consistent and use the same mechanism everywhere.