### PR TITLE
Events consolidation: fix cleaning of target interfaces

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -946,9 +946,13 @@ async function createFolderIfNeeded(folder) {
  * the tree.
  */
 const trees = {
-  // DOM tree:
+  // The DOM tree is defined through "get the parent" algorithms:
   // https://dom.spec.whatwg.org/#node-trees
-  'dom': ['Window', 'Document', 'Element', 'Node'],
+  // https://dom.spec.whatwg.org/#get-the-parent
+  // - Node -> Node
+  // - Document -> Window
+  // - ShadowRoot -> Element (both derive from Node, so covered by Node -> Node)
+  'dom': ['Window', 'Document', 'Node'],
 
   // IndexedDB tree (defined through "get the parent" algorithms)
   // https://www.w3.org/TR/IndexedDB/#ref-for-get-the-parent%E2%91%A0


### PR DESCRIPTION
The update fixes the cleaning of target interfaces and implements new rules for the list to actually make some sense:
1. When an interface and one of the interfaces it inherits from both appear in the list with similar bubbling properties, only the base interface is kept (no need to have an event that targets `HTMLElement` if it already targets `Element`).
2. When an event bubbles at an interface, drop parent interfaces in the bubbling tree from the list. Event can de facto fire at the parent interfaces through bubbling.

The logic seems good enough. It is not perfect in that it does not encode some of the nuances that could theoretically impact events bubbling.

For instance, a bubbling event on `Attr` does not bubble anywhere in practice because `Attr` never has a parent.

Similarly, events in UI events are defined against the DOM (and typically fire at `Element`) but in practice the corresponding IDL attributes are rather defined in HTML and these events really only fire at `HTMLElement` in practice in the web platform.