### PR TITLE
Create cache folder in install folder, not run folder

### DIFF
--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -43,6 +43,11 @@ async function fetch(url, options) {
         options.refresh = 'once';
     }
 
+    // Use cache folder where Reffy was installed, not where it is run
+    if (!options.cacheFolder) {
+        options.cacheFolder = path.resolve(__dirname, '..', '..', '.cache');
+    }
+
     return baseFetch(url, options);
 }
 

--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -5,6 +5,7 @@
  * @module finder
  */
 
+const os = require('os');
 const path = require('path');
 const baseFetch = require('fetch-filecache-for-crawling');
 
@@ -43,9 +44,9 @@ async function fetch(url, options) {
         options.refresh = 'once';
     }
 
-    // Use cache folder where Reffy was installed, not where it is run
+    // Use cache folder in tmp folder by default
     if (!options.cacheFolder) {
-        options.cacheFolder = path.resolve(__dirname, '..', '..', '.cache');
+        options.cacheFolder = path.resolve(os.tmpdir(), 'reffy-cache');
     }
 
     return baseFetch(url, options);


### PR DESCRIPTION
The local cache folder (`.cache`) was created where the command was run. If you install Reffy globally, you won't expect it to create files in the folder you run it into by default.

This update creates the `.cache` folder in the install folder by default. It may not be good practice to put a cache that will typically contain dozens of MB of data in there, but that seems better than putting a cache folder where ever the command is run in any case.

Note one can override the default through the `cacheFolder` setting in a `config.json` file.