### PR TITLE
Link to series extracts from one spec, make idlparsed per series

### DIFF
--- a/src/lib/specs-crawler.js
+++ b/src/lib/specs-crawler.js
@@ -443,10 +443,9 @@ async function adjustExtractsPerSeries(data, property, settings) {
         }
         else if (spec[property]) {
             // Not the right full level in the series, drop created extract
-            // and link to the series extract instead
             const pathname = path.resolve(settings.output, spec[property]);
             fs.unlinkSync(pathname);
-            spec[property] = `${property}/${spec.series.shortname}${path.extname(spec[property])}`;
+            delete spec[property];
         }
     });
 
@@ -554,6 +553,9 @@ function crawlSpecs(options) {
             for (const mod of options.modules) {
                 if (mod.extractsPerSeries) {
                     await adjustExtractsPerSeries(results, mod.property, options);
+                    if (mod.property === 'idl') {
+                        await adjustExtractsPerSeries(results, 'idlparsed', options);
+                    }
                 }
             }
             return results;


### PR DESCRIPTION
This fixes #844. The crawler kept a link to series extracts (CSS and IDL) from all specs in the series. This is clumsy at best, and basically wrong as the extracts may not represent the actual content defined in that spec. The crawler no longer does that.

The `idlparsed` folder is built from the `idl` folder but was per spec instead of per series. For consistency (and to avoid creating duplicate specs under `idlparsed`), the `idlparsed` folder now contains extracts per spec series.