### PR TITLE
Events post-processing: add bubblingPath property

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -990,9 +990,7 @@ function getInterfaceTreeInfo(iface, interfaces) {
   while (iface) {
     for (const [tree, nodes] of Object.entries(trees)) {
       if (nodes.includes(iface)) {
-        // Depth is last occurrence of iface in the array
-        // (but "findLastIndex" is not supported in Node.js)
-        const depth = nodes.length - 1 - nodes.slice().reverse().findIndex(i => i === iface);
+        const depth = nodes.lastIndexOf(iface);
         return {
           tree,
           interface: iface,

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -952,7 +952,7 @@ const trees = {
   // - Node -> Node
   // - Document -> Window
   // - ShadowRoot -> Element (both derive from Node, so covered by Node -> Node)
-  'dom': ['Window', 'Document', 'Node'],
+  'dom': ['Window', 'Document', 'Node', 'Node'],
 
   // IndexedDB tree (defined through "get the parent" algorithms)
   // https://www.w3.org/TR/IndexedDB/#ref-for-get-the-parent%E2%91%A0
@@ -990,10 +990,14 @@ function getInterfaceTreeInfo(iface, interfaces) {
   while (iface) {
     for (const [tree, nodes] of Object.entries(trees)) {
       if (nodes.includes(iface)) {
+        // Depth is last occurrence of iface in the array
+        // (but "findLastIndex" is not supported in Node.js)
+        const depth = nodes.length - 1 - nodes.slice().reverse().findIndex(i => i === iface);
         return {
           tree,
           interface: iface,
-          depth: nodes.findIndex(i => i === iface)
+          depth,
+          bubblingPath: nodes.slice(0, depth).reverse()
         };
       }
     }

--- a/src/postprocessing/events.js
+++ b/src/postprocessing/events.js
@@ -104,7 +104,7 @@ function setBubblingPerTarget(event, parsedInterfaces) {
       updatedTargets.push({target: iface});
       continue;
     }
-    const { tree, depth } = treeInfo;
+    const { tree, depth, bubblingPath } = treeInfo;
     if (!detected[tree]) {
       detected[tree] = {root: false, nonroot: false};
     }
@@ -113,7 +113,7 @@ function setBubblingPerTarget(event, parsedInterfaces) {
       updatedTargets.push({target: iface});
       detected[tree].root = true;
     } else {
-      treeInterfaces.push(iface);
+      treeInterfaces.push({ iface, bubblingPath });
       detected[tree].nonroot = true;
     }
   }
@@ -125,9 +125,11 @@ function setBubblingPerTarget(event, parsedInterfaces) {
       event.bubbles = false;
     }
   }
-  for (let iface of treeInterfaces) {
+  for (let { iface, bubblingPath } of treeInterfaces) {
     if (event.hasOwnProperty('bubbles')) {
-      updatedTargets.push({target: iface, bubbles: event.bubbles});
+      updatedTargets.push(Object.assign(
+        { target: iface, bubbles: event.bubbles },
+        event.bubbles ? { bubblingPath } : {}));
     }
   }
   event.targets = updatedTargets;


### PR DESCRIPTION
This adds a `bubblingPath` property to the description of target interfaces that contains, for bubbling events, the list of interfaces (at the root of the inheritance chain) on which the event may bubble.

For instance, with that change, the definition of `fullscreenchange` becomes:

```json
{
  "type": "fullscreenchange",
  "interface": "Event",
  "targets": [
    {
      "target": "Element",
      "bubbles": true,
      "bubblingPath": [
        "Node",
        "Document",
        "Window"
      ]
    }
  ],
  "src": {
    "format": "dfn",
    "href": "https://fullscreen.spec.whatwg.org/#eventdef-document-fullscreenchange"
  },
  "href": "https://fullscreen.spec.whatwg.org/#eventdef-document-fullscreenchange"
}
```

Actual interfaces on which the event will bubble may well be interfaces that inherit from the interfaces in `bubblingPath`. For instance, `fullscreenchange` will actually bubble on `Element` (and not `Node`), `Document`... and not sure the event actually fires on `ShadowRoot` or `Window` as the spec says that the event handlers are not supported by these interfaces. Anyway, the point is: in the DOM, we don't really know the exact list and can only report the core set of interfaces that are on the bubbling path.

The order of the interfaces in the array is the order of the bubbling path.

This update avoids having to add a separate `bubbling-trees.json` file to the events package, which would be hard to associate with the target interfaces in any case (because one would need to look at the inheritance chain to understand where the target interface fits in the bubbling tree). This is still imperfect because it would be more interesting to have more precise interfaces in there, but that's meant to be a step in the right direction.