### PR TITLE
Ignore dfns that have an invalid type

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -212,7 +212,10 @@ export default function (spec, idToHeading = {}) {
       // propagates to all EDs and /TR specs. To be dropped once crawls no
       // longer produce warnings.
       if (node.getAttribute('data-dfn-type') === 'idl') {
-        node.setAttribute('data-dfn-type', 'attribute');
+        const linkingText = node.hasAttribute('data-lt') ?
+          node.getAttribute('data-lt').split('|').map(normalize) :
+          [normalize(node.textContent)];
+        node.setAttribute('data-dfn-type', linkingText[0].endsWith(')') ? 'method' : 'attribute');
         console.warn('[reffy]', `Fixed invalid "idl" dfn type "${normalize(node.textContent)}"`);
       }
       return node;

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -365,6 +365,15 @@ async function processSpecification(spec, callback, args, counter) {
             await isReady();
         });
 
+        // Capture and report Reffy's browserlib warnings
+        page.on('console', msg => {
+            const text = msg.text();
+            if (text.startsWith('[reffy] ')) {
+                console.warn(spec.url, `[${msg.type()}]`, msg.text().substr('[reffy] '.length));
+            }
+        });
+
+        // Capture and report when page throws an error
         page.on('pageerror', err => {
             console.error(err);
         });

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -143,6 +143,14 @@ const tests = [
    html: "<dfn data-lt='foo \n   |\nbar' id=foo>Foo</dfn>",
    changesToBaseDfn: [{linkingText: ["foo", "bar"]}]
   },
+  {title: "ignores dfns with an invalid data-dfn-type",
+   html: "<dfn id=foo data-dfn-type=invalidtype>Foo</dfn>",
+   changesToBaseDfn: []
+  },
+  {title: "automatically fixes dfns with an invalid 'idl' data-dfn-type",
+   html: "<dfn id=foo data-dfn-type=idl>Foo</dfn>",
+   changesToBaseDfn: [{type: "attribute", access: "public"}]
+  },
   {title: "handles HTML spec conventions of definitions in headings",
    html: '<h6 id="parsing-main-inselect"><span class="secno">12.2.6.4.16</span> The "<dfn>in select</dfn>" insertion mode<a href="#parsing-main-inselect" class="self-link"></a></h6>',
    changesToBaseDfn: [{id: "parsing-main-inselect",

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -147,9 +147,13 @@ const tests = [
    html: "<dfn id=foo data-dfn-type=invalidtype>Foo</dfn>",
    changesToBaseDfn: []
   },
-  {title: "automatically fixes dfns with an invalid 'idl' data-dfn-type",
+  {title: "automatically fixes internal slots dfns with an invalid 'idl' data-dfn-type",
    html: "<dfn id=foo data-dfn-type=idl>Foo</dfn>",
    changesToBaseDfn: [{type: "attribute", access: "public"}]
+  },
+  {title: "automatically fixes internal methods with an invalid 'idl' data-dfn-type",
+   html: "<dfn id=foo data-dfn-type=idl>Foo()</dfn>",
+   changesToBaseDfn: [{ linkingText: [ 'Foo()' ], type: "method", access: "public"}]
   },
   {title: "handles HTML spec conventions of definitions in headings",
    html: '<h6 id="parsing-main-inselect"><span class="secno">12.2.6.4.16</span> The "<dfn>in select</dfn>" insertion mode<a href="#parsing-main-inselect" class="self-link"></a></h6>',


### PR DESCRIPTION
This update restricts dfns extraction to definitions that have a valid type, as defined in:
https://tabatkins.github.io/bikeshed/#dfn-types
(+ `namespace` and `event` that are valid but do not yet appear in the doc)

In practice, the only invalid type that appears in Editor's Drafts is `idl`, which ReSpec uses to flag internal slots. To avoid losing definitions while ReSpec gets fixed and while the changes propagate to all specs and /TR versions of the spec, the code automatically converts `idl` definition types to `attribute`.

Data validation is something that we would typically do at a later stage, through anomaly reports, or through patches as we produce packages. That said, dfns are more time sensitive than other types of data that Reffy extracts from the specs and the validation process would need to be semi-manual.

Dfns with an invalid type get reported as warnings to the console.

Fixes #658.