### PR TITLE
Switch from browser-specs to web-specs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "reffy",
-  "version": "6.2.2",
+  "version": "6.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "reffy",
-      "version": "6.2.2",
+      "version": "6.3.0",
       "license": "MIT",
       "dependencies": {
         "abortcontroller-polyfill": "1.7.3",
-        "browser-specs": "2.27.0",
         "commander": "9.0.0",
         "fetch-filecache-for-crawling": "4.1.0",
         "puppeteer": "13.1.3",
         "semver": "^7.3.5",
+        "web-specs": "^1.0.0",
         "webidl2": "24.2.0"
       },
       "bin": {
@@ -193,11 +193,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/browser-specs": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/browser-specs/-/browser-specs-2.27.0.tgz",
-      "integrity": "sha512-k/0/NAr9mONusiTMqtprQVOHrz2Wpih/Uf9tBIvJFEB9f5dcIoBmti/y21vk9T6gMRXk4SkGsYEoFFZlaCwfcA=="
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -1874,6 +1869,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "node_modules/web-specs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-1.0.0.tgz",
+      "integrity": "sha512-fNFXJ+sOvpQC+/j2v5sAInew6nev5OcWHT7RYT4dUdYQttg5o8lJNSHF+q/O+3V2o8saEBYw6P1P040rjLXALw=="
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -2164,11 +2164,6 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
-    },
-    "browser-specs": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/browser-specs/-/browser-specs-2.27.0.tgz",
-      "integrity": "sha512-k/0/NAr9mONusiTMqtprQVOHrz2Wpih/Uf9tBIvJFEB9f5dcIoBmti/y21vk9T6gMRXk4SkGsYEoFFZlaCwfcA=="
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -3372,6 +3367,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "web-specs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-1.0.0.tgz",
+      "integrity": "sha512-fNFXJ+sOvpQC+/j2v5sAInew6nev5OcWHT7RYT4dUdYQttg5o8lJNSHF+q/O+3V2o8saEBYw6P1P040rjLXALw=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   "bin": "./reffy.js",
   "dependencies": {
     "abortcontroller-polyfill": "1.7.3",
-    "browser-specs": "2.27.0",
     "commander": "9.0.0",
     "fetch-filecache-for-crawling": "4.1.0",
     "puppeteer": "13.1.3",
     "semver": "^7.3.5",
+    "web-specs": "1.0.0",
     "webidl2": "24.2.0"
   },
   "devDependencies": {

--- a/reffy.js
+++ b/reffy.js
@@ -23,7 +23,7 @@
 
 const commander = require('commander');
 const satisfies = require('semver/functions/satisfies');
-const specs = require('browser-specs');
+const specs = require('web-specs');
 const { version, engines } = require('./package.json');
 const { requireFromWorkingDirectory } = require('./src/lib/util');
 const { crawlSpecs } = require('./src/lib/specs-crawler');

--- a/src/lib/specs-crawler.js
+++ b/src/lib/specs-crawler.js
@@ -12,7 +12,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const specs = require('browser-specs');
+const specs = require('web-specs');
 const cssDfnParser = require('./css-grammar-parser');
 const { generateIdlParsed, saveIdlParsed } = require('../cli/generate-idlparsed');
 const { generateIdlNames, saveIdlNames } = require('../cli/generate-idlnames');

--- a/tests/util.js
+++ b/tests/util.js
@@ -1,6 +1,6 @@
 const { assert } = require('chai');
 
-const specs = require('browser-specs');
+const specs = require('web-specs');
 const {
   getGeneratedIDLNamesByCSSProperty,
   isLatestLevelThatPasses


### PR DESCRIPTION
The `web-specs` package contains non browser specs on top of the specs that target browsers in the `browser-specs` package.

Whether a spec targets browsers or not will appear in the crawl results under the `categories` property.

Follows from https://github.com/w3c/browser-specs/issues/436 and https://github.com/w3c/browser-specs/pull/496