### PR TITLE
Add 1mn timeout for Respec generation

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -605,7 +605,7 @@ async function processSpecification(spec, processFunction, args, options) {
                 window.document.head.querySelector("script[src*='respec']");
 
             function sleep(ms) {
-                return new Promise(resolve => setTimeout(resolve, ms));
+                return new Promise(resolve => setTimeout(resolve, ms, 'slept'));
             }
 
             async function isReady(counter) {
@@ -614,7 +614,10 @@ async function processSpecification(spec, processFunction, args, options) {
                     throw new Error('Respec generation took too long');
                 }
                 if (window.document.respec?.ready) {
-                    await window.document.respec.ready;
+                    const res = await Promise.race([window.document.respec.ready, sleep(60000)]);
+                    if (res === 'slept') {
+                        throw new Error('Respec generation took too long');
+                    }
                 }
                 else if (usesRespec) {
                     await sleep(1000);


### PR DESCRIPTION
Respec will never be able to generate a spec that has a syntax error in its Respec configuration. In such cases, Respec will never resolve the "ready" promise.

This update adds a 1mn timeout to make sure that the crawler does not get stuck waiting forever.

(Updated prompted by a [config bug in the PNG spec](https://github.com/w3c/PNG-spec/pull/141) that makes the crawler loop forever)