### PR TITLE
Fix invalid paths in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  extractIdl: require("./src/cli/extract-webidl.js").extract,
   parseIdl: require("./src/cli/parse-webidl").parse,
-  crawlSpecs: require("./src/cli/crawl-specs").crawlList
+  crawlSpecs: require("./src/lib/specs-crawler").crawlList
 };


### PR DESCRIPTION
The extract-webidl script no longer exist (embedded in the crawler) and the crawler script switched to a new location.

Note we'll probably want to adjust `index.js` in the future, e.g. to use it to export all lib functions. That is not part of this update.