### PR TITLE
Update tests following WebIDL URL change and adjust study tool

### DIFF
--- a/src/cli/study-crawl.js
+++ b/src/cli/study-crawl.js
@@ -119,8 +119,9 @@ function studyCrawlResults(results, options = {}) {
             isLatestLevelThatPasses(spec, results, s =>
                 s.idl && s.idl.idlNames && s.idl.idlNames[name])));
 
-    // TODO: we may end up with different variants of the WebIDL spec
-    var WebIDLSpec = results.find(spec => (spec.shortname === 'WebIDL-1')) || {};
+    // WebIDL-1 only kept for historical reasons to process old crawl results
+    var WebIDLSpec = results.find(spec =>
+        spec.shortname === 'webidl' || spec.shortname === 'WebIDL-1') || {};
 
     var sortedResults = results.sort(byTitle);
 

--- a/src/lib/nock-server.js
+++ b/src/lib/nock-server.js
@@ -69,7 +69,7 @@ nock("https://respec.org")
 
 nock("https://api.specref.org")
   .persist()
-  .get("/bibrefs?refs=webidl,html").reply(200, {webidl:{href:"https://heycam.github.io/webidl/"}}, {"Access-Control-Allow-Origin": "*"})
+  .get("/bibrefs?refs=webidl,html").reply(200, {webidl:{href:"https://webidl.spec.whatwg.org/"}}, {"Access-Control-Allow-Origin": "*"})
   .get("/bibrefs?refs=HTML").reply(200, {HTML:{href:"https://html.spec.whatwg.org/multipage/"}}, {"Access-Control-Allow-Origin": "*"});
 
 nock("https://www.w3.org")

--- a/tests/crawl-test.json
+++ b/tests/crawl-test.json
@@ -77,7 +77,7 @@
     ],
     "crawled": "https://w3c.github.io/mediacapture-output/",
     "links": {
-      "https://heycam.github.io/webidl/": [
+      "https://webidl.spec.whatwg.org/": [
         "Exposed",
         "idl-DOMString"
       ]
@@ -91,7 +91,7 @@
         },
         {
           "name": "webidl",
-          "url": "https://heycam.github.io/webidl/"
+          "url": "https://webidl.spec.whatwg.org/"
         }
       ]
     },


### PR DESCRIPTION
The update is needed to take into account the new spec's shortname (`webidl` instead of `WebIDL-1`) and URL.