### PR TITLE
Prefer syntax value over prose definition when both exist

### DIFF
--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -431,6 +431,24 @@ that spans multiple lines */
       }
     }
   },
+
+  {
+    title: "parses syntax value preferably",
+    html: `<div>
+      <p>
+        <dfn data-dfn-type="function" data-lt="&lt;toto()>">&lt;toto(A)></dfn> is a super function.</dfn>
+      </p>
+      <pre class="prod"><code>
+        &lt;toto()> = toto( &lt;integer> )
+      </code></pre>`,
+    propertyName: "valuespaces",
+    css: {
+      "<toto()>": {
+        prose: "<toto(A)> is a super function.",
+        value: "toto( <integer> )"
+      }
+    }
+  },
 ];
 
 describe("Test CSS properties extraction", function() {


### PR DESCRIPTION
This fixes the extraction issue raised in:
https://github.com/w3c/reffy/issues/982#issuecomment-1170741314

Some specs define functions with fake parameters in prose, while the actual definition is found below in a separate syntax section. The extraction code now prefers values extracted from pure syntax blocks over those extracted from the prose when both are available.