### PR TITLE
Add option to use fallback data when crawling spec list

### DIFF
--- a/reffy.js
+++ b/reffy.js
@@ -149,6 +149,12 @@ Usage notes for some of the options:
   Provides an existing JSON crawl data file to use as a source of fallback data
   for specs that fail to be crawled.
 
+  The fallback data gets copied as-is. It is the responsibility of the caller
+  to make sure that extracts it may link to actually exist and match the ones
+  that the crawl would produce in the absence of errors (e.g. same modules).
+
+  The "error" property is set on specs for which fallback data was used.
+
 -m, --module <modules...>
   If processing modules are not specified, the crawler runs all core processing
   modules defined in:

--- a/reffy.js
+++ b/reffy.js
@@ -70,6 +70,7 @@ program
     .usage('[options]')
     .description('Crawls and processes a list of Web specifications')
     .option('-d, --debug', 'debug mode, crawl one spec at a time')
+    .option('-f, --fallback <json>', 'fallback data to use when a spec crawl fails')
     .option('-m, --module <modules...>', 'spec processing modules')
     .option('-o, --output <folder>', 'existing folder/file where crawl results are to be saved')
     .option('-q, --quiet', 'do not report progress and other warnings to the console')
@@ -92,6 +93,7 @@ will dump ~100MB of data to the console:
         }
         const crawlOptions = {
             debug: options.debug,
+            fallback: options.fallback,
             output: options.output,
             publishedVersion: options.release,
             quiet: options.quiet,
@@ -143,6 +145,10 @@ Description:
   strongly recommended.
 
 Usage notes for some of the options:
+-f, --fallback <jsondata>
+  Provides an existing JSON crawl data file to use as a source of fallback data
+  for specs that fail to be crawled.
+
 -m, --module <modules...>
   If processing modules are not specified, the crawler runs all core processing
   modules defined in:

--- a/src/lib/nock-server.js
+++ b/src/lib/nock-server.js
@@ -97,7 +97,15 @@ nock("https://www.w3.org")
     { "Content-Type": "application/js" })
   .get("/Tools/respec/respec-w3c").replyWithFile(200,
     path.join(modulesFolder, "respec", "builds", "respec-w3c.js"),
-    { "Content-Type": "application/js" });
+    { "Content-Type": "application/js" })
+  .get("/TR/idontexist/").reply(404, '');
+
+nock("https://drafts.csswg.org")
+  .persist()
+  .get("/server-hiccup/").reply(200,
+    `<html><title>Server hiccup</title>
+    <h1> Index of Server Hiccup Module Level 42 </h1>`,
+    { 'Content-Type': 'text/html' });
 
 nock.emitter.on('error', function (err) {
   console.error(err);

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -711,6 +711,79 @@ function isLatestLevelThatPasses(spec, list, predicate) {
 
 
 /**
+ * Takes the results of a crawl for a given spec and expands it to include the
+ * contents of referenced files.
+ *
+ * The function handles both files and HTTPS resources, using either filesystem
+ * functions (for files) or fetch (for HTTPS resources).
+ *
+ * Note the spec object is expanded in place.
+ *
+ * @function
+ * @public
+ * @param {Object} spec Spec crawl result that needs to be expanded
+ * @param {string} baseFolder The base folder that contains the crawl file, or
+ *   the base HTTPS URI to resolve relative links in the crawl object.
+ * @param {Array(string)} properties An explicit list of properties to expand
+ *   (no value means "expand all possible properties")
+ * @return {Promise(object)} The promise to get an expanded crawl object that
+ *   contains the contents of referenced files and no longer references external
+ *   files (for the requested properties)
+ */
+async function expandSpecResult(spec, baseFolder, properties) {
+    baseFolder = baseFolder || '';
+    await Promise.all(Object.keys(spec).map(async property => {
+        // Only consider properties explicitly requested
+        if (properties && !properties.includes(property)) {
+            return;
+        }
+
+        // Only consider properties that link to an extract, i.e. an IDL
+        // or JSON file in subfolder.
+        if (!spec[property] ||
+                (typeof spec[property] !== 'string') ||
+                !spec[property].match(/^[^\/]+\/[^\/]+\.(json|idl)$/)) {
+            return;
+        }
+        let contents = null;
+        if (baseFolder.startsWith('https:')) {
+            const url = (new URL(spec[property], baseFolder)).toString();
+            const response = await fetch(url, { nolog: true });
+            contents = await response.text();
+        }
+        else {
+            const filename = path.join(baseFolder, spec[property]);
+            contents = await fs.readFile(filename, 'utf8');
+        }
+        if (spec[property].endsWith('.json')) {
+            contents = JSON.parse(contents);
+        }
+        if (property === 'css') {
+            // Special case for CSS where the "css" level does not exist
+            // in the generated files
+            const css = Object.assign({}, contents);
+            delete css.spec;
+            spec[property] = css;
+        }
+        else if (property === 'idl') {
+            // Special case for raw IDL extracts, which are text extracts.
+            // Also drop header that may have been added when extract was
+            // serialized.
+            if (contents.startsWith('// GENERATED CONTENT - DO NOT EDIT')) {
+                const endOfHeader = contents.indexOf('\n\n');
+                contents = contents.substring(endOfHeader + 2);
+            }
+            spec.idl = contents;
+        }
+        else {
+            spec[property] = contents[property];
+        }
+    }));
+    return spec;
+}
+
+
+/**
  * Takes the results of a crawl (typically the contents of the index.json file)
  * and expands it to include the contents of all referenced files.
  *
@@ -724,66 +797,16 @@ function isLatestLevelThatPasses(spec, list, predicate) {
  * @param {Object} crawl Crawl index object that needs to be expanded
  * @param {string} baseFolder The base folder that contains the crawl file, or
  *   the base HTTPS URI to resolve relative links in the crawl object.
- * @param {Array(string)} An explicit list of properties to expand (no value
- *   means "expand all possible properties")
+ * @param {Array(string)} properties An explicit list of properties to expand
+ *   (no value means "expand all possible properties")
  * @return {Promise(object)} The promise to get an expanded crawl object that
  *   contains the entire crawl report (and no longer references external files)
  */
 async function expandCrawlResult(crawl, baseFolder, properties) {
     baseFolder = baseFolder || '';
-
-    async function expandSpec(spec) {
-        await Promise.all(Object.keys(spec).map(async property => {
-            // Only consider properties explicitly requested
-            if (properties && !properties.includes(property)) {
-                return;
-            }
-
-            // Only consider properties that link to an extract, i.e. an IDL
-            // or JSON file in subfolder.
-            if (!spec[property] ||
-                    (typeof spec[property] !== 'string') ||
-                    !spec[property].match(/^[^\/]+\/[^\/]+\.(json|idl)$/)) {
-                return;
-            }
-            let contents = null;
-            if (baseFolder.startsWith('https:')) {
-                const url = (new URL(spec[property], baseFolder)).toString();
-                const response = await fetch(url, { nolog: true });
-                contents = await response.text();
-            }
-            else {
-                const filename = path.join(baseFolder, spec[property]);
-                contents = await fs.readFile(filename, 'utf8');
-            }
-            if (spec[property].endsWith('.json')) {
-                contents = JSON.parse(contents);
-            }
-            if (property === 'css') {
-                // Special case for CSS where the "css" level does not exist
-                // in the generated files
-                const css = Object.assign({}, contents);
-                delete css.spec;
-                spec[property] = css;
-            }
-            else if (property === 'idl') {
-                // Special case for raw IDL extracts, which are text extracts.
-                // Also drop header that may have been added when extract was
-                // serialized.
-                if (contents.startsWith('// GENERATED CONTENT - DO NOT EDIT')) {
-                    const endOfHeader = contents.indexOf('\n\n');
-                    contents = contents.substring(endOfHeader + 2);
-                }
-                spec.idl = contents;
-            }
-            else {
-                spec[property] = contents[property];
-            }
-        }));
-        return spec;
-    }
-
-    crawl.results = await Promise.all(crawl.results.map(expandSpec));
+    crawl.results = await Promise.all(
+        crawl.results.map(spec => expandSpecResult(spec, baseFolder, properties))
+    );
     return crawl;
 }
 
@@ -869,6 +892,7 @@ module.exports = {
     completeWithAlternativeUrls,
     isLatestLevelThatPasses,
     expandCrawlResult,
+    expandSpecResult,
     getGeneratedIDLNamesByCSSProperty,
     createFolderIfNeeded
 };

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -500,7 +500,10 @@ async function processSpecification(spec, processFunction, args, options) {
             await page.setContent(spec.html, loadOptions);
         }
         else {
-            await page.goto(spec.url, loadOptions);
+          const result = await page.goto(spec.url, loadOptions);
+          if (result.status() !== 200) {
+            throw new Error(`Loading ${spec.url} triggered HTTP status ${result.status()}`);
+          }
         }
 
         // Handle multi-page specs

--- a/tests/crawl-fallback.json
+++ b/tests/crawl-fallback.json
@@ -31,9 +31,9 @@
       "nightly": {
         "url": "https://www.w3.org/TR/idontexist/"
       },
-      "shortname": "httpswwww3orgTRidontexist",
+      "shortname": "idontexist",
       "series": {
-        "shortname": "httpswwww3orgTRidontexist"
+        "shortname": "idontexist"
       },
       "versions": [
         "https://www.w3.org/TR/idontexist/"
@@ -41,7 +41,8 @@
       "crawled": {
         "url": "https://www.w3.org/TR/idontexist/"
       },
-      "title": "On the Internet, nobody knows you don't exist"
+      "title": "On the Internet, nobody knows you don't exist",
+      "refs": "extracts/crawl-refs.json"
     }
   ]
 }

--- a/tests/crawl-fallback.json
+++ b/tests/crawl-fallback.json
@@ -1,0 +1,47 @@
+{
+  "type": "crawl",
+  "title": "Reffy crawl",
+  "date": "2022-02-02T10:45:00.000Z",
+  "options": {
+    "output": "tests",
+    "specs": [
+      "httpswwww3orgTRidontexist"
+    ],
+    "modules": [
+      "title",
+      "generator",
+      "date",
+      "links",
+      "refs",
+      "idl",
+      "css",
+      "dfns",
+      "elements",
+      "headings",
+      "ids"
+    ]
+  },
+  "stats": {
+    "crawled": 1,
+    "errors": 0
+  },
+  "results": [
+    {
+      "url": "https://www.w3.org/TR/idontexist/",
+      "nightly": {
+        "url": "https://www.w3.org/TR/idontexist/"
+      },
+      "shortname": "httpswwww3orgTRidontexist",
+      "series": {
+        "shortname": "httpswwww3orgTRidontexist"
+      },
+      "versions": [
+        "https://www.w3.org/TR/idontexist/"
+      ],
+      "crawled": {
+        "url": "https://www.w3.org/TR/idontexist/"
+      },
+      "title": "On the Internet, nobody knows you don't exist"
+    }
+  ]
+}

--- a/tests/crawl.js
+++ b/tests/crawl.js
@@ -105,6 +105,24 @@ if (global.describe && describe instanceof Function) {
         });
       assert.equal(results[0].title, "On the Internet, nobody knows you don't exist");
       assert.include(results[0].error, "Loading https://www.w3.org/TR/idontexist/ triggered HTTP status 404");
