### PR TITLE
Fix --terse option

### DIFF
--- a/src/lib/specs-crawler.js
+++ b/src/lib/specs-crawler.js
@@ -525,12 +525,13 @@ function crawlSpecs(options) {
                 type: 'crawl',
                 title: 'Reffy crawl',
                 date: (new Date()).toJSON(),
-                options,
+                options: Object.assign({}, options, {
+                    modules: options.modules.map(mod => mod.property)
+                }),
                 stats: {},
                 crawler: `reffy-${reffyVersion}`,
                 results
             };
-            index.options.modules = options.modules.map(mod => mod.property);
             index.stats = {
                 crawled: results.length,
                 errors: results.filter(spec => !!spec.error).length
@@ -542,9 +543,6 @@ function crawlSpecs(options) {
                 const property = options.modules[0].property;
                 results = results.map(result => {
                     let res = result[property];
-                    if (property === 'idl') {
-                        res = res?.idl;
-                    }
                     return res;
                 });
                 if (results.length === 1) {


### PR DESCRIPTION
The code that processed the options object to report selected modules should have made a shallow copy of the options object. The `--terse` option no longer worked as a result because modules in the options object were no longer expanded. This update fixes that problem.

The `--terse` option was also broken when used with the IDL extraction module because the code still expected to find the IDL under `idl.idl`, whereas IDL extraction now just behaves like all other extraction modules and writes IDL under `idl`.