### PR TITLE
[headings] Only report ID when it exists (and fix URL in that case)

### DIFF
--- a/src/browserlib/extract-headings.mjs
+++ b/src/browserlib/extract-headings.mjs
@@ -13,6 +13,7 @@ export default function (spec, idToHeading) {
     const headingLevel = headingNumber ? headingNumber.split(".").length : undefined;
     return {
       id: n.parentNode.id,
+      href: getAbsoluteUrl(n.parentNode, { singlePage }),
       title: n.textContent.replace(headingNumber, '').trim(),
       level: headingLevel,
       number: headingNumber

--- a/src/browserlib/get-absolute-url.mjs
+++ b/src/browserlib/get-absolute-url.mjs
@@ -16,6 +16,9 @@ export default function (node, { singlePage, attribute } =
   const page = singlePage ? null :
     node.closest('[data-reffy-page]')?.getAttribute('data-reffy-page');
   const url = new URL(page ?? window.location.href);
-  url.hash = '#' + node.getAttribute(attribute);
+  const hashid = node.getAttribute(attribute);
+  if (hashid) {
+    url.hash = '#' + hashid;
+  }
   return url.toString();
 }

--- a/src/browserlib/map-ids-to-headings.mjs
+++ b/src/browserlib/map-ids-to-headings.mjs
@@ -79,11 +79,13 @@ export default function () {
       const match = trimmedText.match(reNumber);
       const number = match ? match[1] : null;
 
-      mappingTable[nodeid] = {
-        id,
-        href,
-        title: trimmedText.replace(reNumber, '').trim().replace(/\s+/g, ' ')
-      };
+      const mapping = {};
+      if (id) {
+        mapping.id = id;
+      }
+      mapping.href = href;
+      mapping.title = trimmedText.replace(reNumber, '').trim().replace(/\s+/g, ' ');
+      mappingTable[nodeid] = mapping;
 
       if (number) {
         // Store the number without the final "."
@@ -120,11 +122,13 @@ function esMapIdToHeadings() {
       const match = trimmedText.match(reNumber);
       const number = match ? match[1] : null;
 
-      mappingTable[nodeid] = {
-        id: section.id,
-        href,
-        title: trimmedText.replace(reNumber, '').trim().replace(/\s+/g, ' ')
-      };
+      const mapping = {};
+      if (section.id) {
+        mapping.id = section.id;
+      }
+      mapping.href = href;
+      mapping.title = trimmedText.replace(reNumber, '').trim().replace(/\s+/g, ' ');
+      mappingTable[nodeid] = mapping;
 
       if (number) {
         // Store the number without the final "."


### PR DESCRIPTION
Once in a while, especially in multi-page specs, a definition may be defined in near the top of the page following a heading that does not have any ID. The reported ID was an empty string in such cases, and the URL ended with `#null`.

This update drops the ID when it does not exist and the null fragment.