### PR TITLE
Add JSON schemas for extracts export validation function

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,6 @@ module.exports = {
   mergeCrawlResults: require("./src/lib/util").mergeCrawlResults,
   isLatestLevelThatPasses: require("./src/lib/util").isLatestLevelThatPasses,
   getInterfaceTreeInfo: require("./src/lib/util").getInterfaceTreeInfo,
+  getSchemaValidationFunction: require("./src/lib/util").getSchemaValidationFunction,
   postProcessor: require("./src/lib/post-processor")
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "reffy",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "reffy",
-      "version": "10.0.3",
+      "version": "10.0.4",
       "license": "MIT",
       "dependencies": {
         "abortcontroller-polyfill": "1.7.3",
+        "ajv": "8.11.0",
+        "ajv-formats": "2.1.1",
         "commander": "9.4.0",
         "fetch-filecache-for-crawling": "4.1.0",
         "puppeteer": "18.0.5",
@@ -67,6 +69,37 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-colors": {
@@ -547,6 +580,11 @@
         "@types/yauzl": "^2.9.1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -919,6 +957,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -1235,6 +1278,25 @@
         }
       }
     },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1355,6 +1417,14 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/puppeteer": {
       "version": "18.0.5",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.0.5.tgz",
@@ -1425,6 +1495,14 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1760,11 +1838,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
     "node_modules/trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -1803,6 +1876,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1813,24 +1894,10 @@
       "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-2.25.0.tgz",
       "integrity": "sha512-EXbBkkkjoTQwF1QKKP3euhMOlj0diJdeqEJGAfW/BPA3+1gUyOfkhaY10uxS3rrimSTktcoQ7/r+/4rZ1lDqWQ=="
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
     "node_modules/webidl2": {
       "version": "24.2.2",
       "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-24.2.2.tgz",
       "integrity": "sha512-4l1lBuUqfNBZDzQfG0dpM2haInTZ+IRnXwbWn9Oc49boPTlXQS8Hpg4GK4kE7M+504ZUKCwzBxtQR/0wPVokUw=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/workerpool": {
       "version": "6.2.1",
@@ -2000,6 +2067,25 @@
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "requires": {
         "debug": "4"
+      }
+    },
+    "ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "requires": {
+        "ajv": "^8.0.0"
       }
     },
     "ansi-colors": {
@@ -2341,6 +2427,11 @@
         "yauzl": "^2.10.0"
       }
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -2607,6 +2698,11 @@
         "argparse": "^2.0.1"
       }
     },
