### PR TITLE
Remove trailing line return in IDL when loading from fallback

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -771,7 +771,9 @@ async function expandSpecResult(spec, baseFolder, properties) {
             // serialized.
             if (contents.startsWith('// GENERATED CONTENT - DO NOT EDIT')) {
                 const endOfHeader = contents.indexOf('\n\n');
-                contents = contents.substring(endOfHeader + 2);
+                contents = contents.substring(endOfHeader + 2)
+                // remove trailing newline added in saveIdl
+                  .slice(0, -1);
             }
             spec.idl = contents;
         }


### PR DESCRIPTION
Otherwise new line returns gets added when the fallback is used; among other things, this makes webref curated patches no longer applicable as in https://github.com/w3c/webref/runs/5051707336?check_suite_focus=true