### PR TITLE
Use the first matching event interface name from 'fire an event' phrases

### DIFF
--- a/src/browserlib/extract-events.mjs
+++ b/src/browserlib/extract-events.mjs
@@ -227,6 +227,7 @@ export default function (spec) {
           while ((curEl = curEl.nextElementSibling)) {
             if (curEl.textContent.match(/^([A-Z]+[a-z0-9]*)+Event$/)) {
               iface = curEl.textContent.trim();
+	      break;
             }
           }
           if (iface) {


### PR DESCRIPTION
Otherwise, https://github.com/w3c/webref/commit/348b90a37475563d924f4da8156c290ca27d77e2#diff-3877beb696dd5561959ba0c9b8c1485e9c78fbed53b1ec6723ae68621940e0c7 happens