### PR TITLE
Adapt reference extractor to modern IETF HTML-formatted RFCs

### DIFF
--- a/src/browserlib/extract-references.mjs
+++ b/src/browserlib/extract-references.mjs
@@ -96,7 +96,7 @@ function parseReferences(referenceList, options) {
     if (!desc || !ref.name) {
       return;
     }
-    ref.url = desc.querySelector("a[href]") ? desc.querySelector("a[href]").href : "";
+    ref.url = desc.querySelector('a[href^="http"]')?.href ?? "";
     if (options.filterInformative &&
         desc.textContent.match(/non-normative/i)) {
       return informativeRef.push(ref);


### PR DESCRIPTION
Some of the references contain link to email addresses, which needs to be ignored to hit the actual useful link

This is but a small part of #644, but sufficient to enable bringing the specs identified in https://github.com/w3c/browser-specs/issues/280