### PR TITLE
Ignore ReSpec IDs that are not meant to be link targets

### DIFF
--- a/src/browserlib/extract-ids.mjs
+++ b/src/browserlib/extract-ids.mjs
@@ -8,14 +8,21 @@ export default function () {
   const singlePage = !document.querySelector('[data-reffy-page]');
 
   return [...document.querySelectorAll('*[id]')]
+    // Ignore respec- prefixed ids to avoid keeping track of their evolution
+    // They're clearly not meant to be link target in any case
+    .filter(n => !n.id.startsWith('respec-'))
+
+    // Ignore dfn-panel- prefixed ids that ReSpec generates to avoid keeping
+    // track of their evolution. They're clearly not meant to be link target
+    // either.
+    .filter(n => !n.id.startsWith('dfn-panel-'))
+
+    // Convert IDs to absolute URLs (needed to handle multipage specs)
     .map(n => getAbsoluteUrl(n, { singlePage }))
 
     // Capture anchors set in <a name> when they're not dup of ids
     .concat([...document.querySelectorAll('a[name]')]
-      .filter(n => !n.id || n.id !== n.name).map(n => getAbsoluteUrl(n, { singlePage }))
-    )
-
-    // Ignore respec- prefixed ids to avoid keeping track of their evolution
-    // They're clearly not meant to be link target in any case
-    .filter(id => !id.startsWith('respec-'));
+      .filter(n => !n.id || n.id !== n.name)
+      .map(n => getAbsoluteUrl(n, { singlePage, attribute: 'name' }))
+    );
 }

--- a/src/browserlib/get-absolute-url.mjs
+++ b/src/browserlib/get-absolute-url.mjs
@@ -4,14 +4,18 @@
  * @function
  * @public
  * @param {Element} node DOM node to look at. Must have an ID.
- * @param {Object} options singlePage asserts whether the spec is single page
+ * @param {Object} options "singlePage" asserts whether the spec is single page
  *   or whether that's unknown. Default is false for "unknown".
+ *   "attribute" tells function to use value of given attribute name instead of
+ *   the node's ID. Default is "id".
  * @return {String} Absolute URL ending with fragment ref
  */
-export default function (node, { singlePage } = { singlePage: false }) {
+export default function (node, { singlePage, attribute } =
+                               { singlePage: false, attribute: 'id' }) {
+  attribute = attribute ?? 'id';
   const page = singlePage ? null :
     node.closest('[data-reffy-page]')?.getAttribute('data-reffy-page');
   const url = new URL(page ?? window.location.href);
-  url.hash = '#' + node.id;
+  url.hash = '#' + node.getAttribute(attribute);
   return url.toString();
 }

--- a/tests/crawl-test.json
+++ b/tests/crawl-test.json
@@ -211,9 +211,7 @@
       "https://w3c.github.io/mediacapture-output/#a-1-informative-references",
       "https://w3c.github.io/mediacapture-output/#bib-html",
       "https://w3c.github.io/mediacapture-output/#bib-webidl",
-      "https://w3c.github.io/mediacapture-output/#back-to-top",
-      "https://w3c.github.io/mediacapture-output/#dfn-panel-for-dom-foo",
-      "https://w3c.github.io/mediacapture-output/#dfn-panel-for-dom-foo-bar"
+      "https://w3c.github.io/mediacapture-output/#back-to-top"
     ]
   },
   {

--- a/tests/extract-ids.js
+++ b/tests/extract-ids.js
@@ -1,0 +1,89 @@
+const { assert } = require('chai');
+const puppeteer = require('puppeteer');
+const path = require('path');
+const rollup = require('rollup');
+
+const testIds = [
+  {
+    title: "extracts a simple ID",
+    html: "<h1 id=title>Title</h1>",
+    res: ["about:blank#title"]
+  },
+
+  {
+    title: "extracts all IDs",
+    html: "<h1 id=title>Title <span id=subtitle>Subtitle</span></h1>",
+    res: ["about:blank#title", "about:blank#subtitle"]
+  },
+
+  {
+    title: "excludes IDs that start with respec-",
+    html: "<div id=respec-menu>ReSpec menu</div>",
+    res: []
+  },
+
+  {
+    title: "excludes IDs that start with dfn-panel-",
+    html: "<div id=dfn-panel-term>ReSpec panel menu</div>",
+    res: []
+  },
+
+  {
+    title: "captures anchors set in <a name>",
+    html: "<a name=name>My name</a>",
+    res: ["about:blank#name"]
+  },
+
+  {
+    title: "does not capture name anchors if ID is already set",
+    html: "<a id=name name=name>My name</a>",
+    res: ["about:blank#name"]
+  },
+
+  {
+    title: "associates IDs with the right page",
+    html: `<section data-reffy-page="https://example.org/page1">
+  <p id=first>First page</p>
+</section><section data-reffy-page="https://example.org/page2">
+  <p id=second>Second page</p>
+</section>`,
+    res: ["https://example.org/page1#first", "https://example.org/page2#second"]
+  }
+];
+
+describe("IDs extraction", function () {
+  this.slow(5000);
+
+  let browser;
+  let extractIdsCode;
+
+  before(async () => {
+    const extractIdsBundle = await rollup.rollup({
+      input: path.resolve(__dirname, '../src/browserlib/extract-ids.mjs')
+    });
+    const extractIdsOutput = (await extractIdsBundle.generate({
+      name: 'extractIds',
+      format: 'iife'
+    })).output;
+    extractIdsCode = extractIdsOutput[0].code;
+
+    browser = await puppeteer.launch({ headless: true });
+  });
+
+  testIds.forEach(t => {
+    it(t.title, async () => {
+      const page = await browser.newPage();
+      page.setContent(t.html);
+      await page.addScriptTag({ content: extractIdsCode });
+
+      const extractedIds = await page.evaluate(async () => extractIds());
+      await page.close();
+      assert.deepEqual(extractedIds, t.res);
+    });
+  });
+
+
+  after(async () => {
+    await browser.close();
+  });
+});


### PR DESCRIPTION
IDs prefixed with `respec-` used to be ignored but that broke when the switch to absolute URLs was made. IDs prefixed with `dfn-panel-` can also be safely ignored.

This update also adds tests for ID extraction, and fixes a bug with name extraction that these tests revealed.

Fixes #668.