### PR TITLE
Fix minimal usage example, prevent CLI from running without option

### DIFF
--- a/reffy.js
+++ b/reffy.js
@@ -68,6 +68,19 @@ program
     .option('-s, --spec <specs...>', 'specs to crawl')
     .option('-t, --terse', 'output crawl results without metadata')
     .action(options => {
+        if (!(options.output || options.module || options.spec)) {
+          console.error(`
+At least one of the --output, --module or --spec options needs to be specified.
+For usage notes, run:
+  reffy --help
+
+If you really want to crawl all specs, run all processing modules and report the
+JSON outcome to the console, you may run the following command but note that it
+will dump ~100MB of data to the console:
+  reffy --spec all
+`);
+          process.exit(2);
+        }
         const crawlOptions = {
             debug: options.debug,
             output: options.output,
@@ -102,7 +115,9 @@ program
     .showHelpAfterError('(run with --help for usage information)')
     .addHelpText('after', `
 Minimal usage example:
-  $ reffy reports/test
+  To crawl all known specs, run all processing modules, and save generated
+  extracts to the current folder, run:
+    $ reffy -o .
 
 Description:
   Crawls a set of specifications and runs processing modules against each of
@@ -174,6 +189,8 @@ Usage notes for some of the options:
   Additionally, if an output <folder> is specified and if the IDL processing
   module is run, the crawler will also creates an index of IDL names named
   "idlnames.json" that links to relevant extracts in subfolders.
+
+  The folder targeted by <folder> must exist.
 
 -r, --release
   If the flag is not set, the crawler defaults to crawl nightly versions of the


### PR DESCRIPTION
The minimal usage example was outdated and now incorrect. This fixes it to `reffy -o .` with a short description of what that means.

By default, the CLI crawls all specs (that's fine), runs all processing modules (that's fine too) but dumps the results to the console, which is a good default in theory be it only for the fact that the crawler is going to produce ~100MB of data if it runs all processing modules on all specs...

This update makes it impossible to run reffy without providing at least one of the `--output`, `--module` or `--spec` option. If one really wants to dump things to the console, well, that remains doable by running `reffy -s all`.