### PR TITLE
IDL extraction: drop check on NoInterfaceObject

### DIFF
--- a/src/cli/parse-webidl.js
+++ b/src/cli/parse-webidl.js
@@ -294,9 +294,7 @@ function parseInterfaceOrDictionary(def, idlReport) {
     } else if (def.members.find(member => member.type === 'constructor')) {
         addToJSContext(def.extAttrs, jsNames, def.name, "constructors");
     } else if (def.type === "interface") {
-        if (!def.extAttrs.some(ea => ea.name === "NoInterfaceObject")) {
-            addToJSContext(def.extAttrs, jsNames, def.name, "functions");
-        }
+        addToJSContext(def.extAttrs, jsNames, def.name, "functions");
     }
     def.members.forEach(parseIdlAstTree(idlReport, def.name));
 }


### PR DESCRIPTION
Fix for #87. The extraction code took for granted that an interface defined with `NoInterfaceObject` could not be referenced, which is wrong.

In practice, the `NoInterfaceObject` extended attribute was replaced by `LegacyNoInterfaceObject` some time ago, meaning that the condition always passed in practice, so bug was already fixed.

FWIW, the only interfaces that still use `LegacyNoInterfaceObject` are WebGL extensions.