### PR TITLE
Fix isEmpty logic, replace newlines in titles

### DIFF
--- a/src/browserlib/extract-references.mjs
+++ b/src/browserlib/extract-references.mjs
@@ -20,7 +20,12 @@ export default function () {
   const generator = getGenerator();
   const extractionRules = getExtractionRules(generator);
   const references = extractReferences(extractionRules);
-  return references;
+  if (references?.normative.length || references?.informative.length) {
+    return references;
+  }
+  else {
+    return null;
+  }
 }
 
 

--- a/src/browserlib/get-title.mjs
+++ b/src/browserlib/get-title.mjs
@@ -4,7 +4,7 @@
 export default function () {
   const title = window.document.querySelector('title');
   if (title) {
-    return title.textContent.trim();
+    return title.textContent.replace(/\s+/g, ' ').trim();
   }
   else {
     return '[No title found for ' + window.location.href + ']';

--- a/src/browserlib/reffy.json
+++ b/src/browserlib/reffy.json
@@ -12,23 +12,19 @@
   {
     "href": "./get-lastmodified-date.mjs",
     "property": "date",
-    "metadata": true,
-    "default": ""
+    "metadata": true
   },
   {
     "href": "./extract-links.mjs",
-    "property": "links",
-    "default": {}
+    "property": "links"
   },
   {
     "href": "./extract-references.mjs",
-    "property": "refs",
-    "default": {}
+    "property": "refs"
   },
   {
     "href": "./extract-webidl.mjs",
-    "property": "idl",
-    "default": {}
+    "property": "idl"
   },
   {
     "href": "./extract-cssdfn.mjs",

--- a/src/cli/crawl-specs.js
+++ b/src/cli/crawl-specs.js
@@ -75,14 +75,6 @@ async function crawlSpec(spec, crawlOptions) {
         (spec.release ? spec.release : spec.nightly) :
         spec.nightly;
 
-    // Set default values
-    // TODO: is that really needed? Not setting the properties seems cleaner
-    crawlOptions.modules.forEach(mod => {
-        if (mod.default !== undefined) {
-            spec[mod.property] = mod.default;
-        }
-    });
-
     if (spec.error) {
         return spec;
     }
@@ -463,8 +455,8 @@ async function saveResults(crawlOptions, data, folder) {
     // (it returns true for falsy values, which is good enough for what we need)
     function isEmpty(thing) {
         return !thing ||
-            (typeof thing === 'array') && (thing.length === 0) ||
-            (typeof thing === 'object') && Object.keys(thing).every(key => isEmpty(thing[key]));
+            Array.isArray(thing) && (thing.length === 0) ||
+            (typeof thing == 'object') && (Object.keys(thing).length === 0);
     }
 
     // Save all other extracts

--- a/tests/crawl-test.json
+++ b/tests/crawl-test.json
@@ -17,10 +17,6 @@
         "baz"
       ]
     },
-    "refs": {
-      "normative": [],
-      "informative": []
-    },
     "idl": {
       "jsNames": {
         "constructors": {},


### PR DESCRIPTION
The update makes sure that browserlib modules no longer produce weird empty constructs such as objects with keys at the first level but without real values.

The isEmpty logic was updated, first to fix the array case (`typeof` never returns `array` because because), and second to remain as dumb as possible.

This gave a good opportunity to get rid of module defaults which are indeed completely useless as envisioned by the TODO comment.

Last update drops extraneous spaces in extracted titles to avoid them generating separate paragraphs in the final report.

Fixes #716 and #717.