### PR TITLE
Combine CSS production rules

### DIFF
--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -269,6 +269,25 @@ const tests = [
   },
 
   {
+    title: "knows that second definition of rgb() is legacy",
+    html: `
+      <pre class="prod">
+        &lt;rgb()> = rgb( modern )
+      </pre>
+      <pre class="prod">
+        &lt;rgb()> = rgb( legacy )
+      </pre>
+    `,
+    propertyName: "valuespaces",
+    css: {
+      "<rgb()>": {
+        "value": "rgb( modern )",
+        "legacyValue": "rgb( legacy )"
+      }
+    }
+  },
+
+  {
     title: "extracts an at-rule syntax",
     html: `
       <pre class="prod">
@@ -281,6 +300,27 @@ const tests = [
     css: {
       "@layer": {
         "value": "@layer <layer-name>? { <stylesheet> }",
+        "descriptors": []
+      }
+    }
+  },
+
+  {
+    title: "extracts an at-rule syntax with multiple definitions",
+    html: `
+      <pre class="prod">
+        @layer <a class="production">&lt;layer-name&gt;</a>? {
+          <a class="production">&lt;stylesheet&gt;</a>
+        }
+      </pre>
+      <pre class="prod">
+        @layer <a class="production">&lt;layer-name&gt;</a>#;
+      </pre>
+    `,
+    propertyName: "atrules",
+    css: {
+      "@layer": {
+        "value": "@layer <layer-name>? { <stylesheet> } | @layer <layer-name>#;",
         "descriptors": []
       }
     }


### PR DESCRIPTION
There are couple of places where CSS specs specify a second possible production rule for an at-rule or valuespace:
- the `@layer` at-rule, defined in css-cascade-5 has two production rules because it is both a statement and block rule, as discussed in https://github.com/w3c/webref/issues/706
- the `<rgb()>` and `<hsl()>` valuespaces, defined in css-color-4, have production rules for their legacy form.

The crawler failed to capture these. The legacy forms were added in Webref through a patch.

In order to capture the second rule for `@layer`, this update makes the crawler combine the values with a `|`. It could perhaps be better to separate the definitions somehow, but our structure does not allow that for now.

In order to keep the legacy forms of `<rgb()>` and `<hsl()>` out of the way, handling of these forms is hardcoded so that the legacy forms go to a `legacyValue` property as before. Related patches in Webref will have to be removed as a result.

There are (fortunately!) no other places with more than one production rule for at-rules and valuespaces.