### PR TITLE
Add IDL type to JSON metadata on IDL

### DIFF
--- a/src/cli/generate-idlnames.js
+++ b/src/cli/generate-idlnames.js
@@ -146,6 +146,7 @@ function generateIdlNames(results, options = {}) {
       }
       names[name] = {
         name: name,
+        type: idl.type,
         defined: desc,
         extended: [],
         inheritance: idl.inheritance,


### PR DESCRIPTION
It helps when wanting to target specific types of IDL fragments
I will use it to automate updates to https://github.com/mdn/content/blob/main/files/jsondata/InterfaceData.json among other things