### PR TITLE
Ignore comment lines in CSS value space definitions

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -184,6 +184,7 @@ const extractValueSpaces = doc => {
 
   const parseProductionRules = rules =>
     rules
+      .map(val => val.replace(/\/\*[^]*?\*\//gm, ''))  // Drop comments
       .map(val => val.split(/\n(?=[^\n]*\s?=\s)/m))
       .reduce((acc, val) => acc.concat(val), [])
       .map(line => line.split(/\s?=\s/).map(s => s.trim().replace(/\s+/g, ' ')))

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -391,6 +391,31 @@ const tests = [
      </td></tr></tbody></table>`,
     css: {}
   },
+
+  {
+    title: "ignores comments",
+    html: `<pre class="prod">&lt;page-selector-list> = &lt;page-selector>#
+/* A comment */
+&lt;page-selector> = [ &lt;ident-token>? &lt;pseudo-page>* ]!
+&lt;pseudo-page> = ':' [ left | right | first | blank ] /* Another comment */
+
+/* Yet another one
+that spans multiple lines */
+@top-left-corner = @top-left-corner { &lt;declaration-list> };
+</pre>`,
+    propertyName: "valuespaces",
+    css: {
+      "<page-selector-list>": {
+        value: "<page-selector>#"
+      },
+      "<page-selector>": {
+        value: "[ <ident-token>? <pseudo-page>* ]!"
+      },
+      "<pseudo-page>": {
+        value: "':' [ left | right | first | blank ]"
+      }
+    }
+  },
 ];
 
 describe("Test CSS properties extraction", function() {


### PR DESCRIPTION
Fixes #534 and would allow us to drop the CSS patch for css-page in Webref:
https://github.com/w3c/webref/blob/main/ed/csspatches/css-page.json.patch