### PR TITLE
[references] Handle case when href attribute starts with whitespaces

### DIFF
--- a/src/browserlib/extract-references.mjs
+++ b/src/browserlib/extract-references.mjs
@@ -101,7 +101,10 @@ function parseReferences(referenceList, options) {
     if (!desc || !ref.name) {
       return;
     }
-    ref.url = desc.querySelector('a[href^="http"]')?.href ?? "";
+    const url = desc.querySelector('a[href*="://"]')?.href;
+    if (url) {
+      ref.url = url;
+    }
     if (options.filterInformative &&
         desc.textContent.match(/non-normative/i)) {
       return informativeRef.push(ref);


### PR DESCRIPTION
The selector rule only selected `href` attribute that started with `http`. There are a couple of occurrences in specs where the URL is prefixed with whitespaces, which is technically correct.

This update rather looks for `://` somewhere in the attribute.

The update also completely removes the `url` property when no URL can be found (instead of reporting an empty string).