### PR TITLE
Adjust CSS dfns extraction rules

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -199,7 +199,7 @@ const extractValueSpaces = doc => {
   // Extract non-terminal value spaces defined in `pre` tags
   // (remove note references as in:
   // https://drafts.csswg.org/css-syntax-3/#the-anb-type)
-  parseProductionRules([...doc.querySelectorAll('pre.prod')]
+  parseProductionRules([...doc.querySelectorAll('pre.prod,span.prod')]
     .filter(el => !el.closest(informativeSelector))
     .map(el => {
       [...el.querySelectorAll('sup')]


### PR DESCRIPTION
CSS Animations now uses `<span class=prod>` instead of `<pre class=prod>` for production rules (see https://github.com/w3c/webref/pull/307#pullrequestreview-712521622). The update extends the query selector accordingly (we could probably just use `.prod` but that seems slightly too generic).