+      assert.equal(results[0].refs, "A useful list of refs");
+    });
+
+    it("saves fallback extracts in target folder", async () => {
+      const output = fs.mkdtempSync(path.join(os.tmpdir(), "reffy-"));
+      const url = "https://www.w3.org/TR/idontexist/";
+      await crawlSpecs({
+        specs: [{ url, nightly: { url } }],
+        output: output,
+        forceLocalFetch: true,
+        fallback: path.resolve(__dirname, "crawl-fallback.json")
+      });
+      const results = require(path.resolve(output, "index.json"));
+      assert.equal(results.results[0].url, "https://www.w3.org/TR/idontexist/");
+      assert.include(results.results[0].error, "Loading https://www.w3.org/TR/idontexist/ triggered HTTP status 404");
+      assert.equal(results.results[0].refs, "refs/idontexist.json");
+      const refs = require(path.resolve(output, "refs", "idontexist.json"));
+      assert.equal(refs.refs, "A useful list of refs");
     });
 
     it("reports draft CSS server issues", async () => {

--- a/tests/crawl.js
+++ b/tests/crawl.js
@@ -86,6 +86,24 @@ if (global.describe && describe instanceof Function) {
       assert.equal(results.results[0].title, 'A test spec');
     });
 
+    it("reports HTTP error statuses", async () => {
+      const url = "https://www.w3.org/TR/idontexist/";
+      const results = await crawlList(
+        [{ url, nightly: { url } }],
+        { forceLocalFetch: true });
+      assert.equal(results[0].title, "[Could not be determined, see error]");
+      assert.include(results[0].error, "Loading https://www.w3.org/TR/idontexist/ triggered HTTP status 404");
+    });
+
+    it("reports draft CSS server issues", async () => {
+      const url = "https://drafts.csswg.org/server-hiccup/";
+      const results = await crawlList(
+        [{ url, nightly: { url } }],
+        { forceLocalFetch: true });
+      assert.equal(results[0].title, "[Could not be determined, see error]");
+      assert.include(results[0].error, "CSS server issue detected");
+    });
+
     after(() => {
       if (!nock.isDone()) {
         throw new Error("Additional network requests expected: " + nock.pendingMocks());

--- a/tests/crawl.js
+++ b/tests/crawl.js
@@ -95,6 +95,18 @@ if (global.describe && describe instanceof Function) {
       assert.include(results[0].error, "Loading https://www.w3.org/TR/idontexist/ triggered HTTP status 404");
     });
 
+    it("reports errors and returns fallback data when possible", async () => {
+      const url = "https://www.w3.org/TR/idontexist/";
+      const results = await crawlList(
+        [{ url, nightly: { url } }],
+        {
+          forceLocalFetch: true,
+          fallback: path.resolve(__dirname, 'crawl-fallback.json')
+        });
+      assert.equal(results[0].title, "On the Internet, nobody knows you don't exist");
+      assert.include(results[0].error, "Loading https://www.w3.org/TR/idontexist/ triggered HTTP status 404");
+    });
+
     it("reports draft CSS server issues", async () => {
       const url = "https://drafts.csswg.org/server-hiccup/";
       const results = await crawlList(

--- a/tests/extracts/crawl-refs.json
+++ b/tests/extracts/crawl-refs.json
@@ -1,0 +1,8 @@
+{
+  "spec": {
+    "title": "On the Internet, nobody knows you don't exist",
+    "url": "https://www.w3.org/TR/idontexist/"
+  },
+
+  "refs": "A useful list of refs"
+}


### PR DESCRIPTION
not tested

I'm thinking this approach might help reducing risks for bogus updates to webref