### PR TITLE
Fix spec post-processing when Reffy does not start with a crawl result

### DIFF
--- a/src/lib/post-processor.js
+++ b/src/lib/post-processor.js
@@ -249,6 +249,14 @@ function dependsOn(mod) {
   return mod.dependsOn;
 }
 
+/**
+ * Return the name of the property that will be set in the spec crawl result
+ * when the post-processing module runs, if any
+ */
+function getProperty(mod) {
+  mod = getModule(mod);
+  return mod.property ?? mod.name;
+}
 
 function appliesAtLevel(mod, level) {
   mod = getModule(mod);
@@ -266,5 +274,6 @@ module.exports = {
   run, save,
   extractsPerSeries,
   dependsOn,
+  getProperty,
   appliesAtLevel
 };

--- a/src/lib/specs-crawler.js
+++ b/src/lib/specs-crawler.js
@@ -130,7 +130,7 @@ async function crawlSpec(spec, crawlOptions) {
             }
         });
         crawlOptions.post?.forEach(mod => {
-            const prop = mod.property ?? mod.name;
+            const prop = postProcessor.getProperty(mod);
             if (postProcessor.appliesAtLevel(mod, 'spec') && result[prop]) {
                 spec[prop] = result[prop];
             }


### PR DESCRIPTION
The crawler assumed that it had access to the object describing post-processing modules, whereas it only receives post-processing module names. This prevented it from copying the results of some post-processing modules (`idlparsed` in practice). Everything still worked when post-processing was run from a crawl result, so this bug does not affect webref's use of Reffy in practice.