### PR TITLE
[CSS extraction] Filter out non production rules

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -325,6 +325,7 @@ const extractValueSpaces = doc => {
     .map(val => val.replace(/\/\*[^]*?\*\//gm, ''))  // Drop comments
     .map(val => val.split(/\n(?=[^\n]*\s?=\s)/m))    // Separate definitions
     .flat()
+    .filter(text => text.match(/\s?=\s/))
     .map(text => parseProductionRule(text, { pureSyntax: true }));
 
   // Don't keep the info on whether value comes from a pure syntax section


### PR DESCRIPTION
Some CSS specs use `<pre class="prod">`, typically within a `<dd>` to contain the possible values of a production rule. Logic correctly extracts these values and associates them with the previous `<dt>`. However, it also tries to parse these blocks directly and crashes because they do not look like `<foo> = bar`.

One example is `<image>` in css-content:
https://drafts.csswg.org/css-content/#typedef-content-content-replacement

This update prevents the second invalid attempt to parse these block as production rules.