### PR TITLE
Fix exported functions crawlSpecs and getInterfaceTreeInfo

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 module.exports = {
   parseIdl: require("./src/cli/parse-webidl").parse,
   crawlSpecs: require("./src/lib/specs-crawler").crawlSpecs,
-  crawlList: require("./src/lib/specs-crawler").crawlList,
   expandCrawlResult: require("./src/lib/util").expandCrawlResult,
   mergeCrawlResults: require("./src/lib/util").mergeCrawlResults,
   isLatestLevelThatPasses: require("./src/lib/util").isLatestLevelThatPasses,

--- a/src/lib/specs-crawler.js
+++ b/src/lib/specs-crawler.js
@@ -589,5 +589,13 @@ function crawlSpecs(options) {
 /**************************************************
 Export methods for use as module
 **************************************************/
-module.exports.crawlList = crawlList;
-module.exports.crawlSpecs = crawlSpecs;
+// TODO: consider more alignment between the two crawl functions or
+// find more explicit names to distinguish between them:
+// - "crawlList" takes an explicit list of specs as input, does not run the
+// post-processor, and returns the results without saving them to files.
+// - "crawlSpecs" takes options as input, runs all steps and saves results
+// to files (or outputs the results to the console). It does not return
+// anything.
+module.exports.crawlSpecs = (...args) => Array.isArray(args[0]) ?
+    crawlList.apply(this, args) :
+    crawlSpecs.apply(this, args);

--- a/tests/crawl.js
+++ b/tests/crawl.js
@@ -1,4 +1,4 @@
-const { crawlList, crawlSpecs } = require("../src/lib/specs-crawler");
+const { crawlSpecs } = require("../src/lib/specs-crawler");
 const nock = require('../src/lib/nock-server');
 const fs = require("fs");
 const path = require("path");
@@ -13,7 +13,7 @@ const specs = [
 ];
 
 async function crawl() {
-  const results = await crawlList(specs, { forceLocalFetch: true });
+  const results = await crawlSpecs(specs, { forceLocalFetch: true });
   // to avoid reporting bogus diff on updated date
   results.forEach(s => delete s.date);
   return results;
@@ -56,7 +56,7 @@ if (global.describe && describe instanceof Function) {
 
     it("supports 'file' URLs", async () => {
       const fileurl = (new URL('crawl-spec.html', `file://${__dirname}/`)).href;
-      const results = await crawlList([{
+      const results = await crawlSpecs([{
         url: fileurl,
         nightly: { url: fileurl }
       }], { forceLocalFetch: true });
@@ -102,7 +102,7 @@ if (global.describe && describe instanceof Function) {
     it("skips processing and reuse fallback data when spec cache info indicates it has not changed", async () => {
       const url = "https://www.w3.org/TR/ididnotchange/";
       const fallback = path.resolve(__dirname, 'crawl-cache.json');
-      const results = await runWithAnnotatedCrawlData(fallback, async () => crawlList(
+      const results = await runWithAnnotatedCrawlData(fallback, async () => crawlSpecs(
         [{ url, nightly: { url } }],
         {
           forceLocalFetch: true,
@@ -115,7 +115,7 @@ if (global.describe && describe instanceof Function) {
 
     it("reports HTTP error statuses", async () => {
       const url = "https://www.w3.org/TR/idontexist/";
-      const results = await crawlList(
+      const results = await crawlSpecs(
         [{ url, nightly: { url } }],
         { forceLocalFetch: true });
       assert.equal(results[0].title, "[Could not be determined, see error]");
@@ -125,7 +125,7 @@ if (global.describe && describe instanceof Function) {
     it("reports errors and returns fallback data when possible", async () => {
       const url = "https://www.w3.org/TR/idontexist/";
       const fallback = path.resolve(__dirname, 'crawl-fallback.json');
-      const results = await crawlList(
+      const results = await crawlSpecs(
         [{ url, nightly: { url } }],
         {
           forceLocalFetch: true,
@@ -155,7 +155,7 @@ if (global.describe && describe instanceof Function) {
 
     it("reports draft CSS server issues", async () => {
       const url = "https://drafts.csswg.org/server-hiccup/";
-      const results = await crawlList(
+      const results = await crawlSpecs(
         [{ url, nightly: { url } }],
         { forceLocalFetch: true });
       assert.equal(results[0].title, "[Could not be determined, see error]");

--- a/tests/reffy-package.js
+++ b/tests/reffy-package.js
@@ -33,9 +33,9 @@ describe("The npm package of Reffy", function () {
 
   it("can crawl specs", async () => {
     const clidir = path.join(tmpdir, 'node_modules', 'reffy', 'src', 'lib');
-    const { crawlList } = require(path.join(clidir, 'specs-crawler'));
+    const { crawlSpecs } = require(path.join(clidir, 'specs-crawler'));
     const refResults = JSON.parse(fs.readFileSync(__dirname + "/crawl-test.json", "utf-8"));
-    const results = await crawlList(specs, { forceLocalFetch: true });
+    const results = await crawlSpecs(specs, { forceLocalFetch: true });
     for (const result of results) {
       if (result?.ids?.length) {
         result.ids = result.ids.filter(id => !id.match(/\#respec\-/));


### PR DESCRIPTION
The `getTreeInfo` entry point should have been renamed into `getInterfaceTreeInfo`.

The `crawlSpecs` function targeted the `crawlList` crawl function instead of `crawlSpecs`. I'm not clear that was intended and it would be easier for the curation job in webref to directly call `crawlSpecs`. Let's use the major version bump opportunity to fix this. I added a `crawlList` exported function in case someone actually used that entry point.