+    "json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -2827,6 +2923,27 @@
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "normalize-path": {
@@ -2916,6 +3033,11 @@
         "once": "^1.3.1"
       }
     },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
     "puppeteer": {
       "version": "18.0.5",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.0.5.tgz",
@@ -2973,6 +3095,11 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "respec": {
       "version": "32.2.4",
@@ -3221,11 +3348,6 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
     "trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -3255,6 +3377,14 @@
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -3265,24 +3395,10 @@
       "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-2.25.0.tgz",
       "integrity": "sha512-EXbBkkkjoTQwF1QKKP3euhMOlj0diJdeqEJGAfW/BPA3+1gUyOfkhaY10uxS3rrimSTktcoQ7/r+/4rZ1lDqWQ=="
     },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
     "webidl2": {
       "version": "24.2.2",
       "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-24.2.2.tgz",
       "integrity": "sha512-4l1lBuUqfNBZDzQfG0dpM2haInTZ+IRnXwbWn9Oc49boPTlXQS8Hpg4GK4kE7M+504ZUKCwzBxtQR/0wPVokUw=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "workerpool": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "files": [
     "index.js",
     "reffy.js",
-    "src/"
+    "src/",
+    "schemas/"
   ],
   "bugs": {
     "url": "https://github.com/w3c/reffy/issues"
@@ -32,6 +33,8 @@
   "bin": "./reffy.js",
   "dependencies": {
     "abortcontroller-polyfill": "1.7.3",
+    "ajv": "8.11.0",
+    "ajv-formats": "2.1.1",
     "commander": "9.4.0",
     "fetch-filecache-for-crawling": "4.1.0",
     "puppeteer": "18.0.5",

--- a/schemas/browserlib/extract-cssdfn.json
+++ b/schemas/browserlib/extract-cssdfn.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/browserlib/extract-cssdfn.json",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["properties", "atrules", "valuespaces"],
+  "properties": {
+    "properties": {
+      "type": "object",
+      "propertyNames": { "$ref": "../common.json#/$defs/cssPropertyName" },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": { "$ref": "../common.json#/$defs/cssPropertyName" },
+          "value": { "$ref": "../common.json#/$defs/cssValue" },
+          "styleDeclaration": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1
+          }
+        }
+      }
+    },
+
+    "atrules": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^@"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "value": { "$ref": "../common.json#/$defs/cssValue" },
+          "descriptors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "name": { "type": "string" },
+                "for": { "type": "string" },
+                "value": { "$ref": "../common.json#/$defs/cssValue" }
+              }
+            }
+          }
+        }
+      }
+    },
+
+    "valuespaces": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^<[^>]+>$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "prose": { "type": "string" },
+          "value": { "$ref": "../common.json#/$defs/cssValue" },
+          "legacyValue": { "$ref": "../common.json#/$defs/cssValue" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/browserlib/extract-dfns.json
+++ b/schemas/browserlib/extract-dfns.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/browserlib/extract-dfns.json",
+
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["id", "href", "linkingText", "localLinkingText",
+      "type", "for", "access", "informative", "heading", "definedIn"],
+    "properties": {
+      "id": { "$ref": "../common.json#/$defs/id" },
+      "href": { "$ref": "../common.json#/$defs/url" },
+      "linkingText": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "localLinkingText": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "type": { "type": "string" },
+      "for": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "access": {
+        "type": "string",
+        "enum": ["private", "public"]
+      },
+      "informative": {
+        "type": "boolean"
+      },
+      "heading": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["href", "title"],
+        "properties": {
+          "id": { "$ref": "../common.json#/$defs/id" },
+          "href": { "$ref": "../common.json#/$defs/url" },
+          "title": { "type": "string" },
+          "number": { "$ref": "../common.json#/$defs/headingNumber" }
+        }
+      },
+      "definedIn": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/browserlib/extract-dfns.json
+++ b/schemas/browserlib/extract-dfns.json
@@ -19,7 +19,26 @@
         "type": "array",
         "items": { "type": "string" }
       },
-      "type": { "type": "string" },
+      "type": {
+        "type": "string",
+        "enum": [
+          "property", "descriptor", "value", "type",
+          "at-rule", "function", "selector",
+
+          "namespace", "interface", "constructor", "method", "argument",
+          "attribute", "callback", "dictionary", "dict-member", "enum",
+          "enum-value", "exception", "const", "typedef", "stringifier",
+          "serializer", "iterator", "maplike", "setlike", "extended-attribute",
+          "event", "permission",
+
+          "element", "element-state", "element-attr", "attr-value",
+
+          "scheme", "http-header",
+
+          "grammar", "abstract-op", "dfn"
+        ],
+        "$comment": "Types taken from src/browserlib/extract-dfns.mjs"
+      },
       "for": {
         "type": "array",
         "items": { "type": "string" }

--- a/schemas/browserlib/extract-elements.json
+++ b/schemas/browserlib/extract-elements.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/browserlib/extract-elements.json",
+
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["name"],
+    "properties": {
+      "name": { "type": "string" },
+      "interface": { "$ref": "../common.json#/$defs/interface" },
+      "obsolete": { "type": "boolean" }
+    }
+  }
+}

--- a/schemas/browserlib/extract-events.json
+++ b/schemas/browserlib/extract-events.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/browserlib/extract-events.json",
+
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["type"],
+    "properties": {
+      "type": { "type": "string" },
+      "interface": { "$ref": "../common.json#/$defs/interface" },
+      "targets": {
+        "type": "array",
+        "items": { "$ref": "../common.json#/$defs/interface" }
+      },
+      "bubbles": { "type": "boolean" },
+      "isExtension": { "type": "boolean" },
+      "href": { "$ref": "../common.json#/$defs/url" },
+      "src": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "format": { "type": "string" },
+          "href": { "$ref": "../common.json#/$defs/url" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/browserlib/extract-headings.json
+++ b/schemas/browserlib/extract-headings.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/browserlib/extract-headings.json",
+
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["id", "href", "title", "level"],
+    "properties": {
+      "id": { "$ref": "../common.json#/$defs/id" },
+      "href": { "$ref": "../common.json#/$defs/url" },
+      "title": { "type": "string" },
+      "level": { "type": "integer" },
+      "number": { "$ref": "../common.json#/$defs/headingNumber" }
+    }
+  }
+}

