### PR TITLE
Adjust check-missing-dfns script to handle at-rules

### DIFF
--- a/src/cli/check-missing-dfns.js
+++ b/src/cli/check-missing-dfns.js
@@ -75,15 +75,30 @@ function getExpectedDfnsFromCSS(css) {
       })
   );
 
+  // Add the list of expected at-rules
+  expected = expected.concat(
+    Object.entries(css.atrules || {}).map(([name, rule]) => {
+      if (rule.value) {
+        return {
+          linkingText: [name],
+          type: 'at-rule',
+          'for': []
+        };
+      }
+    }).filter(dfn => !!dfn)
+  );
+
   // Add the list of expected descriptors
   expected = expected.concat(
-    Object.values(css.descriptors || {}).flat().map(desc => {
-      return {
-        linkingText: [desc.name],
-        type: 'descriptor',
-        'for': [desc.for]
-      };
-    })
+    Object.entries(css.atrules || {}).map(([name, rule]) =>
+      (rule.descriptors || []).map(desc => {
+        return {
+          linkingText: [desc.name],
+          type: 'descriptor',
+          'for': [name]
+        };
+      })
+    ).flat()
   );
   
   // Add the list of expected "values".


### PR DESCRIPTION
This makes the script look at at-rules and descriptors, following the new structure returned by the crawler in the CSS extracts.

The script only reports a missing definition for an at-rule when the rule has a formal syntax definition in the CSS extract (there are a number of specs that extend an at-rule defined elsewhere and script would return them as missing definitions without that check).

Fixes #1043.