### PR TITLE
Fix event extension logic in post-processing module

### DIFF
--- a/src/postprocessing/events.js
+++ b/src/postprocessing/events.js
@@ -55,11 +55,13 @@ module.exports = {
       .map(event => {
         const err = extendEvent(event, events);
         if (err) {
+          // Event could not be extended, let's keep extension event
           console.warn(err);
-          return event;
+          return null;
         }
         else {
-          return null;
+          // Event successfully extended, extension can be dropped
+          return event;
         }
       })
       .filter(event => !!event);


### PR DESCRIPTION
This fixes https://github.com/w3c/webref/pull/650#issuecomment-1190120491

The code kept the event extensions that it managed to merge with base event definitions and dropped the ones for which it could not find a base event. That should have been the opposite.

