### PR TITLE
Fix check-missing-dfns script's CSS descriptors handling

### DIFF
--- a/src/cli/check-missing-dfns.js
+++ b/src/cli/check-missing-dfns.js
@@ -77,7 +77,7 @@ function getExpectedDfnsFromCSS(css) {
 
   // Add the list of expected descriptors
   expected = expected.concat(
-    Object.values(css.descriptors || {}).map(desc => {
+    Object.values(css.descriptors || {}).flat().map(desc => {
       return {
         linkingText: [desc.name],
         type: 'descriptor',


### PR DESCRIPTION
Descriptors in CSS extracts now appear in arrays. The script still expected to find only one descriptor per name.