### PR TITLE
Expose idlnames and idlparsed utility functions in package

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,5 +3,9 @@ module.exports = {
   crawlSpecs: require("./src/lib/specs-crawler").crawlList,
   expandCrawlResult: require("./src/lib/util").expandCrawlResult,
   mergeCrawlResults: require("./src/lib/util").mergeCrawlResults,
-  isLatestLevelThatPasses: require("./src/lib/util").isLatestLevelThatPasses
+  isLatestLevelThatPasses: require("./src/lib/util").isLatestLevelThatPasses,
+  generateIdlNames: require("./src/cli/generate-idlnames").generateIdlNames,
+  saveIdlNames: require("./src/cli/generate-idlnames").saveIdlNames,
+  generateIdlParsed: require("./src/cli/generate-idlparsed").generateIdlParsed,
+  saveIdlParsed: require("./src/cli/generate-idlparsed").saveIdlParsed
 };

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -740,6 +740,13 @@ async function expandCrawlResult(crawl, baseFolder, properties) {
                 const filename = path.join(baseFolder, spec[property]);
                 contents = await fs.readFile(filename, 'utf8');
             }
+
+            // Force Linux-style line endings
+            // (Git may auto-convert LF to CRLF on Windows machines and we
+            // want to store multiline IDL fragments as values of properties
+            // in parsed IDL trees)
+            contents = contents.replaceAll('\r\n', '\n');
+
             if (spec[property].endsWith('.json')) {
                 contents = JSON.parse(contents);
             }

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -745,7 +745,7 @@ async function expandCrawlResult(crawl, baseFolder, properties) {
             // (Git may auto-convert LF to CRLF on Windows machines and we
             // want to store multiline IDL fragments as values of properties
             // in parsed IDL trees)
-            contents = contents.replaceAll('\r\n', '\n');
+            contents = contents.replace(/\r\n/g, '\n');
 
             if (spec[property].endsWith('.json')) {
                 contents = JSON.parse(contents);

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -741,7 +741,7 @@ async function expandCrawlResult(crawl, baseFolder, properties) {
                 contents = await fs.readFile(filename, 'utf8');
             }
 
-            // Force Linux-style line endings
+            // Force UNIX-style line endings
             // (Git may auto-convert LF to CRLF on Windows machines and we
             // want to store multiline IDL fragments as values of properties
             // in parsed IDL trees)


### PR DESCRIPTION
This makes it easier to reuse these functions from within other packages. Typically useful to create a curated data view in Webref.

The update also adjusts the `expandCrawlResults` function to convert CRLF to LF when it loads text files, as Git may auto-convert LF to CRLF on checkout on Windows machines (that does not create any error per se, but we'll want to reuse the expanded IDL to create multiline IDL fragments in parsed IDL constructs, and it seems good to make sure that all platforms generate the exact same IDL fragments).