--- a/schemas/browserlib/extract-ids.json
+++ b/schemas/browserlib/extract-ids.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/browserlib/extract-ids.json",
+
+  "type": "array",
+  "items": { "$ref": "../common.json#/$defs/url" }
+}

--- a/schemas/browserlib/extract-links.json
+++ b/schemas/browserlib/extract-links.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/browserlib/extract-links.json",
+
+  "type": "object",
+  "propertyNames": { "$ref": "../common.json#/$defs/url" },
+  "additionalProperties": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "anchors": {
+        "type": "array",
+        "items": { "$ref": "../common.json#/$defs/id" },
+        "minItems": 1
+      },
+      "specShortname": { "$ref": "../common.json#/$defs/shortname" }
+    }
+  }
+}

--- a/schemas/browserlib/extract-refs.json
+++ b/schemas/browserlib/extract-refs.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/browserlib/extract-refs.json",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["normative", "informative"],
+  "properties": {
+    "normative": { "$ref": "../common.json#/$defs/references" },
+    "informative": { "$ref": "../common.json#/$defs/references" }
+  }
+}

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/common.json",
+
+  "$defs": {
+    "url": {
+      "type": "string",
+      "format": "url"
+    },
+
+    "nullableurl": {
+      "oneOf": [
+        { "$ref": "#/$defs/url" },
+        { "type": "null" }
+      ],
+      "$comment": "Extracts sometimes use null values for URLs, they should probably rather drop the property"
+    },
+
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+
+    "shortname": {
+      "type": "string",
+      "pattern": "^[\\w\\-]+((?<=-\\d+)\\.\\d+)?$",
+      "$comment": "Same definition as in browser-specs"
+    },
+
+    "specInExtract": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": { "$ref": "#/$defs/title" },
+        "url": { "$ref": "#/$defs/url" }
+      },
+      "required": ["title", "url"]
+    },
+
+    "cssPropertyName": {
+      "type": "string",
+      "minLength": 1
+    },
+
+    "cssValue": {
+      "type": "string",
+      "minLength": 1
+    },
+
+    "interface": {
+      "type": "string",
+      "pattern": "^[A-Z]([A-Za-z0-9_])*|console$",
+      "$comment": "console is the only interface name that starts with a lower-case character"
+    },
+
+    "global": {
+      "oneOf": [
+        { "$ref": "#/$defs/interface" },
+        { "type": "string", "const": "*" }
+      ]
+    },
+
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+
+    "headingNumber": {
+      "type": "string",
+      "pattern": "^(\\d+|[A-Z])(\\.\\d+)*$",
+      "$comment": "Note appendices start with an upper-case A-Z character"
+    },
+
+    "interfaces": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/interface" }
+    },
+
+    "interfacesByGlobal": {
+      "type": "object",
+      "propertyNames": { "$ref": "#/$defs/global" },
+      "additionalProperties": { "$ref": "#/$defs/interfaces" }
+    },
+
+    "idlFragmentInSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["spec", "fragment"],
+      "properties": {
+        "spec": { "$ref": "#/$defs/specInExtract" },
+        "fragment": { "type": "string" },
+        "href": { "$ref": "#/$defs/url" }
+      }
+    },
+
+    "references": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "url": { "$ref": "#/$defs/url" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -8,14 +8,6 @@
       "format": "url"
     },
 
