### PR TITLE
Events extraction: Reflect new URL of Service Workers spec

### DIFF
--- a/src/browserlib/extract-events.mjs
+++ b/src/browserlib/extract-events.mjs
@@ -154,6 +154,8 @@ export default function (spec) {
           a.href === "https://w3c.github.io/ServiceWorker/#fire-functional-event" ||
           a.href === "https://www.w3.org/TR/service-workers-1/#fire-functional-event-algorithm" ||
           a.href === "https://www.w3.org/TR/service-workers-1/#fire-functional-event" ||
+          a.href === "https://www.w3.org/TR/service-workers/#fire-functional-event-algorithm" ||
+          a.href === "https://www.w3.org/TR/service-workers/#fire-functional-event" ||
         a.href === "https://w3c.github.io/pointerevents/#dfn-fire-a-pointer-event";
   [...document.querySelectorAll("a")]
     .filter(a => !a.closest(informativeSelector) && isFiringLink(a))


### PR DESCRIPTION
ReSpec switched to the new URL of Service Workers (without level). This change adds the new URLs as they are typically now used in specs such as Payment Handler and the Push API to reference the "fire a functional event" concept.

The old "service-workers-1" URLs are probably still used in some specs, so let's keep them for now.