### PR TITLE
Fix line ending detection in IDL extracts

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -816,7 +816,7 @@ async function expandSpecResult(spec, baseFolder, properties) {
             // Also drop header that may have been added when extract was
             // serialized.
             if (contents.startsWith('// GENERATED CONTENT - DO NOT EDIT')) {
-                const hasWindowsEndings = contents.indexOf('\r\n');
+                const hasWindowsEndings = contents.includes('\r\n\r\n');
                 if (hasWindowsEndings) {
                     const endOfHeader = contents.indexOf('\r\n\r\n');
                     contents = contents.substring(endOfHeader + 4)


### PR DESCRIPTION
The check on Windows line endings always returned true because indexOf returns `-1` when no string is found. Now using `includes`.

This fix also strengthens the check to detect a double newline instead of simple one for the unlikely case where extracts would use a mix of `\n` and `\r\n`.