### PR TITLE
Add possibility to crawl "file" URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reffy",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "W3C/WHATWG spec dependencies exploration companion. Features a short set of tools to study spec references as well as WebIDL term definitions and references found in W3C specifications.",
   "repository": {
     "type": "git",

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -314,12 +314,6 @@ async function processSpecification(spec, processFunction, args, options) {
     function interceptRequest(cdp, controller) {
         return async function ({ requestId, request }) {
             try {
-                if ((request.method !== 'GET') ||
-                    (!request.url.startsWith('http:') && !request.url.startsWith('https:'))) {
-                    await cdp.send('Fetch.continueRequest', { requestId });
-                    return;
-                }
-
                 // Abort network requests to common image formats
                 if (/\.(gif|ico|jpg|jpeg|png|ttf|woff)$/i.test(request.url)) {
                     await cdp.send('Fetch.failRequest', { requestId, errorReason: 'Failed' });
@@ -377,6 +371,12 @@ async function processSpecification(spec, processFunction, args, options) {
                     });
                 }
                 else {
+                    if ((request.method !== 'GET') ||
+                        (!request.url.startsWith('http:') && !request.url.startsWith('https:'))) {
+                        await cdp.send('Fetch.continueRequest', { requestId });
+                        return;
+                    }
+
                     const response = await fetch(request.url, { signal: controller.signal });
                     const body = await response.buffer();
                     await cdp.send('Fetch.fulfillRequest', {

--- a/tests/crawl-spec.html
+++ b/tests/crawl-spec.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>A test spec</title>
+  </head>
+  <body>
+    <section id="abstract">
+      <p>This is required.</p>
+    </section>
+    <section id="sotd">
+      <p>This is required.</p>
+    </section>
+    <section class="informative">
+      <h2>Introduction</h2>
+      <p>Some informative introductory text.</p>
+      <aside class="note" title="A useful note">
+        <p>I'm a note!</p>
+      </aside>
+    </section>
+    <section>
+      <h2>A section</h2>
+      <aside class="example">
+        <p>This is an example.</p>
+        <pre class="js">
+        // Automatic syntax highlighting
+        function someJavaScript(){}
+        </pre>
+      </aside>
+      <section>
+        <h3>I'm a sub-section</h3>
+      </section>
+    </section>
+    <section data-dfn-for="Foo">
+      <h2>Start your spec!</h2>
+      <pre class="idl">
+        [Exposed=Window]
+        interface Foo {
+        attribute DOMString bar;
+        undefined doTheFoo();
+        };
+      </pre>
+      <p>The <dfn>Foo</dfn> interface represents a {{Foo}}.</p>
+      <p>
+        The <dfn>doTheFoo()</dfn> method does the foo. Call it by running
+        {{Foo/doTheFoo()}}.
+      </p>
+      <ol class="algorithm">
+        <li>A |variable:DOMString| can be declared like this.</li>
+      </ol>
+    </section>
+    <section id="conformance">
+      <p>
+        This is required for specifications that contain normative material.
+      </p>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
The crawl only supported http and https URLs out of the box, but that constraint was more artificial than anything else. Moving the check on the scheme to the appropriate place is enough to enable support of "file://" URLs in practice.

This is useful to run the crawler on a local spec and typically needed to integrate IDL validation in spec-prod.

The crawler CLI now also interprets relative filenames as "file://" URLs, making it possible to run the crawler on a local file with commands such as:

```
node src/cli/crawl-specs.js -s spec.html
```