### PR TITLE
Prevent duplicates in dfns extracts

### DIFF
--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -152,6 +152,10 @@ const tests = [
    html: "<dfn id=foo data-dfn-type=invalidtype>Foo</dfn>",
    changesToBaseDfn: []
   },
+  {title: "ignores dfns already defined",
+   html: "<dfn id='foo'>Foo</dfn>. <dfn id='foo2'>Foo</dfn> is already defined.",
+   changesToBaseDfn: [{}]
+  },
   {title: "automatically fixes internal slots dfns with an invalid 'idl' data-dfn-type",
    html: "<dfn id=foo data-dfn-type=idl>Foo</dfn>",
    changesToBaseDfn: [{type: "attribute", access: "public"}]


### PR DESCRIPTION
This makes the dfns extraction code skip over a re-defined term (same linking text, same type, same namespace), and report a warning when a duplicate dfn is encountered and skipped.

Warnings are easily glossed over but we don't really have a better mechanism in place right now to report issues found during extractions. Apart from making the whole extraction fail that is, which seems overkill.

Fixes https://github.com/w3c/webref/issues/783