### PR TITLE
CLI: Warn when version of Node.js is too old

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -696,6 +696,14 @@
         "is-unicode-supported": "^0.1.0"
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "marked": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.6.tgz",
@@ -1150,6 +1158,14 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
+    "semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
     "send": {
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
@@ -1421,6 +1437,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "fetch-filecache-for-crawling": "4.0.2",
     "node-pandoc": "0.3.0",
     "puppeteer": "10.4.0",
+    "semver": "^7.3.5",
     "webidl2": "24.1.2"
   },
   "devDependencies": {

--- a/reffy.js
+++ b/reffy.js
@@ -22,10 +22,18 @@
  */
 
 const commander = require('commander');
-const version = require('./package.json').version;
+const satisfies = require('semver/functions/satisfies');
 const specs = require('browser-specs');
+const { version, engines } = require('./package.json');
 const { requireFromWorkingDirectory } = require('./src/lib/util');
 const { crawlSpecs } = require('./src/lib/specs-crawler');
+
+// Warn if version of Node.js does not satisfy requirements
+if (engines && engines.node && !satisfies(process.version, engines.node)) {
+  console.warn(`
+[WARNING] Node.js ${process.version} detected but Reffy needs Node.js ${engines.node}.
+          Please consider upgrading Node.js if the program crashes!`);
+}
 
 
 function parseModuleOption(input) {
@@ -54,6 +62,7 @@ function parseSpecOption(input) {
         return list ?? input;
     }
 }
+
 
 const program = new commander.Command();
 program


### PR DESCRIPTION
This update issues a warning when the CLI is run with a version of Node.js that does not satisfy the `engines` requirements in the `package.json`.

Check is done early on to report the warning before the program actually crashes...

FYI @anssiko

Fix #761