### PR TITLE
Add parsed IDL generator tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ To create the WebIDL extract in the first place, you will need to run the `idl` 
 reffy --spec fetch --module idl > fetch.idl
 ```
 
+### Parsed WebIDL generator
+
+The **Parsed WebIDL generator** takes the results of a crawl as input and applies the WebIDL parser to all specs it contains to create JSON extracts in an `idlparsed` folder. To run the generator: `node src/cli/generate-idlparsed.js [crawl folder] [save folder]`
+
 
 ### WebIDL names generator
 

--- a/src/cli/check-missing-dfns.js
+++ b/src/cli/check-missing-dfns.js
@@ -399,7 +399,7 @@ function checkSpecDefinitions(spec, options = {}) {
     (spec.css || {});
   const idl = (typeof spec.idlparsed === "string") ?
     require(path.resolve(options.rootFolder, spec.idlparsed)).idlparsed :
-    spec.idl;
+    spec.idlparsed;
 
   // Make sure that all expected CSS definitions exist in the dfns extract
   const expectedCSSDfns = getExpectedDfnsFromCSS(css);

--- a/src/cli/generate-idlparsed.js
+++ b/src/cli/generate-idlparsed.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * The parsed IDL generator takes a crawl report or a single spec as input, and
+ * generates (or re-generates if it already exists) a parsed IDL structure from
+ * the raw IDL that the spec defines. Result is dumped to the console or saved
+ * to the given folder.
+ * 
+ * The parsed IDL generator is used by the crawler to create and save the parsed
+ * IDL structures. It is also useful to re-generated the parsed IDL info when
+ * an IDL patch has been applied to the raw IDL.
+ *
+ * The parsed IDL generator can be called directly through:
+ *
+ * `node generate-idlparsed.js [crawl report] [save folder]`
+ *
+ * where `crawl report` is the path to the folder that contains the
+ * `index.json` file and all other crawl results produced by specs-crawler.js,
+ * and `save folder` is an optional folder (which must exist) where IDL
+ * name extracts are to be saved. In the absence of this parameter, the report
+ * is written to the console.
+ *
+ * When a folder is provided, the IDL name extracts are saved as a JSON
+ * structure in an `idlparsed` subfolder.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const webidlParser = require('../cli/parse-webidl');
+const {
+  expandCrawlResult,
+  requireFromWorkingDirectory
+} = require('../lib/util');
+
+
+/**
+ * Update the spec object in place with parsed IDL information.
+ * 
+ * @function
+ * @public
+ * @param {Object} spec The spec object to update. The function looks for the
+ *   raw IDL in the `idl` property.
+ * @return {Object} The updated spec with an `idl` property that contains the
+ *   parsed version of the IDL, and the raw IDL moved under the `idl.idl`
+ *   sub-property. Note the spec object is updated in place.
+ */
+async function generateIdlParsed(spec) {
+  if (!spec?.idl) {
+    return spec;
+  }
+  const rawIdl = spec.idl.idl ?? spec.idl;
+  try {
+    const parsedIdl = await webidlParser.parse(rawIdl);
+    parsedIdl.hasObsoleteIdl = webidlParser.hasObsoleteIdl(rawIdl);
+    parsedIdl.idl = rawIdl;
+    spec.idl = parsedIdl;
+  }
+  catch (err) {
+    // IDL content is invalid and cannot be parsed.
+    // Let's return the error, along with the raw IDL
+    // content so that it may be saved to a file.
+    err.idl = rawIdl;
+    spec.idl = err;
+  }
+  return spec;
+}
+
+
+async function generateIdlParsedFromPath(crawlPath) {
+  const crawlIndex = requireFromWorkingDirectory(path.resolve(crawlPath, 'index.json'));
+  const crawlResults = await expandCrawlResult(crawlIndex, crawlPath, ['idl']);
+  await Promise.all(crawlResults.results.map(generateIdlParsed));
+  return crawlResults;
+}
+
+
+async function createFolderIfNeeded(name) {
+  try {
+    await fs.promises.mkdir(name);
+  }
+  catch (err) {
+    if (err.code !== 'EEXIST') {
+      throw err;
+    }
+  }
+}
+
+
+/**
+ * Generate the `idlparsed` export for the spec.
+ * 
+ * Note that the raw IDL (under `spec.idl.idl`) gets deleted in the process.
+ *
+ * @function
+ * @public
+ * @param {Object} spec Spec object with the parsed IDL
+ * @param {String} folder Path to root folder where `idlparsed` folder needs to
+ *   appear.
+ * @return {String} The relative path from the root folder to the generated file
+ */
+async function saveIdlParsed(spec, folder) {
+  function specInfo(spec) {
+    return {
+      spec: {
+        title: spec.title,
+        url: spec.crawled
+      }
+    };
+  }
+
+  const subfolder = path.join(folder, 'idlparsed');
+  await createFolderIfNeeded(subfolder);
+
+  if (!spec?.idl?.idl) {
+    return;
+  }
+
+  delete spec.idl.idl;
+  const json = JSON.stringify(
+    Object.assign(specInfo(spec), { idlparsed: spec.idl }),
+    null, 2);
+  const filename = path.join(subfolder, spec.shortname + '.json');
+  await fs.promises.writeFile(filename, json);
+  return `idlparsed/${spec.shortname}.json`;
+}
+
+
+/**************************************************
+Export methods for use as module
+**************************************************/
+module.exports.generateIdlParsed = generateIdlParsed;
+module.exports.saveIdlParsed = saveIdlParsed;
+
+
+/**************************************************
+Code run if the code is run as a stand-alone module
+**************************************************/
+if (require.main === module) {
+  const crawlPath = process.argv[2];
+  if (!crawlPath) {
+    console.error('Required path to crawl results folder is missing');
+    process.exit(2);
+  }
+
+  const savePath = process.argv[3];
+  generateIdlParsedFromPath(crawlPath)
+    .then(report => {
+      if (savePath) {
+        return Promise.all(report.results.map(
+          spec => saveIdlParsed(spec, savePath)));
+      }
+      else {
+        console.log(JSON.stringify(report, null, 2));
+      }
+    });
+}

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -732,6 +732,13 @@ async function expandCrawlResult(crawl, baseFolder, properties) {
                     idl: await fs.readFile(path.join(baseFolder, spec.idl), 'utf8')
                 };
             }
+
+            // Drop IDL header comment that got added when IDL content was
+            // serialized to a file.
+            if (spec.idl.idl.startsWith('// GENERATED CONTENT - DO NOT EDIT')) {
+                const endOfHeader = spec.idl.idl.indexOf('\n\n');
+                spec.idl.idl = spec.idl.idl.substring(endOfHeader + 2);
+            }
         }
 
         await Promise.all(Object.keys(spec).map(async property => {

--- a/tests/crawl-test.json
+++ b/tests/crawl-test.json
@@ -17,20 +17,6 @@
         "baz"
       ]
     },
-    "idl": {
-      "jsNames": {
-        "constructors": {},
-        "functions": {}
-      },
-      "idlNames": {},
-      "idlExtendedNames": {},
-      "globals": {},
-      "exposed": {},
-      "dependencies": {},
-      "externalDependencies": [],
-      "hasObsoleteIdl": false,
-      "idl": ""
-    },
     "title": "WOFF2",
     "css": {
       "properties": {},
@@ -94,20 +80,6 @@
           "url": "https://webidl.spec.whatwg.org/"
         }
       ]
-    },
-    "idl": {
-      "jsNames": {
-        "constructors": {},
-        "functions": {}
-      },
-      "idlNames": {},
-      "idlExtendedNames": {},
-      "globals": {},
-      "exposed": {},
-      "dependencies": {},
-      "externalDependencies": [],
-      "hasObsoleteIdl": false,
-      "idl": ""
     },
     "title": "No Title",
     "generator": "respec",
@@ -229,20 +201,6 @@
         }
       ],
       "informative": []
-    },
-    "idl": {
-      "jsNames": {
-        "constructors": {},
-        "functions": {}
-      },
-      "idlNames": {},
-      "idlExtendedNames": {},
-      "globals": {},
-      "exposed": {},
-      "dependencies": {},
-      "externalDependencies": [],
-      "hasObsoleteIdl": false,
-      "idl": ""
     },
     "title": "[No title found for https://w3c.github.io/accelerometer/]",
     "css": {

--- a/tests/generate-idlparsed.js
+++ b/tests/generate-idlparsed.js
@@ -1,0 +1,56 @@
+const { assert } = require('chai');
+const { generateIdlParsed } = require('../src/cli/generate-idlparsed');
+
+describe('The parsed IDL generator', function () {
+  it('leaves a spec without IDL intact', async () => {
+    const spec = {};
+    const result = await generateIdlParsed(spec);
+    assert.deepEqual(result, {});
+  });
+
+  it('parses raw IDL defined in the `idl` property', async () => {
+    const idl = 'interface foo {};';
+    const spec = { idl };
+    const result = await generateIdlParsed(spec);
+    assert.equal(result?.idl?.idl, idl);
+    assert.deepEqual(result?.idl?.idlNames, {
+      foo: {
+        extAttrs: [],
+        fragment: 'interface foo {};',
+        inheritance: null,
+        members: [],
+        name: 'foo',
+        partial: false,
+        type: 'interface'
+      }
+    });
+  });
+
+  it('parses raw IDL defined in the `idl.idl` property', async () => {
+    const idl = 'interface foo {};';
+    const spec = { idl: { idl } };
+    const result = await generateIdlParsed(spec);
+    assert.equal(result?.idl?.idl, idl);
+    assert.deepEqual(result?.idl?.idlNames, {
+      foo: {
+        extAttrs: [],
+        fragment: 'interface foo {};',
+        inheritance: null,
+        members: [],
+        name: 'foo',
+        partial: false,
+        type: 'interface'
+      }
+    });
+  });
+
+  it('reports IDL parsing errors', async () => {
+    const idl = 'intraface foo {};';
+    const spec = { idl };
+    const result = await generateIdlParsed(spec);
+    assert.equal(result?.idl?.idl, idl);
+    assert.equal(result.idl, `WebIDLParseError: Syntax error at line 1:
+intraface foo {};
+^ Unrecognised tokens`);
+  });
+});

--- a/tests/generate-idlparsed.js
+++ b/tests/generate-idlparsed.js
@@ -12,26 +12,7 @@ describe('The parsed IDL generator', function () {
     const idl = 'interface foo {};';
     const spec = { idl };
     const result = await generateIdlParsed(spec);
-    assert.equal(result?.idl?.idl, idl);
-    assert.deepEqual(result?.idl?.idlNames, {
-      foo: {
-        extAttrs: [],
-        fragment: 'interface foo {};',
-        inheritance: null,
-        members: [],
-        name: 'foo',
-        partial: false,
-        type: 'interface'
-      }
-    });
-  });
-
-  it('parses raw IDL defined in the `idl.idl` property', async () => {
-    const idl = 'interface foo {};';
-    const spec = { idl: { idl } };
-    const result = await generateIdlParsed(spec);
-    assert.equal(result?.idl?.idl, idl);
-    assert.deepEqual(result?.idl?.idlNames, {
+    assert.deepEqual(result?.idlparsed?.idlNames, {
       foo: {
         extAttrs: [],
         fragment: 'interface foo {};',
@@ -48,8 +29,7 @@ describe('The parsed IDL generator', function () {
     const idl = 'intraface foo {};';
     const spec = { idl };
     const result = await generateIdlParsed(spec);
-    assert.equal(result?.idl?.idl, idl);
-    assert.equal(result.idl, `WebIDLParseError: Syntax error at line 1:
+    assert.equal(result.idlparsed, `WebIDLParseError: Syntax error at line 1:
 intraface foo {};
 ^ Unrecognised tokens`);
   });


### PR DESCRIPTION
The tool contains the logic to generate parsed IDL structures from the raw IDL. It takes a crawl report as input and creates JSON files in an `idlparsed` folder.

The crawler now uses the functions exported by the tool to generate the `idlparsed` extracts.

The tool is needed to creates curated versions of reports and in particular to re-generate the `idlparsed` extracts once IDL patches have been applied to the crawled IDL.

This update includes some tests on the generation.