### PR TITLE
Normalize Web IDL spaces right after extraction

### DIFF
--- a/src/browserlib/extract-webidl.mjs
+++ b/src/browserlib/extract-webidl.mjs
@@ -11,19 +11,28 @@ import informativeSelector from './informative-selector.mjs';
  */
 export default function () {
     const generator = getGenerator();
+    let idl = '';
     if (generator === 'bikeshed') {
-        return extractBikeshedIdl();
+        idl = extractBikeshedIdl();
     }
     else if (document.title.startsWith('Web IDL')) {
         // IDL content in the Web IDL spec are... examples,
         // not real definitions
-        return '';
     }
     else {
         // Most non-ReSpec specs still follow the ReSpec conventions
         // for IDL definitions
-        return extractRespecIdl();
+        idl = extractRespecIdl();
     }
+
+    if (idl) {
+        // Remove trailing spaces and use spaces throughout
+        idl = idl
+            .replace(/\s+$/gm, '\n')
+            .replace(/\t/g, '  ')
+            .trim();
+    }
+    return idl;
 }
 
 

--- a/src/lib/specs-crawler.js
+++ b/src/lib/specs-crawler.js
@@ -226,11 +226,7 @@ async function saveSpecResults(spec, settings) {
             // (https://github.com/w3c/webref)
             // Source: ${spec.title} (${spec.crawled})`;
         idlHeader = idlHeader.replace(/^\s+/gm, '').trim() + '\n\n';
-        let idl = spec.idl
-            .replace(/\s+$/gm, '\n')
-            .replace(/\t/g, '  ')
-            .trim();
-        idl = idlHeader + idl + '\n';
+        const idl = idlHeader + spec.idl + '\n';
         await fs.promises.writeFile(
             path.join(folders.idl, spec.shortname + '.idl'), idl);
         return `idl/${spec.shortname}.idl`;

--- a/tests/extract-webidl.js
+++ b/tests/extract-webidl.js
@@ -1,0 +1,153 @@
+const { assert } = require('chai');
+const puppeteer = require('puppeteer');
+const path = require('path');
+const rollup = require('rollup');
+
+const testIds = [
+  {
+    title: "extracts Web IDL from pre.idl",
+    html: `<h1 id=title>Title</h1>
+<pre class="idl">interface GreatIdl {}</pre>`,
+    res: 'interface GreatIdl {}'
+  },
+
+  {
+    title: "extracts Web IDL from pre > code.idl-code",
+    html: `<h1 id=title>Title</h1>
+<pre><code class="idl-code">interface GreatIdl {}</code></pre>`,
+    res: 'interface GreatIdl {}'
+  },
+
+  {
+    title: "extracts Web IDL from pre > code.idl",
+    html: `<h1 id=title>Title</h1>
+<pre><code class="idl">interface GreatIdl {}</code></pre>`,
+    res: 'interface GreatIdl {}'
+  },
+
+  {
+    title: "extracts Web IDL from div.idl-code > pre",
+    html: `<h1 id=title>Title</h1>
+<div class="idl-code"><pre>interface GreatIdl {}</pre></div>`,
+    res: 'interface GreatIdl {}'
+  },
+
+  {
+    title: "extracts Web IDL from pre.widl",
+    html: `<h1 id=title>Title</h1>
+<pre class="widl">interface GreatIdl {}</pre>`,
+    res: 'interface GreatIdl {}'
+  },
+
+  {
+    title: "combines Web IDL defined in multiple blocks",
+    html: `<h1 id=title>Title</h1>
+<pre class="idl">interface GreatIdl {}</pre>
+<pre><code class="idl">interface GreatIdl2 {}</code></pre>
+<div class="idl-code"><pre>interface GreatIdl3 {}</pre></div>
+<pre class="widl">interface GreatIdl4 {}</pre>`,
+    res: `interface GreatIdl {}
+
+interface GreatIdl2 {}
+
+interface GreatIdl3 {}
+
+interface GreatIdl4 {}`
+  },
+
+  {
+    title: "ignores Web IDL defined with .exclude",
+    html: `<h1 id=title>Title</h1>
+<pre class="idl exclude">interface GreatIdl {}</pre>
+<pre class="exclude"><code class="idl">interface GreatIdl {}</code></pre>
+<pre><code class="idl exclude">interface GreatIdl {}</code></pre>
+<div class="idl-code exclude"><pre>interface GreatIdl {}</pre></div>
+<div class="idl-code"><pre class="exclude">interface GreatIdl {}</pre></div>
+<pre class="widl exclude">interface GreatIdl {}</pre>`,
+    res: ''
+  },
+
+  {
+    title: "ignores Web IDL defined with .extract",
+    html: `<h1 id=title>Title</h1>
+<pre class="idl extract">interface GreatIdl {}</pre>
+<pre class="extract"><code class="idl">interface GreatIdl {}</code></pre>
+<pre><code class="idl extract">interface GreatIdl {}</code></pre>
+<div class="idl-code extract"><pre>interface GreatIdl {}</pre></div>
+<div class="idl-code"><pre class="extract">interface GreatIdl {}</pre></div>
+<pre class="widl extract">interface GreatIdl {}</pre>`,
+    res: ''
+  },
+
+  {
+    title: "trims trailing spaces",
+    html: `<h1 id=title>Title</h1>
+<pre class="idl">interface GreatIdl {}  </pre>`,
+    res: 'interface GreatIdl {}'
+  },
+
+  {
+    title: "replaces tabs with spaces",
+    html: `<h1 id=title>Title</h1>
+<pre class="idl">interface GreatIdl {
+\tboolean amIGreat();\t
+}</pre>`,
+    res: `interface GreatIdl {
+  boolean amIGreat();
+}`
+  },
+
+  {
+    title: "ignores the Web IDL index by default",
+    html: `<h1 id=title>Title</h1>
+<div id="idl-index"><pre class="idl">interface GreatIdl {}</pre></div>`,
+    res: ''
+  },
+
+  {
+    title: "uses the Web IDL index in Bikeshed specs",
+    html: `<meta name="generator" content="Bikeshed" />
+<h1 id=title>Title</h1>
+<pre class="idl">interface GreatIdl {}</pre>
+<h2 id="idl-index">IDL index</h2>index
+<pre class="idl">interface GreatIdl {}</pre>`,
+    res: 'interface GreatIdl {}'
+  }
+];
+
+describe("Web IDL extraction", function () {
+  this.slow(5000);
+
+  let browser;
+  let extractCode;
+
+  before(async () => {
+    const extractBundle = await rollup.rollup({
+      input: path.resolve(__dirname, '../src/browserlib/extract-webidl.mjs')
+    });
+    const extractOutput = (await extractBundle.generate({
+      name: 'extractIdl',
+      format: 'iife'
+    })).output;
+    extractCode = extractOutput[0].code;
+
+    browser = await puppeteer.launch({ headless: true });
+  });
+
+  testIds.forEach(t => {
+    it(t.title, async () => {
+      const page = await browser.newPage();
+      page.setContent(t.html);
+      await page.addScriptTag({ content: extractCode });
+
+      const extracted = await page.evaluate(async () => extractIdl());
+      await page.close();
+      assert.deepEqual(extracted, t.res);
+    });
+  });
+
+
+  after(async () => {
+    await browser.close();
+  });
+});


### PR DESCRIPTION
The crawler normalized spaces in Web IDL extracts just before the extracts were saved to the `idl` folder. This meant that the Web IDL fragments that appear in the `idlparsed` extracts used non-normalized Web IDL (because they are created before Web IDL extracts get saved).

This update normalizes spaces in Web IDL extracts right after extraction, so that normalized Web IDL gets used everywhere. In turn, this means that re-generating the `idlparsed` extracts afterwards from the `idl` folder (needed to release curated data), will embed the same Web IDL fragments as when that operation is carried out during crawling.

This update also adds tests for the Web IDL extraction module, including tests on the normalization.