### PR TITLE
Use latest version of Ubuntu for actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 name: test
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2


### PR DESCRIPTION
Ubuntu 18.04 is being deprecated. Staying on latest should be relatively harmless.