### PR TITLE
Well-known Web IDL types: Drop Error, RegExp and DOMException

### DIFF
--- a/src/cli/parse-webidl.js
+++ b/src/cli/parse-webidl.js
@@ -355,8 +355,16 @@ function parseType(idltype, idlReport, contextName) {
         parseType(idltype.idlType, idlReport, contextName);
         return;
     }
-    var wellKnownTypes = ["undefined", "any", "boolean", "byte", "octet", "short", "unsigned short", "long", "unsigned long", "long long", "unsigned long long", "float", "unrestricted float", "double", "unrestricted double", "DOMString", "ByteString", "USVString", "object",
-                          "RegExp", "Error", "DOMException"];
+    var wellKnownTypes = [
+            "undefined", "any",
+            "boolean",
+            "byte", "octet",
+            "short", "unsigned short",
+            "long", "unsigned long", "long long", "unsigned long long",
+            "float", "unrestricted float", "double", "unrestricted double",
+            "DOMString", "ByteString", "USVString",
+            "object"
+    ];
     if (wellKnownTypes.indexOf(idltype.idlType) === -1) {
         addDependency(idltype.idlType, idlReport.idlNames, idlReport.externalDependencies);
         if (contextName) {


### PR DESCRIPTION
PR #771 took care of most Web IDL types that are defined in the Web IDL spec as actual IDL interfaces, except `DOMException`. It appears 24 times across all specs, that seems like a good dependency to track as well (and not too noisy).

`Error` and `RegExp` are not valid Web IDL types, so not sure why they were added to the list of well-known Web IDL types in the first place!

This would fix #516. Automation seems overkill for that.