### PR TITLE
Add bigint to list of well-known IDL types

### DIFF
--- a/src/cli/parse-webidl.js
+++ b/src/cli/parse-webidl.js
@@ -362,6 +362,7 @@ function parseType(idltype, idlReport, contextName) {
             "short", "unsigned short",
             "long", "unsigned long", "long long", "unsigned long long",
             "float", "unrestricted float", "double", "unrestricted double",
+            "bigint",
             "DOMString", "ByteString", "USVString",
             "object"
     ];


### PR DESCRIPTION
The `bigint` type, used in WebRTC Encoded Transforms was reported as an external dependency in the `idlparsed` extract.