### PR TITLE
Accept series shortnames as input for specs

### DIFF
--- a/reffy.js
+++ b/reffy.js
@@ -202,7 +202,10 @@ Usage notes for some of the options:
 
   Valid spec values may be a shortname, a URL, or a relative path to a file that
   contains a list of spec URLs and/or shortnames. All shortnames must exist in
-  browser-specs.
+  browser-specs. Shortname may be the shortname of the spec series, in which
+  case the spec identified as the current specification in the series is used.
+  For instance, as of September 2021, "pointerlock" will map to "pointerlock-2"
+  because Pointer Lock 2.0 is the current level in the series.
 
   Use "all" to include all specs in browser-specs in the crawl. For instance, to
   crawl all specs plus one custom spec that does not exist in browser-specs:

--- a/src/lib/nock-server.js
+++ b/src/lib/nock-server.js
@@ -36,7 +36,8 @@ const mockSpecs = {
     }
   },
   "/mediacapture-output/": `<script>respecConfig = { shortName: 'test' };</script><script src='https://www.w3.org/Tools/respec/respec-w3c'></script><div id=abstract></div><pre class='idl'>[Exposed=Window] interface Foo { attribute DOMString bar; };</pre>`,
-  "/accelerometer/": `<html><h2>Normative references</h2><dl><dt>FOO</dt><dd><a href='https://www.w3.org/TR/Foo'>Foo</a></dd></dl>`
+  "/accelerometer/": `<html><h2>Normative references</h2><dl><dt>FOO</dt><dd><a href='https://www.w3.org/TR/Foo'>Foo</a></dd></dl>`,
+  "/pointerlock/": `<html><h1>Pointer Lock 2.0`
 };
 
 nock.disableNetConnect();

--- a/src/lib/specs-crawler.js
+++ b/src/lib/specs-crawler.js
@@ -482,7 +482,12 @@ function crawlSpecs(options) {
             if (typeof spec !== 'string') {
                 return spec;
             }
-            const match = specs.find(s => s.url === spec || s.shortname === spec);
+            let match = specs.find(s => s.url === spec || s.shortname === spec);
+            if (!match) {
+                match = specs.find(s => s.series &&
+                    s.series.shortname === spec &&
+                    s.series.currentSpecification === s.shortname);
+            }
             if (match) {
                 return match;
             }
@@ -496,7 +501,8 @@ function crawlSpecs(options) {
                     url = (new URL(spec, `file://${process.cwd()}/`)).href;
                 }
                 else {
-                    throw new Error(`Spec ID "${spec}" can neither be interpreted as a URL, a valid shortname or a relative path to an HTML file`);
+                    const msg = `Spec ID "${spec}" can neither be interpreted as a URL, a valid shortname or a relative path to an HTML file`;
+                    throw new Error(msg);
                 }
             }
             return {

--- a/tests/crawl.js
+++ b/tests/crawl.js
@@ -60,6 +60,16 @@ if (global.describe && describe instanceof Function) {
       assert.equal(refResults.title, results.results[0].title);
     });
 
+    it("matches spec series shortnames", async() => {
+      const output = fs.mkdtempSync(path.join(os.tmpdir(), 'reffy-'));
+      await crawlSpecs({
+        specs: ['pointerlock'],
+        output: output
+      });
+      const results = require(path.resolve(output, 'index.json'));
+      assert.equal(results.results[0].url, 'https://www.w3.org/TR/pointerlock-2/');
+    });
+
     it("interprets filenames relative to the current folder", async() => {
       const output = fs.mkdtempSync(path.join(os.tmpdir(), 'reffy-'));
       await crawlSpecs({


### PR DESCRIPTION
If a shortname is not a spec shortname, Reffy now looks for a match in series shortname, and crawls the current specification in the series.