### PR TITLE
Do not produce CSS/IDL extracts for fork specs

### DIFF
--- a/src/lib/specs-crawler.js
+++ b/src/lib/specs-crawler.js
@@ -447,11 +447,20 @@ async function adjustExtractsPerSeries(data, property, settings) {
 
     data.forEach(spec => {
         if (fullLevels.includes(spec)) {
-            // Full level, rename the extract after the series' shortname
-            const pathname = path.resolve(settings.output, spec[property]);
-            spec[property] = `${property}/${spec.series.shortname}${path.extname(spec[property])}`;
-            const newpathname = path.resolve(settings.output, spec[property]);
-            fs.renameSync(pathname, newpathname);
+            // Full level, rename the extract after the series' shortname,
+            // unless we're dealing with a fork spec, in which case, we'll
+            // drop the created extract (not to run into IDL duplication issues)
+            if (spec.seriesComposition === 'fork') {
+                const pathname = path.resolve(settings.output, spec[property]);
+                fs.unlinkSync(pathname);
+                delete spec[property];
+            }
+            else {
+                const pathname = path.resolve(settings.output, spec[property]);
+                spec[property] = `${property}/${spec.series.shortname}${path.extname(spec[property])}`;
+                const newpathname = path.resolve(settings.output, spec[property]);
+                fs.renameSync(pathname, newpathname);
+            }
         }
         else if (deltaLevels.includes(spec)) {
             // Delta level, need to keep the extract as-is


### PR DESCRIPTION
This update makes it possible to integrate "fork" specs in `web-specs` (see https://github.com/w3c/browser-specs/pull/528). Reffy will not produce CSS/IDL extracts for these specs for the time being to avoid running into thorny duplicate issues, see comment in https://github.com/w3c/browser-specs/issues/511#issuecomment-1050958822