### PR TITLE
Events extraction: ignore invalid Web IDL

### DIFF
--- a/src/browserlib/extract-events.mjs
+++ b/src/browserlib/extract-events.mjs
@@ -13,11 +13,17 @@ const href = el => el?.getAttribute("id") ? getAbsoluteUrl(el, {singlePage}) : n
 
 export default function (spec) {
   // Used to find eventhandler attributes
-  const idl = extractWebIdl();
-  const idlTree = parse(idl);
-  const idlInterfaces = idlTree.filter(item =>
-    item.type === "interface" ||
-    item.type === "interface mixin");
+  let idlInterfaces = [];
+  try {
+    const idl = extractWebIdl();
+    const idlTree = parse(idl);
+    idlInterfaces = idlTree.filter(item =>
+      item.type === "interface" ||
+      item.type === "interface mixin");
+  }
+  catch {
+    // Spec defines some invalid Web IDL, proceed without it
+  }
 
   // associate event names from event handlers to interfaces with such an handler
   const handledEventNames = idlInterfaces

--- a/tests/extract-events.js
+++ b/tests/extract-events.js
@@ -103,6 +103,15 @@ ${defaultIdl}`,
     res: defaultResults("fire an event phrasing", {successIface: "ExtendableEvent"})
   },
   {
+    title: "ignores invalid IDL fragments",
+    html: `<p id=success><a href='https://w3c.github.io/ServiceWorker/#fire-functional-event'>Fire Functional Event</a> <code>success</code> with the <code>bubbles</code> attribute initialized to <code>true</code></p>${defaultIdl.replace(/attribute/, 'allezbut')}`,
+    res: [ {
+      type: "success", interface: "ExtendableEvent", bubbles: true,
+      href: "about:blank#success",
+      src: { format: "fire an event phrasing", href: "about:blank#success" }
+    } ]
+  },
+  {
     title: "extracts events from event definitions",
     html: `<p><dfn id=success data-dfn-type=event data-dfn-for=Example>success</dfn> is an event, not a state.</p>`,
     res: [


### PR DESCRIPTION
Events extraction crashed whenever it encountered invalid Web IDL (see e.g. WebCryptoAPI in latest results of TR crawl). This update makes it simply ignore the offending Web IDL.

We will most likely miss the target interfaces of the event as a result but at least we won't prevent other extractions (including Web IDL extraction so that we know that a patch is needed) to proceed.

In an ideal world, we would somehow re-run events extraction after IDL patching.