### PR TITLE
Switch to new "main" branch name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,16 @@
 on:
   push:
-    branches: master
+    branches: main
   pull_request:
-    branches: master
+    branches: main
 name: test
 jobs:
   test:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: '14'
     - run: npm ci
     - run: npm test


### PR DESCRIPTION
This adjusts the test workflow to run on pushes and PRs against the new default `main` branch.

This also refreshes the workflow to use current versions of actions.