### PR TITLE
Extract CSS at-rules, move descriptors under at-rules

### DIFF
--- a/tests/crawl-test.json
+++ b/tests/crawl-test.json
@@ -19,8 +19,8 @@
     },
     "title": "WOFF2",
     "css": {
+      "atrules": {},
       "properties": {},
-      "descriptors": {},
       "valuespaces": {}
     },
     "dfns": [
@@ -81,8 +81,8 @@
     "title": "No Title",
     "generator": "respec",
     "css": {
+      "atrules": {},
       "properties": {},
-      "descriptors": {},
       "valuespaces": {}
     },
     "dfns": [
@@ -201,8 +201,8 @@
     },
     "title": "[No title found for https://w3c.github.io/accelerometer/]",
     "css": {
+      "atrules": {},
       "properties": {},
-      "descriptors": {},
       "valuespaces": {}
     },
     "dfns": [],

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -267,6 +267,64 @@ const tests = [
     css: {}
   },
 
+  {
+    title: "extracts an at-rule syntax",
+    html: `
+      <pre class="prod">
+        @layer <a class="production">&lt;layer-name&gt;</a>? {
+          <a class="production">&lt;stylesheet&gt;</a>
+        }
+      </pre>
+    `,
+    propertyName: "atrules",
+    css: {
+      "@layer": {
+        "value": "@layer <layer-name>? { <stylesheet> }",
+        "descriptors": []
+      }
+    }
+  },
+
+  {
+    title: "combines an at-rule syntax with descriptor",
+    html: `
+      <pre class="prod">
+        @font-face {
+          &lt;declaration-list&gt;
+        }
+      </pre>
+      <table class="def descdef">
+      <tbody>
+       <tr>
+        <th>Name:
+        </th><td><dfn class="dfn-paneled css" data-dfn-for="@font-face" data-dfn-type="descriptor" data-export="" id="descdef-font-face-font-display">font-display</dfn>
+       </td></tr><tr>
+        <th>For:
+        </th><td><a class="css" data-link-type="at-rule" href="#at-font-face-rule" id="ref-for-at-font-face-rule④⑥">@font-face</a>
+       </td></tr><tr>
+        <th>Value:
+        </th><td class="prod">auto <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one⑥⑨">|</a> block <span id="ref-for-comb-one⑦⓪">|</span> swap <span id="ref-for-comb-one⑦①">|</span> fallback <span id="ref-for-comb-one⑦②">|</span> optional
+       </td></tr><tr>
+        <th>Initial:
+        </th><td>auto
+     </td></tr></tbody></table>
+    `,
+    propertyName: "atrules",
+    css: {
+      "@font-face": {
+        "value": "@font-face { <declaration-list> }",
+        "descriptors": [
+          {
+            for: "@font-face",
+            initial: "auto",
+            name: "font-display",
+            value: "auto | block | swap | fallback | optional"
+          }
+        ]
+      }
+    }
+  },
+
 
   {
     title: "extracts multiple descriptors with the same name",
@@ -301,22 +359,28 @@ const tests = [
       <th>Initial:
       </th><td>auto
    </td></tr></tbody></table>`,
-    propertyName: "descriptors",
+    propertyName: "atrules",
     css: {
-      "font-display": [
-        {
-          for: "@font-face",
-          initial: "auto",
-          name: "font-display",
-          value: "auto | block | swap | fallback | optional"
-        },
-        {
-          for: "@font-feature-values",
-          initial: "auto",
-          name: "font-display",
-          value: "auto | block | swap | fallback | optional"
-        }
-      ]
+      "@font-face": {
+        "descriptors": [
+          {
+            for: "@font-face",
+            initial: "auto",
+            name: "font-display",
+            value: "auto | block | swap | fallback | optional"
+          }
+        ]
+      },
+      "@font-feature-values": {
+        "descriptors": [
+          {
+            for: "@font-feature-values",
+            initial: "auto",
+            name: "font-display",
+            value: "auto | block | swap | fallback | optional"
+          }
+        ]
+      }
     }
   },
 


### PR DESCRIPTION
This creates an `atrules` property in CSS extracts that contains at-rules syntax as suggested in #1028. Descriptors associated with an at-rule (and all selectors are associated with an at-rule in practice) now appear under the at-rule definition.

The new `atrules` property contains a `value` property when a formal syntax could be extracted from the spec, and a `descriptors` array that lists descriptors associated with the at-rule (if any).

**Breaking change:** The former `descriptors` property that appeared at the root level of the extract no longer exists. The same info can be found under the `atrules` property.

This update also adjusts a couple of tests and adds two new tests on at-rules extraction.

The code can only extract the formal syntax of an at-rule if it is defined in a `<pre class="prod">` block. That is the case in most CSS specs, but some of the definitions are done in `<pre>` tags without any class for now (e.g. `@counter-style` and `@scroll-timeline`). The specs need fixing or the extraction logic needs to also parse mere `<pre>` tags (but that seems fragile).

As opposed to the structure proposed in #1028, the list of descriptors is not indexed by the descriptor's name.

For instance, the `@container` at-rule would lead to:

```json
{
  "@container": {
    "value": "@container [ <container-name> ]? <container-condition> { <stylesheet> }",
    "descriptors": [
      {
        "name": "width",
        "for": "@container",
        "value": "<length>",
        "type": "range"
      },
      {
        "name": "height",
        "for": "@container",
        "value": "<length>",
        "type": "range"
      },
      {
        "name": "inline-size",
        "for": "@container",
        "value": "<length>",
        "type": "range"
      },
      {
        "name": "block-size",
        "for": "@container",
        "value": "<length>",
        "type": "range"
      },
      {
        "name": "aspect-ratio",
        "for": "@container",
        "value": "<ratio>",
        "type": "range"
      },
      {
        "name": "orientation",
        "for": "@container",
        "value": "portrait | landscape",
        "type": "discrete"
      }
    ]
  }
}
```

Creating the pull request as draft as I still need to run additional tests to make sure that the code successfully extracts all known at-rules defined in CSS specs (or that the specs need fixing).