-    "nullableurl": {
-      "oneOf": [
-        { "$ref": "#/$defs/url" },
-        { "type": "null" }
-      ],
-      "$comment": "Extracts sometimes use null values for URLs, they should probably rather drop the property"
-    },
-
     "title": {
       "type": "string",
       "minLength": 1
@@ -49,8 +41,22 @@
 
     "interface": {
       "type": "string",
-      "pattern": "^[A-Z]([A-Za-z0-9_])*|console$",
+      "pattern": "^[A-Z]([A-Za-z0-9_])*$|^console$",
       "$comment": "console is the only interface name that starts with a lower-case character"
+    },
+
+    "interfacetype": {
+      "type": "string",
+      "enum": [
+        "dictionary", "interface", "interface mixin", "enum", "typedef",
+        "callback", "callback interface", "namespace"]
+    },
+
+    "extensiontype": {
+      "oneOf": [
+        { "$ref": "#/$defs/interfacetype" },
+        { "type": "string", "const": "includes" }
+      ]
     },
 
     "global": {

--- a/schemas/files/extracts/css.json
+++ b/schemas/files/extracts/css.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/files/extracts/css.json",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["spec", "properties", "atrules", "valuespaces"],
+  "properties": {
+    "spec": { "$ref": "../../common.json#/$defs/specInExtract" },
+    "properties": { "$ref": "../../browserlib/extract-cssdfn.json#/properties/properties" },
+    "atrules": { "$ref": "../../browserlib/extract-cssdfn.json#/properties/atrules" },
+    "valuespaces": { "$ref": "../../browserlib/extract-cssdfn.json#/properties/valuespaces" }
+  }
+}

--- a/schemas/files/extracts/dfns.json
+++ b/schemas/files/extracts/dfns.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/files/extracts/dfns.json",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["spec", "dfns"],
+  "properties": {
+    "spec": { "$ref": "../../common.json#/$defs/specInExtract" },
+    "dfns": { "$ref": "../../browserlib/extract-dfns.json" }
+  }
+}

--- a/schemas/files/extracts/elements.json
+++ b/schemas/files/extracts/elements.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/files/extracts/elements.json",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["spec", "elements"],
+  "properties": {
+    "spec": { "$ref": "../../common.json#/$defs/specInExtract" },
+    "elements": { "$ref": "../../browserlib/extract-elements.json" }
+  }
+}

--- a/schemas/files/extracts/events.json
+++ b/schemas/files/extracts/events.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/files/extracts/events.json",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["spec", "events"],
+  "properties": {
+    "spec": { "$ref": "../../common.json#/$defs/specInExtract" },
+    "events": { "$ref": "../../browserlib/extract-events.json" }
+  }
+}

--- a/schemas/files/extracts/headings.json
+++ b/schemas/files/extracts/headings.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/files/extracts/headings.json",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["spec", "headings"],
+  "properties": {
+    "spec": { "$ref": "../../common.json#/$defs/specInExtract" },
+    "headings": { "$ref": "../../browserlib/extract-headings.json" }
+  }
+}

--- a/schemas/files/extracts/ids.json
+++ b/schemas/files/extracts/ids.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/files/extracts/ids.json",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["spec", "ids"],
+  "properties": {
+    "spec": { "$ref": "../../common.json#/$defs/specInExtract" },
+    "ids": { "$ref": "../../browserlib/extract-ids.json" }
+  }
+}

--- a/schemas/files/extracts/links.json
+++ b/schemas/files/extracts/links.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/files/extracts/links.json",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["spec", "links"],
+  "properties": {
+    "spec": { "$ref": "../../common.json#/$defs/specInExtract" },
+    "links": { "$ref": "../../browserlib/extract-links.json" }
+  }
+}

--- a/schemas/files/extracts/refs.json
+++ b/schemas/files/extracts/refs.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/files/extracts/refs.json",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["spec", "refs"],
+  "properties": {
+    "spec": { "$ref": "../../common.json#/$defs/specInExtract" },
+    "refs": { "$ref": "../../browserlib/extract-refs.json" }
+  }
+}

