### PR TITLE
Remove uievents-specific event extraction code

### DIFF
--- a/src/browserlib/extract-events.mjs
+++ b/src/browserlib/extract-events.mjs
@@ -75,7 +75,10 @@ export default function (spec) {
         const bubblingInfoColumn = [...table.querySelectorAll("thead th")]
           .findIndex(n => n.textContent.trim().match(/^bubbl/i));
         const interfaceColumn = [...table.querySelectorAll("thead th")]
-          .findIndex(n => n.textContent.trim().match(/^interface/i));
+          .findIndex(n => n.textContent.trim().match(/^(dom )?interface/i));
+        const targetsColumn = [...table.querySelectorAll("thead th")]
+          .findIndex(n => n.textContent.trim().match(/target/i));
+
         table.querySelectorAll("tbody tr").forEach(tr => {
           const event = {};
           // clean up possible MDN annotations
@@ -119,26 +122,12 @@ export default function (spec) {
               tr.querySelector(`td:nth-child(${interfaceColumn + 1}) a`)?.textContent ??
               tr.querySelector(`td:nth-child(${interfaceColumn + 1}) code`)?.textContent;
           }
+	  if (targetsColumn >= 0 && !event.targets) {
+	    event.targets = tr.querySelector(`td:nth-child(${targetsColumn + 1})`)?.textContent?.split(',').map(t => t.trim());
+	  }
           events.push(event);
           eventEl.replaceWith(origEventEl);
         });
-      } else if (table.className === "event-definition") {
-        hasStructuredData = true;
-        // Format used e.g. in uievents
-        const eventName = table.querySelector("tbody tr:first-child td:nth-child(2)")?.textContent.trim();
-        let iface = table.querySelector("tbody tr:nth-child(2) td:nth-child(2) a")?.textContent.trim();
-        let bubbles = table.querySelector("tbody tr:nth-child(4) td:nth-child(2)")?.textContent?.trim() === "Yes";
-        let targets = table.querySelector("tbody tr:nth-child(5) td:nth-child(2)")?.textContent?.split(",")?.map(t => t.trim());
-        if (targets && targets.find(t => t.match(/\s/))) {
-          // Prose description, skip it
-          targets = null;
-        }
-        if (eventName) {
-          events.push({
-            type: eventName, interface: iface, targets, bubbles,
-            src: { format: "definition table", href: href(table.closest('*[id]')) },
-            href: href(table.closest('*[id]')) });
-        }
       } else if (table.className === "def") {
         // Used in https://drafts.csswg.org/css-nav-1/
         const rowHeadings = [...table.querySelectorAll("tbody th")];

--- a/tests/extract-events.js
+++ b/tests/extract-events.js
@@ -47,31 +47,6 @@ const tests = [
     res: defaultResults("summary table")
   },
   {
-    title: "extracts events from an event described by a  table with data spread across rows",
-    html: `
-<section>
-<h3><code>success</code> Event</h3>
-<table class="event-definition" id='success'>
-<tbody>
-<tr><th>Type</th><td><code>success</code></td>
-<tr><th>Interface</th><td><a><code>SuccessEvent</code></a></td>
-<tr><th>Stuff</th><td></td>
-<tr><th>Bubbles</th><td><code>Yes</code></td>
-<tr><th>Targets</th><td><code>Example</code></td>
-</section>
-<section>
-<h3><code>error</code> Event</h3>
-<table class="event-definition" id=error>
-<tbody>
-<tr><th>Type</th><td><code>error</code></td>
-<tr><th>Interface</th><td><a><code>ErrorEvent</code></a></td>
-<tr><th>Stuff</th><td></td>
-<tr><th>Bubbles</th><td><code>No</code></td>
-<tr><th>Targets</th><td><code>Example</code></td>
-</section>`,
-    res: defaultResults("definition table")
-  },
-  {
     title: "extracts events from an event described by a CSS def table with data spread across rows, completed by an IDL fragment",
     html: `<h3><code>success</code> Event</h3>
 <table class="def" id='success'>


### PR DESCRIPTION
Their summary table is now compatible with the script
This loses extraction of legacy events https://w3c.github.io/uievents/#legacy-event-types - maybe worth revisiting at some point