### PR TITLE
Extract info about events defined in a different spec

### DIFF
--- a/src/browserlib/extract-events.mjs
+++ b/src/browserlib/extract-events.mjs
@@ -89,13 +89,6 @@ export default function (spec) {
           annotations.forEach(n => n.remove());
 
           let el = eventEl.querySelector("dfn,a");
-          if (el?.tagName === "A" && el?.getAttribute("href")?.startsWith("https:")) {
-            // we skip when we hit a link pointing to an external spec
-            // (this is needed since the HTML spec table includes
-            // links to pointer events)
-            eventEl.replaceWith(origEventEl);
-            return;
-          }
           if (!el) {
             el = eventEl.querySelector("code");
           }
@@ -202,13 +195,10 @@ export default function (spec) {
           event.type = name;
           // looking at the element following the link
 	  // if its content match the name of the event
-	  const eventEl = a.nextElementSibling?.textContent?.trim() === event.type ? a.nextElementSibling : null;
+	  const eventEl = a.nextElementSibling?.textContent?.trim() === event.type ? a.nextElementSibling.querySelector("a,dfn") || a.nextElementSibling : null;
           if (eventEl) {
             if (eventEl.tagName === "A" && eventEl.getAttribute("href")) {
-              // If the event being fired is from another spec, let's skip it
-              if (eventEl.getAttribute("href").startsWith("https://")) return;
-
-              // otherwise, use the target of the link as our href
+              // use the target of the link as our href
               event.href = eventEl.href;
             } else if (eventEl.tagName === "DFN" && eventEl.id) {
               eventEl.href = href(eventEl);
@@ -345,5 +335,5 @@ export default function (spec) {
       }
     }
   });
-  return events;
+  return events.map(e => e.href && !e.href.startsWith(spec.crawled.url) ? Object.assign(e, {isExtension: true}) : e) ;
 }

--- a/tests/extract-events.js
+++ b/tests/extract-events.js
@@ -154,7 +154,8 @@ ${defaultIdl}`,
 	type: "success",
 	interface: "SuccessEvent",
 	src: { format: "summary table", href:"https://example.org/indices.html#success"},
-	href:"https://example.org/indices.html#success"
+	href:"https://example.org/indices.html#success",
+	isExtension: true
       }
     ]
   }
@@ -182,7 +183,7 @@ describe("Events extraction", function () {
   tests.forEach(t => {
     it(t.title, async () => {
       const page = await browser.newPage();
-      const pageContent = t.html + "<script>let spec = '" + (t.spec || "example") + "';</script>";
+      const pageContent = t.html + "<script>let spec = {shortname: '" + (t.spec || "example") + "', crawled: {url: 'about:blank'}};</script>";
       page.setContent(pageContent);
       await page.addScriptTag({ content: extractEventsCode });
 


### PR DESCRIPTION
This will let us compile info on events re-use across specs and possibly complete information when it is split across multiple specs