--- a/schemas/files/index.json
+++ b/schemas/files/index.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/files/index.json",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["type", "title", "date", "stats", "crawler", "results"],
+  "properties": {
+    "type": { "type": "string", "const": "crawl" },
+    "title": { "type": "string" },
+    "date": {
+      "type": "string",
+      "pattern": "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"
+    },
+    "crawler": { "type": "string" },
+
+    "options": { "type": "object" },
+
+    "stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["crawled", "errors"],
+      "properties": {
+        "crawled": {
+          "type": "integer"
+        },
+        "errors": {
+          "type": "integer"
+        }
+      }
+    },
+
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/schemas/postprocessing/events.json
+++ b/schemas/postprocessing/events.json
@@ -19,10 +19,7 @@
           "properties": {
             "target": { "$ref": "../common.json#/$defs/interface" },
             "bubbles": { "type": "boolean" },
-            "bubblingPath": {
-              "type": "array",
-              "items": { "$ref": "../common.json#/$defs/interface" }
-            }
+            "bubblingPath": { "$ref": "../common.json#/$defs/interfaces" }
           }
         }
       },

--- a/schemas/postprocessing/events.json
+++ b/schemas/postprocessing/events.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/postprocessing/events.json",
+
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["type", "interface", "targets"],
+    "properties": {
+      "type": { "type": "string" },
+      "interface": { "$ref": "../common.json#/$defs/interface" },
+      "targets": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["target"],
+          "properties": {
+            "target": { "$ref": "../common.json#/$defs/interface" },
+            "bubbles": { "type": "boolean" },
+            "bubblingPath": {
+              "type": "array",
+              "items": { "$ref": "../common.json#/$defs/interface" }
+            }
+          }
+        }
+      },
+      "href": { "$ref": "../common.json#/$defs/url" },
+      "src": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "format": { "type": "string" },
+          "href": { "$ref": "../common.json#/$defs/url" }
+        }
+      },
+      "extendedIn": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["spec"],
+          "properties": {
+            "spec": { "$ref": "../common.json#/$defs/shortname" },
+            "href": { "$ref": "../common.json#/$defs/url" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/postprocessing/idlnames-parsed.json
+++ b/schemas/postprocessing/idlnames-parsed.json
@@ -7,11 +7,7 @@
   "required": ["name", "type", "defined", "extended", "includes"],
   "properties": {
     "name": { "$ref": "../common.json#/$defs/interface" },
-    "type": {
-      "type": "string",
-      "enum": ["dictionary", "interface", "interface mixin", "enum", "typedef",
-        "callback", "callback interface", "namespace"]
-    },
+    "type": { "$ref": "../common.json#/$defs/interfacetype" },
     "defined": { "$ref": "../common.json#/$defs/idlFragmentInSpec" },
     "extended": {
       "type": "array",

--- a/schemas/postprocessing/idlnames-parsed.json
+++ b/schemas/postprocessing/idlnames-parsed.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/postprocessing/idlnames-parsed.json",
+  
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name", "type", "defined", "extended", "includes"],
+  "properties": {
+    "name": { "$ref": "../common.json#/$defs/interface" },
+    "type": {
+      "type": "string",
+      "enum": ["dictionary", "interface", "interface mixin", "enum", "typedef",
+        "callback", "callback interface", "namespace"]
+    },
+    "defined": { "$ref": "../common.json#/$defs/idlFragmentInSpec" },
+    "extended": {
+      "type": "array",
+      "items": { "$ref": "../common.json#/$defs/idlFragmentInSpec" }
+    },
+    "inheritance": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#" }
+      ]
+    },
+    "includes": {
+      "type": "array",
+      "items": { "$ref": "#" }
+    }
+  }
+}

--- a/schemas/postprocessing/idlnames.json
+++ b/schemas/postprocessing/idlnames.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/postprocessing/idlnames.json",
+
+  "type": "object",
+  "propertyNames": { "$ref": "../common.json#/$defs/interface" },
+  "additionalProperties": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["fragment", "parsed"],
+    "properties": {
+      "fragment": { "type": "string" },
+      "parsed": { "type": "string" }
+    }
+  }
+}

