### PR TITLE
CSS extracts: do not choke on "=" used in prose

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -257,10 +257,22 @@ const extractValueSpaces = doc => {
         // https://drafts.csswg.org/css-easing-2/#typedef-step-easing-function
         const prod = text.split(reSplitRules)
             .find(p => p.trim().startsWith(dfn.textContent.trim()));
-        if (!prod) {
-          throw new Error(`Production rule for ${dfn.textContent.trim()} found has unexpected format`);
+        if (prod) {
+          parseProductionRule(prod, { pureSyntax: true });
         }
-        parseProductionRule(prod, { pureSyntax: true });
+        else {
+          // "=" may appear in another formula in the body of the text, as in:
+          // https://drafts.csswg.org/css-speech-1/#typedef-voice-volume-decibel
+          // It may be worth checking but not an error per se.
+          console.warn('[reffy]', `Found "=" next to definition of ${dfn.textContent.trim()} but no production rule. Did I miss something?`);
+          const name = (dfn.getAttribute('data-lt') ?? dfn.textContent)
+            .trim().replace(/^<?(.*?)>?$/, '<$1>');
+          if (!(name in res)) {
+            res[name] = {
+              prose: parent.textContent.trim().replace(/\s+/g, ' ')
+            };
+          }
+        }
       }
       else if (dfn.textContent.trim().match(/^[a-zA-Z_][a-zA-Z0-9_\-]+\([^\)]+\)$/)) {
         // Definition is "prod(foo bar)", create a "prod() = prod(foo bar)" entry

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -498,6 +498,24 @@ that spans multiple lines */
         value: "'=' | equal"
       }
     }
+  },
+
+  {
+    title: "does not choke on equal signs that are in prose",
+    html: `<div class="prod">
+        <p>The <dfn data-dfn-type="type">&lt;decibel&gt;</dfn> type denotes
+        a dimension with a "dB" (decibel unit) unit identifier. Decibels
+        represent the ratio of the squares of the new signal amplitude
+        <var>a1</var> and the current amplitude <var>a0</var>,
+        as per the following logarithmic equation:
+        volume(dB) = 20 × log10(<var>a1</var> / <var>a0</var>).</p>
+      </div>`,
+    propertyName: "valuespaces",
+    css: {
+      "<decibel>": {
+        prose: "The <decibel> type denotes a dimension with a \"dB\" (decibel unit) unit identifier. Decibels represent the ratio of the squares of the new signal amplitude a1 and the current amplitude a0, as per the following logarithmic equation: volume(dB) = 20 × log10(a1 / a0)."
+      }
+    }
   }
 ];
 


### PR DESCRIPTION
An "=" sign may be used in a separate formula next to a definition without creating a production rule per se. The CSS module used to throw an exception when that happens. It now just reports a warning.