### PR TITLE
Filter imported dfns from extracted dfns

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -230,6 +230,13 @@ export default function (spec, idToHeading = {}) {
       return node;
     })
     .filter(hasValidType)
+    // When the whole term links to an external spec, the definition is an
+    // imported definition. Such definitions are not "real" definitions, let's
+    // skip them.
+    .filter(node => {
+      const link = node.querySelector('a[href^="http"]');
+      return !link || (node.textContent.trim() !== link.textContent.trim());
+    })
     .map(node => definitionMapper(node, idToHeading));
 }
 
@@ -581,32 +588,6 @@ function preProcessHTML() {
       const headingId = el.closest("h2, h3, h4, h5, h6").id;
       if (!el.id) {
         el.id = headingId;
-      }
-    });
-
-  // all the definitions in indices.html are non-normative, so we skip them
-  // to avoid having to properly type them
-  // they're not all that interesting
-  document.querySelectorAll('section[data-reffy-page$="indices.html"] dfn[id]')
-    .forEach(el => {
-      el.dataset.dfnSkip = true;
-    });
-
-  document.querySelectorAll("dfn[id]:not([data-dfn-type]):not([data-skip])")
-    .forEach(el => {
-      // Hard coded rules for special ids
-      // dom-style is defined elsewhere
-      if (el.id === "dom-style") {
-        el.dataset.dfnType = 'attribute';
-        el.dataset.dfnFor = 'HTMLElement';
-        el.dataset.noexport = "";
-        return;
-      }
-
-      // If there is a link, we assume this documents an imported definition
-      // so we make it ignored by removing the id
-      if (el.querySelector('a[href^="http"]')) {
-        return;
       }
     });
 }

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -271,25 +271,7 @@ const tests = [
   {
     "title": "ignores definitions imported in the HTML spec from other specs",
     html: '<li>The <dfn id="xmlhttprequest"><a href="https://xhr.spec.whatwg.org/#xmlhttprequest"><code>XMLHttpRequest</code></a></dfn> interface</li>',
-    changesToBaseDfn: [{
-      id: "xmlhttprequest",
-      linkingText: ["XMLHttpRequest"]
-    }],
-    spec: "html"
-  },
-  {
-    "title": "ignores definitions imported in the indices.html page of the HTML spec",
-    html: '<section data-reffy-page="https://example.org/indices.html"><dl><dt><dfn id="text/xml"><code>text/xml</code></dfn></dt></dl></section>',
-    changesToBaseDfn: [{
-      id: "text/xml",
-      linkingText: ["text/xml"],
-      href: "https://example.org/indices.html#text/xml",
-      definedIn: "dt",
-      heading: {
-        href: "https://example.org/indices.html",
-        title: ""
-      }
-    }],
+    changesToBaseDfn: [],
     spec: "html"
   },
   {


### PR DESCRIPTION
Various specs import definitions from other specs. Such "proxy" definitions are not real definitions. This update makes the extraction logic skip them.

This update also drops useless pre-processing logic for the HTML spec, see #1092 for details.

This will remove a number of (ghost) private definitions from the extracts, including over 1250 definitions from HTML.

Examples of spec sections that use imported dfns:
https://html.spec.whatwg.org/multipage/infrastructure.html#dependencies https://html.spec.whatwg.org/multipage/parsing.html#character-encodings https://drafts.csswg.org/web-animations-2/#grouping-and-synchronization https://w3c.github.io/web-share-target/#dom-webappmanifest https://wicg.github.io/js-self-profiling/#profiling-sessions https://w3c.github.io/webdriver/#index
https://w3c.github.io/DOM-Parsing/#dependencies
https://w3c.github.io/json-ld-framing/#terms-imported-from-other-specifications https://w3c.github.io/network-error-logging/#dependencies https://w3c.github.io/payment-handler/#dependencies https://w3c.github.io/dnt/drafts/tracking-dnt.html#terminology

Examples of specs that use imported dfns, but that could be worth fixing because nothing links back to the local definition in practice, as all references target the external spec directly:
https://wicg.github.io/is-input-pending/
https://wicg.github.io/netinfo/#navigatornetworkinformation-interface

This fixes #1092.