--- a/schemas/postprocessing/idlparsed.json
+++ b/schemas/postprocessing/idlparsed.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/postprocessing/idlparsed.json",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["spec", "idlparsed"],
+  "properties": {
+    "spec": { "$ref": "../common.json#/$defs/specInExtract" },
+
+    "idlparsed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["jsNames", "idlNames", "idlExtendedNames", "globals",
+        "exposed", "dependencies", "externalDependencies", "hasObsoleteIdl"],
+      "properties": {
+        "jsNames": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["constructors", "functions"],
+          "properties": {
+            "constructors": { "$ref": "../common.json#/$defs/interfacesByGlobal" },
+            "functions": { "$ref": "../common.json#/$defs/interfacesByGlobal" }
+          }
+        },
+        "idlNames": {
+          "type": "object",
+          "propertyNames": { "$ref": "../common.json#/$defs/interface" },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["fragment", "type"],
+            "properties": {
+              "fragment": { "type": "string" },
+              "type": { "type": "string" }
+            }
+          }
+        },
+        "idlExtendedNames": {
+          "type": "object",
+          "propertyNames": { "$ref": "../common.json#/$defs/interface" },
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": ["fragment", "type"],
+              "properties": {
+                "fragment": { "type": "string" },
+                "type": { "type": "string" }
+              }
+            }
+          }
+        },
+        "globals": { "$ref": "../common.json#/$defs/interfacesByGlobal" },
+        "exposed": { "$ref": "../common.json#/$defs/interfacesByGlobal" },
+        "dependencies": {
+          "type": "object",
+          "propertyNames": { "$ref": "../common.json#/$defs/interface" },
+          "additionalProperties": { "$ref": "../common.json#/$defs/interfaces" }
+        },
+        "externalDependencies": { "$ref": "../common.json#/$defs/interfaces" },
+        "hasObsoleteIdl": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/schemas/postprocessing/idlparsed.json
+++ b/schemas/postprocessing/idlparsed.json
@@ -32,7 +32,7 @@
             "required": ["fragment", "type"],
             "properties": {
               "fragment": { "type": "string" },
-              "type": { "type": "string" }
+              "type": { "$ref": "../common.json#/$defs/interfacetype" }
             }
           }
         },
@@ -47,7 +47,7 @@
               "required": ["fragment", "type"],
               "properties": {
                 "fragment": { "type": "string" },
-                "type": { "type": "string" }
+                "type": { "$ref": "../common.json#/$defs/extensiontype" }
               }
             }
           }

--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -175,8 +175,12 @@ function definitionMapper(el, idToHeading) {
     // Whether the term is defined in a normative/informative section
     informative: !!el.closest(informativeSelector),
 
-    // Heading under which the term is to be found
-    heading: idToHeading[href],
+    // Heading under which the term is to be found,
+    // Defaults to the page or document URL and the spec's title
+    heading: idToHeading[href] ?? {
+      href: (new URL(page ?? window.location.href)).toString(),
+      title: document.title
+    },
 
     // Enclosing element under which the definition appears. Value can be one of
     // "dt", "pre", "table", "heading", "note", "example", or "prose" (last one

--- a/src/browserlib/extract-events.mjs
+++ b/src/browserlib/extract-events.mjs
@@ -356,5 +356,21 @@ export default function (spec) {
       }
     }
   });
-  return events.map(e => e.href && !e.href.startsWith(window.location.toString()) ? Object.assign(e, {isExtension: true}) : e) ;
+  return events
+    .map(e => {
+      // Drop null properties (mandated by the schema for event extracts)
+      if (e.hasOwnProperty('interface') && !e.interface) {
+        delete e.interface;
+      }
+      if (e.hasOwnProperty('href') && !e.href) {
+        delete e.href;
+      }
+      if (e.src && e.src.hasOwnProperty('href') && !e.src.href) {
+        delete e.src.href;
+      }
+      return e;
+    })
+    .map(e => e.href && !e.href.startsWith(window.location.toString()) ?
+      Object.assign(e, {isExtension: true}) :
+      e) ;
 }

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1026,14 +1026,31 @@ function getInterfaceTreeInfo(iface, interfaces) {
  *   if the requested schema does not exist.
  */
 function getSchemaValidationFunction(schemaName) {
+    // Helper function that selects the right schema file from the given
+    // schema name.
+    function getSchemaFileFromSchemaName(name) {
+        switch (name) {
+            case 'index.json':
+                return path.join('files', name);
+            case 'idlnamesparsed':
+                return path.join('postprocessing', 'idlnames-parsed.json');
+            case 'idlparsed':
+                return path.join('postprocessing', 'idlparsed.json');
+            default:
+                if (name.startsWith('extract-')) {
+                    return path.join('browserlib', `${name}.json`);
+                }
+                else if (name.endsWith('.json')) {
+                    return path.join('postprocessing', name);
+                }
+                else {
+                    return path.join('files', 'extracts', `${name}.json`)
+                }
+        }
+    }
+
     const schemasFolder = path.join(__dirname, '..', '..', 'schemas');
-    const schemaFile =
-        (schemaName === 'index.json') ? path.join('files', schemaName) :
-        (schemaName === 'idlnamesparsed') ? path.join('postprocessing', 'idlnames-parsed.json') :
-        (schemaName === 'idlparsed') ? path.join('postprocessing', 'idlparsed.json') :
-        schemaName.startsWith('extract-') ? path.join('browserlib', `${schemaName}.json`) :
-        schemaName.endsWith('.json') ? path.join('postprocessing', schemaName) :
-        path.join('files', 'extracts', `${schemaName}.json`);
+    const schemaFile = getSchemaFileFromSchemaName(schemaName);
     let schema;
     try {
         schema = require(path.join(schemasFolder, schemaFile));

--- a/src/postprocessing/events.js
+++ b/src/postprocessing/events.js
@@ -74,6 +74,8 @@ module.exports = {
       })
       .sort((event1, event2) =>
         event1.type.localeCompare(event2.type, 'en-US') ||
+        (!event2.interface ? -1 : 0) ||
+        (!event1.interface ? 1 : 0) ||
         event1.interface.localeCompare(event2.interface, 'en-US') ||
         (!event2.href ? -1 : 0) ||
         (!event1.href ? 1 : 0) ||
@@ -217,5 +219,7 @@ function extendEvent(event, events) {
   if (!extendedEvent.extendedIn) {
     extendedEvent.extendedIn = [];
   }
-  extendedEvent.extendedIn.push({ spec: event.spec.series.shortname, href: event.src?.href });
+  extendedEvent.extendedIn.push(Object.assign(
+    { spec: event.spec.series.shortname },
+    event.src?.href ? { href: event.src?.href } : {}));
 }

--- a/tests/crawl-test.json
+++ b/tests/crawl-test.json
@@ -37,6 +37,10 @@
         "for": [],
         "access": "private",
         "informative": false,
+        "heading": {
+          "href": "https://w3c.github.io/woff/woff2/",
+          "title": "WOFF2"
+        },
         "definedIn": "prose"
       }
     ],

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const puppeteer = require('puppeteer');
 const path = require('path');
 const rollup = require('rollup');
+const { getSchemaValidationFunction } = require('../src/lib/util');
 
 const tests = [
   {title: "parses a regular propdef table",
@@ -588,6 +589,8 @@ describe("Test CSS properties extraction", function() {
   this.timeout(10000);
   let browser;
   let extractCSSCode;
+  const validateSchema = getSchemaValidationFunction('extract-cssdfn');
+
   before(async () => {
     // Convert the JS module to a JS script that can be loaded in Puppeteer
     // without having to provide a URL for it (tests run in "about:blank" pages)
@@ -624,6 +627,8 @@ describe("Test CSS properties extraction", function() {
       }
       else {
         assert.deepEqual(extractedCss[t.propertyName ?? 'properties'], t.css);
+        const errors = validateSchema(extractedCss);
+        assert.strictEqual(errors, null, JSON.stringify(errors, null, 2));
       }
     });
   });

--- a/tests/extract-elements.js
+++ b/tests/extract-elements.js
@@ -2,7 +2,7 @@ const { assert } = require('chai');
 const puppeteer = require('puppeteer');
 const path = require('path');
 const rollup = require('rollup');
-
+const { getSchemaValidationFunction } = require('../src/lib/util');
 
 const tests = [
   {
@@ -165,6 +165,7 @@ describe("Markup element extraction", function () {
 
   let browser;
   let extractElementsCode;
+  const validateSchema = getSchemaValidationFunction('extract-elements');
 
   before(async () => {
     const bundle = await rollup.rollup({
@@ -191,6 +192,9 @@ describe("Markup element extraction", function () {
       });
       await page.close();
       assert.deepEqual(extractedElements, t.res);
+
+      const errors = validateSchema(extractedElements);
+      assert.strictEqual(errors, null, JSON.stringify(errors, null, 2));
     });
   });
 

--- a/tests/extract-events.js
+++ b/tests/extract-events.js
@@ -2,6 +2,7 @@ const { assert } = require('chai');
 const puppeteer = require('puppeteer');
 const path = require('path');
 const rollup = require('rollup');
+const { getSchemaValidationFunction } = require('../src/lib/util');
 
 const defaultResults = (format, {successIface} = {successIface: "SuccessEvent"}) =>  [
   {
@@ -107,7 +108,6 @@ ${defaultIdl}`,
     res: [
       {
 	type: "success",
-	interface: null,
 	targets: ["Example"],
 	src: { format: "dfn", href:"about:blank#success"},
 	href:"about:blank#success"
@@ -164,6 +164,7 @@ describe("Events extraction", function () {
   this.slow(5000);
   let browser;
   let extractEventsCode;
+  const validateSchema = getSchemaValidationFunction('extract-events');
 
   before(async () => {
     const bundle = await rollup.rollup({
@@ -191,6 +192,9 @@ describe("Events extraction", function () {
       });
       await page.close();
       assert.deepEqual(extractedEvents, t.res);
+
+      const errors = validateSchema(extractedEvents);
+      assert.strictEqual(errors, null, JSON.stringify(errors, null, 2));
     });
   });
 

--- a/tests/extract-headings.js
+++ b/tests/extract-headings.js
@@ -2,6 +2,7 @@ const { assert } = require('chai');
 const puppeteer = require('puppeteer');
 const path = require('path');
 const rollup = require('rollup');
+const { getSchemaValidationFunction } = require('../src/lib/util');
 
 const testHeadings = [
   {
@@ -27,6 +28,7 @@ describe("Test headings extraction", function () {
   let browser;
   let extractDefinitionsCode;
   let mapIdsToHeadingsCode;
+  const validateSchema = getSchemaValidationFunction('extract-headings');
 
   before(async () => {
     const extractHeadingsBundle = await rollup.rollup({
@@ -63,6 +65,9 @@ describe("Test headings extraction", function () {
       });
       await page.close();
       assert.deepEqual(extractedHeadings, t.res);
+
+      const errors = validateSchema(extractedHeadings);
+      assert.strictEqual(errors, null, JSON.stringify(errors, null, 2));
     });
   });
 

--- a/tests/extract-ids.js
+++ b/tests/extract-ids.js
@@ -2,6 +2,7 @@ const { assert } = require('chai');
 const puppeteer = require('puppeteer');
 const path = require('path');
 const rollup = require('rollup');
+const { getSchemaValidationFunction } = require('../src/lib/util');
 
 const testIds = [
   {
@@ -56,6 +57,7 @@ describe("IDs extraction", function () {
 
   let browser;
   let extractIdsCode;
+  const validateSchema = getSchemaValidationFunction('extract-ids');
 
   before(async () => {
     const extractIdsBundle = await rollup.rollup({
@@ -79,6 +81,9 @@ describe("IDs extraction", function () {
       const extractedIds = await page.evaluate(async () => extractIds());
       await page.close();
       assert.deepEqual(extractedIds, t.res);
+
+      const errors = validateSchema(extractedIds);
+      assert.strictEqual(errors, null, JSON.stringify(errors, null, 2));
     });
   });
 


### PR DESCRIPTION
This creates JSON schemas for all extracts and files generated by Reffy. A new `getSchemaValidationFunction` function is now exported by Reffy to validate data against the schemas. It is typically intended for use in Webref to validate curated data before publication.

Some minor adjustments made along the way to make data more consistent and keep schemas relatively simple:
- The dfns extractor now always returns a `heading` property, defaulting to the top of the page
- The events extractor now gets rid of null properties altogether
- The events post-processor no longer outputs null href.

Existing tests on extractors were updated to also check the schema of the extracted data. More tests could be added to check post-processors, and the crawler as a whole.

Note this update also includes a minor bug fix in the sorting code of the events post-processor so that it may run on not-yet-curated events extracts.

This is based on (and intends to replace the current form of) https://github.com/w3c/webref/pull/731