### PR TITLE
Re-write CSS extraction logic. Add values

### DIFF
--- a/schemas/browserlib/extract-cssdfn.json
+++ b/schemas/browserlib/extract-cssdfn.json
@@ -82,6 +82,19 @@
           "values": { "$ref": "../common.json#/$defs/cssValues" }
         }
       }
+    },
+
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["msg", "name"],
+        "properties": {
+          "msg": { "type": "string" },
+          "name": { "type": "string" }
+        }
+      },
+      "minItems": 1
     }
   }
 }

--- a/schemas/browserlib/extract-cssdfn.json
+++ b/schemas/browserlib/extract-cssdfn.json
@@ -34,6 +34,7 @@
         "properties": {
           "name": { "type": "string", "pattern": "^@" },
           "value": { "$ref": "../common.json#/$defs/cssValue" },
+          "prose": { "type": "string" },
           "descriptors": {
             "type": "array",
             "items": {

--- a/schemas/browserlib/extract-cssdfn.json
+++ b/schemas/browserlib/extract-cssdfn.json
@@ -4,17 +4,18 @@
 
   "type": "object",
   "additionalProperties": false,
-  "required": ["properties", "atrules", "valuespaces"],
+  "required": ["properties", "atrules", "selectors", "values"],
   "properties": {
     "properties": {
-      "type": "object",
-      "propertyNames": { "$ref": "../common.json#/$defs/cssPropertyName" },
-      "additionalProperties": {
+      "type": "array",
+      "items": {
         "type": "object",
         "additionalProperties": true,
+        "required": ["name"],
         "properties": {
           "name": { "$ref": "../common.json#/$defs/cssPropertyName" },
           "value": { "$ref": "../common.json#/$defs/cssValue" },
+          "values": { "$ref": "../common.json#/$defs/cssValues" },
           "styleDeclaration": {
             "type": "array",
             "items": { "type": "string" },
@@ -25,25 +26,25 @@
     },
 
     "atrules": {
-      "type": "object",
-      "propertyNames": {
-        "type": "string",
-        "pattern": "^@"
-      },
-      "additionalProperties": {
+      "type": "array",
+      "items": {
         "type": "object",
+        "required": ["name"],
         "additionalProperties": false,
         "properties": {
+          "name": { "type": "string", "pattern": "^@" },
           "value": { "$ref": "../common.json#/$defs/cssValue" },
           "descriptors": {
             "type": "array",
             "items": {
               "type": "object",
+              "required": ["name", "for"],
               "additionalProperties": true,
               "properties": {
                 "name": { "type": "string" },
                 "for": { "type": "string" },
-                "value": { "$ref": "../common.json#/$defs/cssValue" }
+                "value": { "$ref": "../common.json#/$defs/cssValue" },
+                "values": { "$ref": "../common.json#/$defs/cssValues" }
               }
             }
           }
@@ -51,19 +52,34 @@
       }
     },
 
-    "valuespaces": {
-      "type": "object",
-      "propertyNames": {
-        "type": "string",
-        "pattern": "^<[^>]+>$"
-      },
-      "additionalProperties": {
+    "selectors": {
+      "type": "array",
+      "items": {
         "type": "object",
+        "required": ["name"],
         "additionalProperties": false,
         "properties": {
+          "name": { "$ref": "../common.json#/$defs/cssPropertyName" },
           "prose": { "type": "string" },
           "value": { "$ref": "../common.json#/$defs/cssValue" },
-          "legacyValue": { "$ref": "../common.json#/$defs/cssValue" }
+          "values": { "$ref": "../common.json#/$defs/cssValues" }
+        }
+      }
+    },
+
+    "values": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string", "pattern": "^<[^>]+>$|^.*()$" },
+          "type": { "type": "string", "enum": ["type", "function"] },
+          "prose": { "type": "string" },
+          "value": { "$ref": "../common.json#/$defs/cssValue" },
+          "legacyValue": { "$ref": "../common.json#/$defs/cssValue" },
+          "values": { "$ref": "../common.json#/$defs/cssValues" }
         }
       }
     }

--- a/schemas/browserlib/extract-cssdfn.json
+++ b/schemas/browserlib/extract-cssdfn.json
@@ -29,7 +29,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["name"],
+        "required": ["name", "descriptors"],
         "additionalProperties": false,
         "properties": {
           "name": { "type": "string", "pattern": "^@" },

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -39,6 +39,23 @@
       "minLength": 1
     },
 
+    "cssValues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type", "value"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "$ref": "#/$defs/cssValue" },
+          "type": { "type": "string", "enum": ["type", "function", "value"] },
+          "prose": { "type": "string" },
+          "value": { "$ref": "#/$defs/cssValue" },
+          "legacyValue": { "$ref": "#/$defs/cssValue" },
+          "values": { "$ref": "#/$defs/cssValues" }
+        }
+      }
+    },
+
     "interface": {
       "type": "string",
       "pattern": "^[A-Z]([A-Za-z0-9_])*$|^console$",

--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -27,6 +27,8 @@ export default function () {
 
     // At-rules, selectors, functions and types are defined through dfns with
     // the right "data-dfn-type" attribute
+    // Note some selectors are re-defined locally in HTML and Fullscreen. We
+    // won't import them.
     atrules: extractDfns({
       selector: 'dfn[data-dfn-type=at-rule]',
       extractor: extractTypedDfn,
@@ -34,7 +36,7 @@ export default function () {
       warnings
     }),
     selectors: extractDfns({
-      selector: 'dfn[data-dfn-type=selector]',
+      selector: 'dfn[data-dfn-type=selector][data-export]',
       extractor: extractTypedDfn,
       duplicates: 'reject',
       warnings

--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -160,7 +160,7 @@ export default function () {
           res.warnings = []
         }
         const warning = Object.assign({ msg: 'Missing definition' }, rule);
-        res.warnings.push(warning);
+        warnings.push(warning);
         rootDfns.push(warning);
       }
     }

--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -640,7 +640,7 @@ const extractTypedDfn = dfn => {
 
   res.type = dfnType;
   if (dfnType === 'value') {
-    res.value = res.name;
+    res.value = normalize(res.name);
   }
   if (dfnFor) {
     res.for = dfnFor;

--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -34,7 +34,9 @@ export default function () {
     }),
     values: extractDfns({
       selector: ['dfn[data-dfn-type=function]:not([data-dfn-for])',
-                 'dfn[data-dfn-type=type]:not([data-dfn-for])'
+                 'dfn[data-dfn-type=function][data-dfn-for=""]',
+                 'dfn[data-dfn-type=type]:not([data-dfn-for])',
+                 'dfn[data-dfn-type=type][data-dfn-for=""]'
                 ].join(','),
       extractor: extractTypedDfn,
       duplicates: 'reject',
@@ -97,9 +99,9 @@ export default function () {
   // as "<content-replacement>" in css-content-3:
   // https://drafts.csswg.org/css-content-3/#typedef-content-content-replacement
   const values = extractDfns({
-    selector: ['dfn[data-dfn-type=value][data-dfn-for]',
-               'dfn[data-dfn-type=function][data-dfn-for]',
-               'dfn[data-dfn-type=type][data-dfn-for]'
+    selector: ['dfn[data-dfn-type=value][data-dfn-for]:not([data-dfn-for=""])',
+               'dfn[data-dfn-type=function][data-dfn-for]:not([data-dfn-for=""])',
+               'dfn[data-dfn-type=type][data-dfn-for]:not([data-dfn-for=""])'
               ].join(','),
     extractor: extractTypedDfn,
     duplicates: 'push',

--- a/src/cli/check-missing-dfns.js
+++ b/src/cli/check-missing-dfns.js
@@ -16,6 +16,9 @@
  * - `format` is the optional output format. Either `json` or `markdown` with
  * `markdown` being the default.
  *
+ * Note: CSS extraction already relies on dfns and reports missing dfns in a
+ * "warnings" property. This checker simply looks at that list.
+ *
  * @module checker
  */
 
@@ -59,61 +62,15 @@ function arraysEqual(a, b) {
  * @return {Array} An array of expected definitions
  */
 function getExpectedDfnsFromCSS(css) {
-  let expected = [];
-
-  // Add the list of expected properties, filtering out properties that define
-  // new values to an existing property (defined elsewhere)
-  expected = expected.concat(
-    Object.values(css.properties || {})
-      .filter(desc => !desc.newValues)
-      .map(desc => {
-        return {
-          linkingText: [desc.name],
-          type: 'property',
-          'for': []
-        };
-      })
-  );
-
-  // Add the list of expected at-rules
-  expected = expected.concat(
-    Object.entries(css.atrules || {}).map(([name, rule]) => {
-      if (rule.value) {
-        return {
-          linkingText: [name],
-          type: 'at-rule',
-          'for': []
-        };
-      }
-    }).filter(dfn => !!dfn)
-  );
-
-  // Add the list of expected descriptors
-  expected = expected.concat(
-    Object.entries(css.atrules || {}).map(([name, rule]) =>
-      (rule.descriptors || []).map(desc => {
-        return {
-          linkingText: [desc.name],
-          type: 'descriptor',
-          'for': [name]
-        };
-      })
-    ).flat()
-  );
-  
-  // Add the list of expected "values".
-  // Note: we don't qualify the "type" of values in valuespaces and don't store
-  // the scope of values either (the "for" property). Definition types can be
-  // "type", "function", "value", etc. in practice. The comparison cannot be
-  // perfect as a result.
-  expected = expected.concat(
-    Object.entries(css.valuespaces || {}).map(([name, desc]) => {
+  const expected = (css.warnings ?? [])
+    .filter(warning => warning.msg === 'Missing definition')
+    .map(warning => {
       return {
-        linkingText: [name],
-        value: desc.value
+        linkingText: [warning.name],
+        type: warning.type,
+        'for': warning.for
       };
-    })
-  );
+    });
 
   return expected;
 }

--- a/src/lib/specs-crawler.js
+++ b/src/lib/specs-crawler.js
@@ -241,10 +241,11 @@ async function saveSpecResults(spec, settings) {
 
     // Save CSS dumps
     function defineCSSContent(spec) {
-        return spec.css && (
-            (Object.keys(spec.css.properties || {}).length > 0) ||
-            (Object.keys(spec.css.atrules || {}).length > 0) ||
-            (Object.keys(spec.css.valuespaces || {}).length > 0));
+        return (spec.css?.properties?.length > 0) ||
+               (spec.css?.atrules?.length > 0) ||
+               (spec.css?.selectors?.length > 0) ||
+               (spec.css?.values?.length > 0) ||
+               (spec.css?.warnings?.length > 0);
     }
     if (defineCSSContent(spec)) {
         spec.css = await saveCss(spec);

--- a/src/postprocessing/csscomplete.js
+++ b/src/postprocessing/csscomplete.js
@@ -20,10 +20,10 @@ module.exports = {
         .filter(dfn => dfn.type == "property" && !dfn.informative)
         .forEach(propDfn => {
           propDfn.linkingText.forEach(lt => {
-            if (!spec.css.properties.hasOwnProperty(lt)) {
-              spec.css.properties[lt] = {
+            if (!spec.css.properties.find(p => p.name === lt)) {
+              spec.css.properties.push({
                 name: lt
-              };
+              });
             }
           });
         });
@@ -31,18 +31,15 @@ module.exports = {
 
     if (spec.css) {
       // Add generated IDL attribute names
-      Object.entries(spec.css.properties || {}).forEach(([prop, dfn]) => {
-        dfn.styleDeclaration = getGeneratedIDLNamesByCSSProperty(prop);
+      spec.css.properties.forEach(dfn => {
+        dfn.styleDeclaration = getGeneratedIDLNamesByCSSProperty(dfn.name);
       });
 
       // Drop the sample definition (property-name) in CSS2 and the custom
       // property definition (--*) in CSS Variables that specs incorrectly flag
       // as real CSS properties.
-      ['property-name', '--*'].forEach(prop => {
-          if ((spec.css.properties || {})[prop]) {
-              delete spec.css.properties[prop];
-          }
-      });
+      spec.css.properties = spec.css.properties.filter(p =>
+        !['property-name', '--*'].includes(p.name));
     }
 
     return spec;

--- a/tests/crawl-test.json
+++ b/tests/crawl-test.json
@@ -21,9 +21,10 @@
     },
     "title": "WOFF2",
     "css": {
-      "atrules": {},
-      "properties": {},
-      "valuespaces": {}
+      "atrules": [],
+      "properties": [],
+      "selectors": [],
+      "values": []
     },
     "dfns": [
       {
@@ -89,9 +90,10 @@
     "title": "No Title",
     "generator": "respec",
     "css": {
-      "atrules": {},
-      "properties": {},
-      "valuespaces": {}
+      "atrules": [],
+      "properties": [],
+      "selectors": [],
+      "values": []
     },
     "dfns": [
       {
@@ -209,9 +211,10 @@
     },
     "title": "[No title found for https://w3c.github.io/accelerometer/]",
     "css": {
-      "atrules": {},
-      "properties": {},
-      "valuespaces": {}
+      "atrules": [],
+      "properties": [],
+      "selectors": [],
+      "values": []
     },
     "dfns": [],
     "elements": [],

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -331,8 +331,9 @@ const tests = [
     `,
     propertyName: "atrules",
     css: [{
-        "name": "@layer",
-        "value": "@layer <layer-name>? { <stylesheet> }"
+        name: "@layer",
+        value: "@layer <layer-name>? { <stylesheet> }",
+        descriptors: []
     }]
   },
 
@@ -351,8 +352,9 @@ const tests = [
     `,
     propertyName: "atrules",
     css: [{
-        "name": "@layer",
-        "value": "@layer <layer-name>? { <stylesheet> } | @layer <layer-name>#;"
+        name: "@layer",
+        value: "@layer <layer-name>? { <stylesheet> } | @layer <layer-name>#;",
+        descriptors: []
     }]
   },
 
@@ -989,6 +991,116 @@ that spans multiple lines */
       newValues: 'auto | [ [ stable | always ] && mirror? && force? ] || match-parent'
     }]
   },
+
+  {
+    title: 'keeps the "type" of descriptors if so defined',
+    html: `
+    <table class="def descdef mq">
+    <tbody>
+     <tr>
+      <th>Name:
+      </th><td><dfn class="dfn-paneled css" data-dfn-for="@media" data-dfn-type="descriptor">-webkit-device-pixel-ratio</dfn>
+     </td></tr><tr>
+      <th>For:
+      </th><td>@media
+     </td></tr><tr>
+      <th>Value:
+      </th><td class="prod">&lt;number&gt;
+     </td></tr><tr>
+      <th>Type:
+      </th><td>range
+   </td></tr></tbody></table>
+    `,
+    propertyName: 'atrules',
+    css: [{
+      name: '@media',
+      descriptors: [{
+        name: '-webkit-device-pixel-ratio',
+        for: '@media',
+        value: '<number>',
+        type: 'range'
+      }]
+    }]
+  },
+
+  {
+    title: 'handles cycles in value references',
+    html: `
+    <pre class="prod">
+      <dfn data-dfn-type="type">&lt;my-type&gt;</dfn> = &lt;my-subtype>
+      <dfn data-dfn-type="type" data-dfn-for="&lt;my-type&gt;">&lt;my-subtype&gt;</dfn> = none | auto | &lt;recurring-type&gt;
+      <dfn data-dfn-type="type" data-dfn-for="&lt;my-subtype&gt;">&lt;recurring-type&gt;</dfn> = &lt;my-type&gt;
+    </pre>
+    `,
+    propertyName: 'values',
+    css: [{
+      name: '<my-type>',
+      type: 'type',
+      value: '<my-subtype>',
+      values: [
+        {
+          name: '<my-subtype>',
+          type: 'type',
+          value: 'none | auto | <recurring-type>',
+          values: [
+            {
+              name: '<recurring-type>',
+              type: 'type',
+              value: '<my-type>'
+            }
+          ]
+        }
+      ]
+    }]
+  },
+
+  {
+    title: 'skips production rules of IDL blocks in HTML spec',
+    html: `
+    <pre>
+      <code class="idl">
+        <dfn>&lt;not-a-css-type&gt;</dfn> = blah
+      </code>
+    </pre>
+    `,
+    propertyName: 'values',
+    css: []
+  },
+
+  {
+    title: 'does not report production rules of IDL blocks in HTML spec as warnings',
+    html: `
+    <pre>
+      <code class="idl">
+        <dfn>&lt;not-a-css-type&gt;</dfn> = blah
+      </code>
+    </pre>
+    `,
+    propertyName: 'warnings',
+    css: undefined
+  },
+
+  {
+    title: 'skips production rules that are not of the right type',
+    html: `
+    <pre>
+      <dfn data-dfn-type="dfn">&lt;not-a-css-type&gt;</dfn> = none | auto
+    </pre>
+    `,
+    propertyName: 'values',
+    css: []
+  },
+
+  {
+    title: 'does not report production rules that are not of the right type as warnings',
+    html: `
+    <pre>
+      <dfn data-dfn-type="dfn">&lt;not-a-css-type&gt;</dfn> = none | auto
+    </pre>
+    `,
+    propertyName: 'warnings',
+    css: undefined
+  }
 ];
 
 describe("Test CSS properties extraction", function() {

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -15,23 +15,23 @@ const tests = [
       <th><a href="#values">Value</a>: 
       </th><td><a class="production css" data-link-type="type" href="https://www.w3.org/TR/css-color-3/#valuea-def-color" id="ref-for-valuea-def-color" title="Expands to: aliceblue | antiquewhite | aqua | aquamarine | azure | beige | bisque | black | blanchedalmond | blue | blueviolet | brown | burlywood | cadetblue | chartreuse | chocolate | coral | cornflowerblue | cornsilk | crimson | currentcolor | cyan | darkblue | darkcyan | darkgoldenrod | darkgray | darkgreen | darkgrey | darkkhaki | darkmagenta | darkolivegreen | darkorange | darkorchid | darkred | darksalmon | darkseagreen | darkslateblue | darkslategray | darkslategrey | darkturquoise | darkviolet | deeppink | deepskyblue | dimgray | dimgrey | dodgerblue | firebrick | floralwhite | forestgreen | fuchsia | gainsboro | ghostwhite | gold | goldenrod | gray | green | greenyellow | grey | honeydew | hotpink | indianred | indigo | ivory | khaki | lavender | lavenderblush | lawngreen | lemonchiffon | lightblue | lightcoral | lightcyan | lightgoldenrodyellow | lightgray | lightgreen | lightgrey | lightpink | lightsalmon | lightseagreen | lightskyblue | lightslategray | lightslategrey | lightsteelblue | lightyellow | lime | limegreen | linen | magenta | maroon | mediumaquamarine | mediumblue | mediumorchid | mediumpurple | mediumseagreen | mediumslateblue | mediumspringgreen | mediumturquoise | mediumvioletred | midnightblue | mintcream | mistyrose | moccasin | navajowhite | navy | oldlace | olive | olivedrab | orange | orangered | orchid | palegoldenrod | palegreen | paleturquoise | palevioletred | papayawhip | peachpuff | peru | pink | plum | powderblue | purple | rebeccapurple | red | rosybrown | royalblue | saddlebrown | salmon | sandybrown | seagreen | seashell | sienna | silver | skyblue | slateblue | slategray | slategrey | snow | springgreen | steelblue | tan | teal | thistle | tomato | transparent | turquoise | violet | wheat | white | whitesmoke | yellow | yellowgreen">&lt;color&gt;</a> 
      </td></tr><tr>
-      <th>Initial: 
-      </th><td>transparent 
+      <th>Initial:
+      </th><td>transparent
      </td></tr><tr>
-      <th>Applies to: 
-      </th><td>all elements 
+      <th>Applies to:
+      </th><td>all elements
      </td></tr><tr>
-      <th>Inherited: 
-      </th><td>no 
+      <th>Inherited:
+      </th><td>no
      </td></tr><tr>
-      <th>Percentages: 
-      </th><td>N/A 
+      <th>Percentages:
+      </th><td>N/A
      </td></tr><tr>
-      <th>Computed value: 
-      </th><td>computed color 
+      <th>Computed value:
+      </th><td>computed color
      </td></tr><tr>
-      <th>Animation type: 
-      </th><td>by computed value 
+      <th>Animation type:
+      </th><td>by computed value
    </td></tr></tbody></table>`,
    css: [{
       "name": "background-color",
@@ -82,28 +82,28 @@ const tests = [
        <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-align-content">align-content</dfn>
      </td></tr><tr class="value">
       <th><a href="https://www.w3.org/TR/css-values/#value-defs">Value:</a>
-      </th><td class="prod">normal <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one①⑤">|</a> <a class="production css" data-link-type="type" href="#typedef-baseline-position" id="ref-for-typedef-baseline-position①" title="Expands to: baseline | first | last">&lt;baseline-position&gt;</a> <span id="ref-for-comb-one①⑥">|</span> <a class="production css" data-link-type="type" href="#typedef-content-distribution" id="ref-for-typedef-content-distribution①" title="Expands to: space-around | space-between | space-evenly | stretch">&lt;content-distribution&gt;</a> <span id="ref-for-comb-one①⑦">|</span> <a class="production css" data-link-type="type" href="#typedef-overflow-position" id="ref-for-typedef-overflow-position②" title="Expands to: safe | unsafe">&lt;overflow-position&gt;</a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt①">?</a> <a class="production css" data-link-type="type" href="#typedef-content-position" id="ref-for-typedef-content-position②" title="Expands to: center | end | flex-end | flex-start | start">&lt;content-position&gt;</a> 
+      </th><td class="prod">normal <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one①⑤">|</a> <a class="production css" data-link-type="type" href="#typedef-baseline-position" id="ref-for-typedef-baseline-position①" title="Expands to: baseline | first | last">&lt;baseline-position&gt;</a> <span id="ref-for-comb-one①⑥">|</span> <a class="production css" data-link-type="type" href="#typedef-content-distribution" id="ref-for-typedef-content-distribution①" title="Expands to: space-around | space-between | space-evenly | stretch">&lt;content-distribution&gt;</a> <span id="ref-for-comb-one①⑦">|</span> <a class="production css" data-link-type="type" href="#typedef-overflow-position" id="ref-for-typedef-overflow-position②" title="Expands to: safe | unsafe">&lt;overflow-position&gt;</a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt①">?</a> <a class="production css" data-link-type="type" href="#typedef-content-position" id="ref-for-typedef-content-position②" title="Expands to: center | end | flex-end | flex-start | start">&lt;content-position&gt;</a>
      </td></tr><tr>
       <th><a href="https://www.w3.org/TR/css-cascade/#initial-values">Initial:</a>
-      </th><td>normal 
+      </th><td>normal
      </td></tr><tr>
       <th>Applies to:
-      </th><td>block containers, multicol containers, flex containers, and grid containers 
+      </th><td>block containers, multicol containers, flex containers, and grid containers
      </td></tr><tr>
       <th><a href="https://www.w3.org/TR/css-cascade/#inherited-property">Inherited:</a>
-      </th><td>no 
+      </th><td>no
      </td></tr><tr>
       <th><a href="https://www.w3.org/TR/css-values/#percentages">Percentages:</a>
-      </th><td>n/a 
+      </th><td>n/a
      </td></tr><tr>
       <th><a href="https://www.w3.org/TR/css-cascade/#computed">Computed value:</a>
-      </th><td>specified keyword(s) 
+      </th><td>specified keyword(s)
      </td></tr><tr>
       <th>Canonical order:
-      </th><td>per grammar 
+      </th><td>per grammar
      </td></tr><tr>
       <th><a href="https://www.w3.org/TR/web-animations/#animation-type">Animation type:</a>
-      </th><td>discrete 
+      </th><td>discrete
    </td></tr></tbody></table>`,
    css: [{
        "name": "align-content",
@@ -184,7 +184,7 @@ const tests = [
   },
 
   {
-    title: "parses a value definition, excluding tests and notes",
+    title: "parses a type definition, excluding tests and notes",
     html: `<dl>
     <dt><dfn class="css" data-dfn-type="type" data-export="" id="valdef-text-indent-percentage">&lt;percentage&gt;<a class="self-link" href="#valdef-text-indent-percentage"></a></dfn> 
     </dt><dd>
@@ -458,60 +458,6 @@ const tests = [
 
 
   {
-    title: "throws when a property is defined more than once and cannot be merged",
-    html: `
-      <table class="def propdef" data-link-for-hint="scrollbar-gutter"><tbody>
-       <tr>
-        <th>Name:
-        </th><td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-scrollbar-gutter">scrollbar-gutter</dfn>
-       </td></tr><tr class="value">
-        <th><a href="https://www.w3.org/TR/css-values/#value-defs">Value:</a>
-        </th><td class="prod">auto <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one">|</a> stable <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all" id="ref-for-comb-all">&amp;&amp;</a> mirror<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt">?</a>
-       </td></tr><tr>
-        <th><a href="https://www.w3.org/TR/css-cascade/#initial-values">Initial:</a>
-        </th><td>auto
-       </td></tr><tr>
-        <th>Applies to:
-        </th><td><a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container">scroll containers</a>
-       </td></tr><tr>
-        <th><a href="https://www.w3.org/TR/css-cascade/#inherited-property">Inherited:</a>
-        </th><td>no
-       </td></tr><tr>
-        <th><a href="https://www.w3.org/TR/css-values/#percentages">Percentages:</a>
-        </th><td>n/a
-       </td></tr><tr>
-        <th><a href="https://www.w3.org/TR/css-cascade/#computed">Computed value:</a>
-        </th><td>specified keyword(s)
-       </td></tr><tr>
-        <th>Canonical order:
-        </th><td>per grammar
-       </td></tr><tr>
-        <th><a href="https://www.w3.org/TR/web-animations/#animation-type">Animation type:</a>
-        </th><td>discrete
-        </td></tr>
-      </tbody></table>
-      <table class="def propdef partial" data-link-for-hint="scrollbar-gutter">
-       <tbody>
-        <tr>
-         <th>Name:
-         </th><td><a class="css" data-link-type="property" href="#propdef-scrollbar-gutter" id="ref-for-propdef-scrollbar-gutter①⓪">scrollbar-gutter</a>
-        </td></tr><tr class="value">
-         <th><a href="https://www.w3.org/TR/css-values/#value-defs">New values:</a>
-         </th><td class="prod">auto <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one①⓪">|</a> [ [ stable <span id="ref-for-comb-one①①">|</span> always ] <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all" id="ref-for-comb-all①">&amp;&amp;</a> mirror<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt①">?</a> <span id="ref-for-comb-all②">&amp;&amp;</span> force<span id="ref-for-mult-opt②">?</span> ] <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-any" id="ref-for-comb-any">||</a> match-parent
-        </td></tr><tr>
-          <th><a href="https://www.w3.org/TR/css-cascade/#initial-values">Initial:</a>
-          </th><td>A different initial value
-         </td></tr><tr>
-         <th>Applies to:
-         </th><td><a href="https://www.w3.org/TR/css-pseudo/#generated-content" title="Includes ::before and ::after pseudo-elements.">all elements</a>
-        </td></tr>
-       </tbody>
-      </table>`,
-    error: 'More than one CSS dfn found for \"scrollbar-gutter\" and dfns cannot be merged'
-  },
-
-
-  {
     title: "ignores definitions that describe changes",
     html: `<table class="propdef">
       <tbody>
@@ -671,7 +617,378 @@ that spans multiple lines */
         type: "type",
         prose: "The <decibel> type denotes a dimension with a \"dB\" (decibel unit) unit identifier. Decibels represent the ratio of the squares of the new signal amplitude a1 and the current amplitude a0, as per the following logarithmic equation: volume(dB) = 20 × log10(a1 / a0)."
     }]
-  }
+  },
+
+  {
+    title: "parses selectors definitions",
+    html: `
+    <p>
+      The <dfn data-dfn-type="selector">:open</dfn> pseudo-class represents an
+      element that has both “open” and “closed” states, and which is currently
+      in the “open” state.
+    </p>
+    <p>
+      The <dfn data-dfn-type="selector">:closed</dfn> pseudo-class represents an
+      element that has both “open” and “closed” states, and which is currently
+      in the “closed” state.
+    </p>
+    `,
+    propertyName: "selectors",
+    css: [
+      {
+        name: ":open",
+        prose: "The :open pseudo-class represents an element that has both “open” and “closed” states, and which is currently in the “open” state."
+      },
+      {
+        name: ":closed",
+        prose: "The :closed pseudo-class represents an element that has both “open” and “closed” states, and which is currently in the “closed” state."
+      }
+    ]
+  },
+
+  {
+    title: 'parses a "value" definition for a "property"',
+    html: `
+    <table class="def propdef" data-link-for-hint="animation-name">
+    <tbody>
+     <tr>
+      <th>Name:
+      </th><td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-animation-name">animation-name</dfn>
+     </td></tr><tr class="value">
+      <th><a href="https://www.w3.org/TR/css-values/#value-defs">Value:</a>
+      </th><td class="prod">[ none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one">|</a> <a class="production css" data-link-type="type" href="#typedef-keyframes-name" id="ref-for-typedef-keyframes-name①">&lt;keyframes-name&gt;</a> ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-comma" id="ref-for-mult-comma">#</a>
+     </td></tr><tr>
+      <th><a href="https://www.w3.org/TR/css-cascade/#initial-values">Initial:</a>
+      </th><td>none
+     </td></tr><tr>
+      <th><a href="https://www.w3.org/TR/css-cascade/#applies-to">Applies to:</a>
+      </th><td><a href="https://www.w3.org/TR/css-pseudo/#generated-content" title="Includes ::before and ::after pseudo-elements.">all elements</a>
+     </td></tr><tr>
+      <th><a href="https://www.w3.org/TR/css-cascade/#inherited-property">Inherited:</a>
+      </th><td>no
+     </td></tr><tr>
+      <th><a href="https://www.w3.org/TR/css-values/#percentages">Percentages:</a>
+      </th><td>N/A
+     </td></tr><tr>
+      <th><a href="https://www.w3.org/TR/css-cascade/#computed">Computed value:</a>
+      </th><td>list, each item either a case-sensitive <a data-link-type="dfn" href="https://drafts.csswg.org/css-values-4/#css-css-identifier" id="ref-for-css-css-identifier">css identifier</a> or the keyword <a class="css" data-link-type="maybe" href="#valdef-animation-name-none" id="ref-for-valdef-animation-name-none①">none</a>
+     </td></tr><tr>
+      <th><a href="https://www.w3.org/TR/cssom/#serializing-css-values">Canonical order:</a>
+      </th><td>per grammar
+     </td></tr><tr>
+      <th><a href="https://www.w3.org/TR/web-animations/#animation-type">Animation type:</a>
+      </th><td>not animatable
+    </td></tr></tbody></table>
+    <dl>
+    <dt><dfn class="dfn-paneled css" data-dfn-for="animation-name" data-dfn-type="value" data-export="" id="valdef-animation-name-none">none</dfn>
+    </dt><dd> No keyframes are specified at all, so there will be no animation.
+      Any other animations properties specified for this animation have no effect.
+    </dd><dt><dfn class="css" data-dfn-for="animation-name" data-dfn-type="value" data-export="" id="valdef-animation-name-keyframes-name"><a class="production css" data-link-type="type" href="#typedef-keyframes-name" id="ref-for-typedef-keyframes-name②">&lt;keyframes-name&gt;</a><a class="self-link" href="#valdef-animation-name-keyframes-name"></a></dfn>
+    </dt><dd> The animation will use the keyframes with the name specified by the <a class="production css" data-link-type="type" href="#typedef-keyframes-name" id="ref-for-typedef-keyframes-name③">&lt;keyframes-name&gt;</a>,
+      if they exist.
+      If no <a class="css" data-link-type="maybe" href="#at-ruledef-keyframes" id="ref-for-at-ruledef-keyframes⑧">@keyframes</a> rule with that name exists, there is no animation.
+    </dd></dl>
+    `,
+    css: [{
+      "name": "animation-name",
+      "animationType": "not animatable",
+      "appliesTo": "all elements",
+      "canonicalOrder": "per grammar",
+      "computedValue": "list, each item either a case-sensitive css identifier or the keyword none",
+      "inherited": "no",
+      "initial": "none",
+      "percentages": "N/A",
+      "value": "[ none | <keyframes-name> ]#",
+      "values": [
+        {
+          "name": "none",
+          "prose": "No keyframes are specified at all, so there will be no animation. Any other animations properties specified for this animation have no effect.",
+          "type": "value",
+          "value": "none"
+        },
+        {
+          "name": "<keyframes-name>",
+          "prose": "The animation will use the keyframes with the name specified by the <keyframes-name>, if they exist. If no @keyframes rule with that name exists, there is no animation.",
+          "type": "value",
+          "value": "<keyframes-name>"
+        }
+      ]
+    }]
+  },
+
+  {
+    title: 'parses a "value" definition for a "descriptor"',
+    html: `
+    <p>The <dfn data-dfn-type="at-rule">@counter-style</dfn> rule allows authors
+    to define a custom counter style.</p>
+    <table class="def descdef">
+    <tbody>
+     <tr>
+      <th>Name:
+      </th><td><dfn class="css" data-dfn-for="@counter-style" data-dfn-type="descriptor" data-export="" id="descdef-counter-style-system">system<a class="self-link" href="#descdef-counter-style-system"></a></dfn>
+     </td></tr><tr>
+      <th>For:
+      </th><td><a class="css" data-link-type="at-rule" href="#at-ruledef-counter-style" id="ref-for-at-ruledef-counter-style①④">@counter-style</a>
+     </td></tr><tr>
+      <th>Value:
+      </th><td class="prod">cyclic <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one">|</a> numeric <span id="ref-for-comb-one①">|</span> alphabetic <span id="ref-for-comb-one②">|</span> symbolic <span id="ref-for-comb-one③">|</span> additive <span id="ref-for-comb-one④">|</span> <span class="nobr">[fixed <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value">&lt;integer&gt;</a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt">?</a>]</span> <span id="ref-for-comb-one⑤">|</span> <span class="nobr">[ extends <a class="production css" data-link-type="type" href="#typedef-counter-style-name" id="ref-for-typedef-counter-style-name③" title="Expands to: arabic-indic | armenian | bengali | cambodian | circle | cjk-decimal | cjk-earthly-branch | cjk-heavenly-stem | decimal | decimal-leading-zero | devanagari | disc | disclosure-closed | disclosure-open | ethiopic-numeric | georgian | gujarati | gurmukhi | hebrew | hiragana | hiragana-iroha | kannada | katakana | katakana-iroha | khmer | korean-hangul-formal | korean-hanja-formal | korean-hanja-informal | lao | lower-alpha | lower-armenian | lower-greek | lower-latin | lower-roman | malayalam | mongolian | myanmar | oriya | persian | square | tamil | telugu | thai | tibetan | upper-alpha | upper-armenian | upper-latin | upper-roman">&lt;counter-style-name&gt;</a> ]</span>
+     </td></tr><tr>
+      <th>Initial:
+      </th><td>symbolic
+   </td></tr></tbody></table>
+   <p>The <dfn data-dfn-for="@counter-style/system" data-dfn-type="value">cyclic</dfn>
+   counter system cycles repeatedly through its provided symbols.</p>
+    `,
+    propertyName: 'atrules',
+    css: [{
+      name: '@counter-style',
+      prose: 'The @counter-style rule allows authors to define a custom counter style.',
+      descriptors: [
+        {
+          name: 'system',
+          for: '@counter-style',
+          initial: 'symbolic',
+          value: 'cyclic | numeric | alphabetic | symbolic | additive | [fixed <integer>?] | [ extends <counter-style-name> ]',
+          values: [
+            {
+              name: 'cyclic',
+              type: 'value',
+              value: 'cyclic',
+              prose: 'The cyclic counter system cycles repeatedly through its provided symbols.'
+            }
+          ]
+        }
+      ]
+    }]
+  },
+
+  {
+    title: 'parses "value" definitions for a "type"',
+    html: `
+    <pre class="prod">
+      <dfn data-dfn-type="type">&lt;font-weight-absolute&gt;</dfn> = [normal | bold | &lt;number [1,1000]&gt;]
+    </pre>
+    <dl>
+    <dt><dfn data-dfn-for="&lt;font-weight-absolute&gt;" data-dfn-type="value">&lt;number [1,1000]&gt;</dfn>
+    </dt><dd>
+      Each number indicates a weight that is at least as dark as its predecessor.
+    </dd><dt><dfn data-dfn-for="&lt;font-weight-absolute&gt;" data-dfn-type="value">normal</dfn>
+    </dt><dd>Same as <span class="css">400</span>.
+    </dd></dl>
+    `,
+    propertyName: 'values',
+    css: [{
+      name: '<font-weight-absolute>',
+      type: 'type',
+      value: '[normal | bold | <number [1,1000]>]',
+      values: [
+        {
+          name: '<number [1,1000]>',
+          type: 'value',
+          prose: 'Each number indicates a weight that is at least as dark as its predecessor.',
+          value: '<number [1,1000]>',
+        },
+        {
+          name: 'normal',
+          type: 'value',
+          prose: 'Same as 400.',
+          value: 'normal'
+        }
+      ]
+    }]
+  },
+
+  {
+    title: 'parses "type" and "function" definitions for a "type"',
+    html: `
+    <pre class="prod">
+      <dfn data-dfn-type="type">&lt;my-type&gt;</dfn> =
+        &lt;my-function()> &lt;my-subtype>
+      <dfn data-dfn-type="function" data-dfn-for="&lt;my-type&gt;">my-function()</dfn> = my-function(takes parameters)
+      <dfn data-dfn-type="type" data-dfn-for="&lt;my-type&gt;">&lt;my-subtype&gt;</dfn> = none | auto
+    </pre>
+    `,
+    propertyName: 'values',
+    css: [{
+      name: '<my-type>',
+      type: 'type',
+      value: '<my-function()> <my-subtype>',
+      values: [
+        {
+          name: 'my-function()',
+          type: 'function',
+          value: 'my-function(takes parameters)'
+        },
+        {
+          name: '<my-subtype>',
+          type: 'type',
+          value: 'none | auto'
+        }
+      ]
+    }]
+  },
+
+  {
+    title: 'does not choke on empty data-dfn-for attributes',
+    html: `
+    <pre class="prod">
+      <dfn data-dfn-type="type" data-dfn-for="">&lt;my-type&gt;</dfn> =
+      &lt;my-function()> &lt;my-subtype>
+    </pre>
+    `,
+    propertyName: 'values',
+    css: [{
+      name: '<my-type>',
+      type: 'type',
+      value: '<my-function()> <my-subtype>'
+    }]
+  },
+
+  {
+    title: 'associates values with the deepest structure it is for',
+    html: `
+    <pre class="prod">
+      <dfn data-dfn-type="type">&lt;my-type&gt;</dfn> = &lt;my-subtype>
+      <dfn data-dfn-type="type">&lt;my-subtype&gt;</dfn> = none | auto
+    </pre>
+    <p>The <dfn data-dfn-type="value" data-dfn-for="&lt;my-type&gt;,&lt;my-subtype&gt;">none</dfn>
+      value is fantastic.</p>
+    <p>The <dfn data-dfn-type="value" data-dfn-for="&lt;my-type&gt;,&lt;my-subtype&gt;">auto</dfn>
+      value is also fantastic.</p>
+    `,
+    propertyName: 'values',
+    css: [
+      {
+        name: '<my-type>',
+        type: 'type',
+        value: '<my-subtype>'
+      },
+      {
+        name: '<my-subtype>',
+        type: 'type',
+        value: 'none | auto',
+        values: [
+          {
+            name: 'none',
+            type: 'value',
+            value: 'none',
+            prose: 'The none value is fantastic.'
+          },
+          {
+            name: 'auto',
+            type: 'value',
+            value: 'auto',
+            prose: 'The auto value is also fantastic.'
+          }
+        ]
+      }
+    ]
+  },
+
+  {
+    title: 'issues a warning when a definition is missing',
+    html: `
+    <pre class="prod">&lt;my-type&gt; = none | auto
+    `,
+    propertyName: 'warnings',
+    css: [{
+      msg: 'Missing definition',
+      name: '<my-type>',
+      value: 'none | auto'
+    }]
+  },
+
+  {
+    title: 'issues a warning when it bumps into a duplicated definition',
+    html: `
+    <p><dfn data-dfn-type='type'>&lt;my-type&gt;</dfn> is defined a first time.</p>
+    <p><dfn data-dfn-type='type'>&lt;my-type&gt;</dfn> is defined a second time.</p>
+    `,
+    propertyName: 'warnings',
+    css: [{
+      msg: 'Duplicate definition',
+      name: '<my-type>',
+      type: 'type',
+      prose: '<my-type> is defined a second time.'
+    }]
+  },
+
+  {
+    title: 'issues a warning when a value is dangling',
+    html: `
+    <p>The <dfn data-dfn-type="value" data-dfn-for="my-property">dangling</dfn>
+    value is dangling.</p>
+    `,
+    propertyName: 'warnings',
+    css: [{
+      msg: 'Dangling value',
+      name: 'dangling',
+      for: 'my-property',
+      type: 'value',
+      value: 'dangling',
+      prose: 'The dangling value is dangling.'
+    }]
+  },
+
+  {
+    title: "issues a warning when a property is defined more than once and cannot be merged",
+    html: `
+      <table class="def propdef" data-link-for-hint="scrollbar-gutter"><tbody>
+       <tr>
+        <th>Name:
+        </th><td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-scrollbar-gutter">scrollbar-gutter</dfn>
+       </td></tr><tr class="value">
+        <th><a href="https://www.w3.org/TR/css-values/#value-defs">Value:</a>
+        </th><td class="prod">auto <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one">|</a> stable <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all" id="ref-for-comb-all">&amp;&amp;</a> mirror<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt">?</a>
+       </td></tr><tr>
+        <th><a href="https://www.w3.org/TR/css-cascade/#initial-values">Initial:</a>
+        </th><td>auto
+       </td></tr><tr>
+        <th>Applies to:
+        </th><td><a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container">scroll containers</a>
+       </td></tr><tr>
+        <th><a href="https://www.w3.org/TR/css-cascade/#inherited-property">Inherited:</a>
+        </th><td>no
+       </td></tr><tr>
+        <th><a href="https://www.w3.org/TR/css-values/#percentages">Percentages:</a>
+        </th><td>n/a
+       </td></tr><tr>
+        <th><a href="https://www.w3.org/TR/css-cascade/#computed">Computed value:</a>
+        </th><td>specified keyword(s)
+       </td></tr><tr>
+        <th>Canonical order:
+        </th><td>per grammar
+       </td></tr><tr>
+        <th><a href="https://www.w3.org/TR/web-animations/#animation-type">Animation type:</a>
+        </th><td>discrete
+        </td></tr>
+      </tbody></table>
+      <table class="def propdef partial" data-link-for-hint="scrollbar-gutter">
+       <tbody>
+        <tr>
+         <th>Name:
+         </th><td><a class="css" data-link-type="property" href="#propdef-scrollbar-gutter" id="ref-for-propdef-scrollbar-gutter①⓪">scrollbar-gutter</a>
+        </td></tr><tr class="value">
+         <th><a href="https://www.w3.org/TR/css-values/#value-defs">New values:</a>
+         </th><td class="prod">auto <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one①⓪">|</a> [ [ stable <span id="ref-for-comb-one①①">|</span> always ] <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-all" id="ref-for-comb-all①">&amp;&amp;</a> mirror<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt①">?</a> <span id="ref-for-comb-all②">&amp;&amp;</span> force<span id="ref-for-mult-opt②">?</span> ] <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-any" id="ref-for-comb-any">||</a> match-parent
+        </td></tr><tr>
+          <th><a href="https://www.w3.org/TR/css-cascade/#initial-values">Initial:</a>
+          </th><td>A different initial value
+         </td></tr><tr>
+         <th>Applies to:
+         </th><td><a href="https://www.w3.org/TR/css-pseudo/#generated-content" title="Includes ::before and ::after pseudo-elements.">all elements</a>
+        </td></tr>
+       </tbody>
+      </table>`,
+    propertyName: "warnings",
+    css: [{
+      msg: 'Unmergeable definition',
+      name: "scrollbar-gutter",
+      appliesTo: 'all elements',
+      initial: 'A different initial value',
+      newValues: 'auto | [ [ stable | always ] && mirror? && force? ] || match-parent'
+    }]
+  },
 ];
 
 describe("Test CSS properties extraction", function() {

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -545,14 +545,15 @@ const tests = [
 
   {
     title: "ignores comments",
-    html: `<pre class="prod">&lt;page-selector-list> = &lt;page-selector>#
+    html: `<pre class="prod">
+<dfn data-dfn-type="type">&lt;page-selector-list></dfn> = &lt;page-selector>#
 /* A comment */
-&lt;page-selector> = [ &lt;ident-token>? &lt;pseudo-page>* ]!
-&lt;pseudo-page> = ':' [ left | right | first | blank ] /* Another comment */
+<dfn data-dfn-type="type">&lt;page-selector></dfn> = [ &lt;ident-token>? &lt;pseudo-page>* ]!
+<dfn data-dfn-type="type">&lt;pseudo-page></dfn> = ':' [ left | right | first | blank ] /* Another comment */
 
 /* Yet another one
 that spans multiple lines */
-@top-left-corner = @top-left-corner { &lt;declaration-list> };
+<dfn data-dfn-type="at-rule">@top-left-corner</dfn> = @top-left-corner { &lt;declaration-list> };
 </pre>`,
     propertyName: "values",
     css: [

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -1105,6 +1105,46 @@ that spans multiple lines */
     `,
     propertyName: 'warnings',
     css: undefined
+  },
+
+  {
+    title: 'normalizes values ("−" to "-")',
+    html: `
+    <pre>
+      <dfn data-dfn-type="type">&lt;my-type&gt;</dfn> = none | oblique &lt;angle [−90deg,90deg]&gt;?
+    </pre>
+    `,
+    propertyName: 'values',
+    css: [{
+      name: '<my-type>',
+      type: 'type',
+      value: 'none | oblique <angle [-90deg,90deg]>?'
+    }]
+  },
+
+  {
+    title: 'normalizes values at a deeper level ("−" to "-")',
+    html: `
+    <pre>
+      <dfn data-dfn-type="type">&lt;my-type&gt;</dfn> = none | oblique &lt;angle [−90deg,90deg]&gt;?</dfn>
+    </pre>
+    <p>
+      The <dfn data-dfn-type="value" data-dfn-for="&lt;my-type&gt;">oblique &lt;angle [−90deg,90deg]&gt;?</dfn>
+      value is super.
+    </p>
+    `,
+    propertyName: 'values',
+    css: [{
+      name: '<my-type>',
+      type: 'type',
+      value: 'none | oblique <angle [-90deg,90deg]>?',
+      values: [{
+        name: 'oblique <angle [−90deg,90deg]>?',
+        type: 'value',
+        value: 'oblique <angle [-90deg,90deg]>?',
+        prose: 'The oblique <angle [−90deg,90deg]>? value is super.'
+      }]
+    }]
   }
 ];
 

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -33,8 +33,7 @@ const tests = [
       <th>Animation type: 
       </th><td>by computed value 
    </td></tr></tbody></table>`,
-   css: {
-    "background-color": {
+   css: [{
       "name": "background-color",
       "value": "<color>",
       "initial": "transparent",
@@ -43,8 +42,7 @@ const tests = [
       "percentages": "N/A",
       "computedValue": "computed color",
       "animationType": "by computed value"
-    }
-   }
+   }]
   },
   {title: "parses a propdef table with embedded MDN annotations",
    html: `<table class="def propdef" data-link-for-hint="align-content">
@@ -107,8 +105,7 @@ const tests = [
       <th><a href="https://www.w3.org/TR/web-animations/#animation-type">Animation type:</a>
       </th><td>discrete 
    </td></tr></tbody></table>`,
-   css: {
-     "align-content": {
+   css: [{
        "name": "align-content",
        "value": "normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position>",
        "initial": "normal",
@@ -118,8 +115,7 @@ const tests = [
        "computedValue": "specified keyword(s)",
        "canonicalOrder": "per grammar",
        "animationType": "discrete"
-     }
-   }
+   }]
   },
 
   {
@@ -152,45 +148,45 @@ const tests = [
         <th>Animation type:
         </th><td>by computed value
      </td></tr></tbody></table></div>`,
-    css: {}
+    css: []
   },
 
   {
-    title: "parses a valuespace prose definition",
+    title: "parses a type value definition",
     html: `<dl>
-    <dt><dfn class="css" data-dfn-for="text-indent" data-dfn-type="type" data-export="" id="valdef-text-indent-percentage">&lt;percentage&gt;<a class="self-link" href="#valdef-text-indent-percentage"></a></dfn> 
+    <dt><dfn class="css" data-dfn-type="type" data-export="" id="valdef-text-indent-percentage">&lt;percentage&gt;<a class="self-link" href="#valdef-text-indent-percentage"></a></dfn> 
     </dt><dd>
       Gives the amount of the indent
       as a percentage of the block container’s own <a data-link-type="dfn" href="https://drafts.csswg.org/css-writing-modes-4/#logical-width" id="ref-for-logical-width">logical width</a>. 
      <p>Percentages must be treated as <span class="css">0</span> for the purpose of calculating <a data-link-type="dfn" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution" id="ref-for-intrinsic-size-contribution">intrinsic size contributions</a>,
       but are always resolved normally when performing layout.</p>
     </dd></dl>`,
-    propertyName: "valuespaces",
-    css: {
-      "<percentage>": {
+    propertyName: "values",
+    css: [{
+        "name": "<percentage>",
+        "type": "type",
         "prose": "Gives the amount of the indent as a percentage of the block container’s own logical width. Percentages must be treated as 0 for the purpose of calculating intrinsic size contributions, but are always resolved normally when performing layout."
-      }
-    }
+    }]
   },
 
   {
-    title: "ignores a valuespace prose definition in an informative section",
+    title: "ignores a value definition in an informative section",
     html: `<div class="note"><dl>
-    <dt><dfn class="css" data-dfn-for="text-indent" data-dfn-type="value" data-export="" id="valdef-text-indent-percentage">&lt;percentage&gt;<a class="self-link" href="#valdef-text-indent-percentage"></a></dfn> 
+    <dt><dfn class="css" data-dfn-type="value" data-export="" id="valdef-text-indent-percentage">&lt;percentage&gt;<a class="self-link" href="#valdef-text-indent-percentage"></a></dfn> 
     </dt><dd>
       Gives the amount of the indent
       as a percentage of the block container’s own <a data-link-type="dfn" href="https://drafts.csswg.org/css-writing-modes-4/#logical-width" id="ref-for-logical-width">logical width</a>. 
      <p>Percentages must be treated as <span class="css">0</span> for the purpose of calculating <a data-link-type="dfn" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution" id="ref-for-intrinsic-size-contribution">intrinsic size contributions</a>,
       but are always resolved normally when performing layout.</p>
     </dd></dl></div>`,
-    propertyName: "valuespaces",
-    css: {}
+    propertyName: "values",
+    css: []
   },
 
   {
-    title: "parses a valuespace prose definition, excluding tests and notes",
+    title: "parses a value definition, excluding tests and notes",
     html: `<dl>
-    <dt><dfn class="css" data-dfn-for="text-indent" data-dfn-type="type" data-export="" id="valdef-text-indent-percentage">&lt;percentage&gt;<a class="self-link" href="#valdef-text-indent-percentage"></a></dfn> 
+    <dt><dfn class="css" data-dfn-type="type" data-export="" id="valdef-text-indent-percentage">&lt;percentage&gt;<a class="self-link" href="#valdef-text-indent-percentage"></a></dfn> 
     </dt><dd>
       Gives the amount of the indent
       as a percentage of the block container’s own <a data-link-type="dfn" href="https://drafts.csswg.org/css-writing-modes-4/#logical-width" id="ref-for-logical-width">logical width</a>. 
@@ -211,22 +207,22 @@ const tests = [
      <p class="note" role="note"><span>Note:</span> This can lead to the element overflowing.
       It is not recommended to use percentage indents and intrinsic sizing together.</p>
     </dd></dl>`,
-    propertyName: "valuespaces",
-    css: {
-      "<percentage>": {
+    propertyName: "values",
+    css: [{
+        "name": "<percentage>",
+        "type": "type",
         "prose": "Gives the amount of the indent as a percentage of the block container’s own logical width. Percentages must be treated as 0 for the purpose of calculating intrinsic size contributions, but are always resolved normally when performing layout."
-      }
-    }
+    }]
   },
 
   {
-    title: "parses a valuespace prose definition, excluding subsections",
+    title: "parses a type definition, excluding subsections",
     html: `<dl>
-     <dt data-md=""><dfn class="css" data-dfn-for="ray()" data-dfn-type="type" data-export="" id="valdef-ray-size">&lt;size&gt;<a class="self-link" href="#valdef-ray-size"></a></dfn>
+     <dt data-md=""><dfn class="css" data-dfn-type="type" data-export="" id="valdef-ray-size">&lt;size&gt;<a class="self-link" href="#valdef-ray-size"></a></dfn>
       </dt><dd data-md="">
        <p>Decides the path length used when <a class="property" data-link-type="propdesc" href="#propdef-offset-distance" id="ref-for-propdef-offset-distance②">offset-distance</a> is expressed as a percentage, using the distance to the containing box. For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-size" id="ref-for-typedef-size①" title="Expands to: <length-percentage>{2} | <length> | closest-corner | closest-side | farthest-corner | farthest-side | sides">&lt;size&gt;</a> values other than <a href="#size-sides" id="ref-for-size-sides">sides</a>, the path length is independent of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" id="ref-for-angle-value④" title="Expands to: deg | grad | rad | turn">&lt;angle&gt;</a>.</p>
        <p>It is defined as:</p>
-       <p>&nbsp;<b>&lt;size&gt;</b> = [ closest-side | closest-corner | farthest-side | farthest-corner | sides ]</p>
+       <pre class="prod">&nbsp;<b>&lt;size&gt;</b> = [ closest-side | closest-corner | farthest-side | farthest-corner | sides ]</pre>
        <dl>
         <dt data-md=""><dfn class="dfn-paneled css" data-dfn-for="<size>" data-dfn-type="value" data-export="" id="size-closest-side">closest-side</dfn>
         </dt><dd data-md="">
@@ -245,17 +241,50 @@ const tests = [
          <p>The distance is measured between the initial position and the intersection of the ray with the box. If the initial position is not within the box, the distance is 0.</p>
        </dd></dl>
       </dd></dl>`,
-    propertyName: "valuespaces",
-    css: {
-      "<size>": {
-        "prose": "Decides the path length used when offset-distance is expressed as a percentage, using the distance to the containing box. For <size> values other than sides, the path length is independent of <angle>. It is defined as: <size> = [ closest-side | closest-corner | farthest-side | farthest-corner | sides ]"
-      }
-    }
+    propertyName: "values",
+    css: [{
+        "name": "<size>",
+        "type": "type",
+        "value": "[ closest-side | closest-corner | farthest-side | farthest-corner | sides ]",
+      "type": "type",
+      "values": [
+        {
+          "name": "closest-side",
+          "prose": "The perpendicular distance is measured between the initial position and the closest side of the box from it.",
+          "value": "closest-side",
+          "type": "value"
+        },
+        {
+          "name": "closest-corner",
+          "prose": "The distance is measured between the initial position and the closest corner of the box from it.",
+          "value": "closest-corner",
+          "type": "value"
+        },
+        {
+          "name": "farthest-side",
+          "prose": "The perpendicular distance is measured between the initial position and the farthest side of the box from it.",
+          "value": "farthest-side",
+          "type": "value"
+        },
+        {
+          "name": "farthest-corner",
+          "prose": "The distance is measured between the initial position and the farthest corner of the box from it.",
+          "value": "farthest-corner",
+          "type": "value"
+        },
+        {
+          "name": "sides",
+          "prose": "The distance is measured between the initial position and the intersection of the ray with the box. If the initial position is not within the box, the distance is 0.",
+          "value": "sides",
+          "type": "value"
+        }
+      ]
+    }]
   },
 
 
   {
-    title: "ignores a valuespace definition when data-dfn-type is not correct",
+    title: "ignores a value definition when data-dfn-type is not correct",
     html: `<div class="note"><dl>
     <dt><dfn class="css" data-dfn-type="value">value</dfn></dt>
     <dd>Value</dd>
@@ -264,13 +293,15 @@ const tests = [
     <dt><dfn class="css" data-dfn-type="at-rule">at-rule</dfn></dt>
     <dd>Selector</dd>
     </dl></div>`,
-    propertyName: "valuespaces",
-    css: {}
+    propertyName: "values",
+    css: []
   },
 
   {
     title: "knows that second definition of rgb() is legacy",
     html: `
+      <p>The <dfn data-dfn-type="function">rgb()</dfn> function has a
+      legacy value.</p>
       <pre class="prod">
         &lt;rgb()> = rgb( modern )
       </pre>
@@ -278,18 +309,20 @@ const tests = [
         &lt;rgb()> = rgb( legacy )
       </pre>
     `,
-    propertyName: "valuespaces",
-    css: {
-      "<rgb()>": {
+    propertyName: "values",
+    css: [{
+        "name": "rgb()",
+        "type": "function",
+        "prose": "The rgb() function has a legacy value.",
         "value": "rgb( modern )",
         "legacyValue": "rgb( legacy )"
-      }
-    }
+    }]
   },
 
   {
     title: "extracts an at-rule syntax",
     html: `
+      <dfn data-dfn-type="at-rule">@layer</dfn> is an at-rule.
       <pre class="prod">
         @layer <a class="production">&lt;layer-name&gt;</a>? {
           <a class="production">&lt;stylesheet&gt;</a>
@@ -297,17 +330,16 @@ const tests = [
       </pre>
     `,
     propertyName: "atrules",
-    css: {
-      "@layer": {
-        "value": "@layer <layer-name>? { <stylesheet> }",
-        "descriptors": []
-      }
-    }
+    css: [{
+        "name": "@layer",
+        "value": "@layer <layer-name>? { <stylesheet> }"
+    }]
   },
 
   {
     title: "extracts an at-rule syntax with multiple definitions",
     html: `
+      <dfn data-dfn-type="at-rule">@layer</dfn> is an at-rule.
       <pre class="prod">
         @layer <a class="production">&lt;layer-name&gt;</a>? {
           <a class="production">&lt;stylesheet&gt;</a>
@@ -318,12 +350,10 @@ const tests = [
       </pre>
     `,
     propertyName: "atrules",
-    css: {
-      "@layer": {
-        "value": "@layer <layer-name>? { <stylesheet> } | @layer <layer-name>#;",
-        "descriptors": []
-      }
-    }
+    css: [{
+        "name": "@layer",
+        "value": "@layer <layer-name>? { <stylesheet> } | @layer <layer-name>#;"
+    }]
   },
 
   {
@@ -351,8 +381,8 @@ const tests = [
      </td></tr></tbody></table>
     `,
     propertyName: "atrules",
-    css: {
-      "@font-face": {
+    css: [{
+        "name": "@font-face",
         "value": "@font-face { <declaration-list> }",
         "descriptors": [
           {
@@ -362,8 +392,7 @@ const tests = [
             value: "auto | block | swap | fallback | optional"
           }
         ]
-      }
-    }
+    }]
   },
 
 
@@ -401,8 +430,9 @@ const tests = [
       </th><td>auto
    </td></tr></tbody></table>`,
     propertyName: "atrules",
-    css: {
-      "@font-face": {
+    css: [
+      {
+        "name": "@font-face",
         "descriptors": [
           {
             for: "@font-face",
@@ -412,7 +442,8 @@ const tests = [
           }
         ]
       },
-      "@font-feature-values": {
+      {
+        "name": "@font-feature-values",
         "descriptors": [
           {
             for: "@font-feature-values",
@@ -422,7 +453,7 @@ const tests = [
           }
         ]
       }
-    }
+    ]
   },
 
 
@@ -476,7 +507,7 @@ const tests = [
         </td></tr>
        </tbody>
       </table>`,
-    error: 'More than one dfn found for CSS property \"scrollbar-gutter\" and dfns cannot be merged'
+    error: 'More than one CSS dfn found for \"scrollbar-gutter\" and dfns cannot be merged'
   },
 
 
@@ -509,7 +540,7 @@ const tests = [
         <th>Animation type:
         </th><td>by computed value
      </td></tr></tbody></table>`,
-    css: {}
+    css: []
   },
 
   {
@@ -523,36 +554,42 @@ const tests = [
 that spans multiple lines */
 @top-left-corner = @top-left-corner { &lt;declaration-list> };
 </pre>`,
-    propertyName: "valuespaces",
-    css: {
-      "<page-selector-list>": {
+    propertyName: "values",
+    css: [
+      {
+        name: "<page-selector-list>",
+        type: "type",
         value: "<page-selector>#"
       },
-      "<page-selector>": {
+      {
+        name: "<page-selector>",
+        type: "type",
         value: "[ <ident-token>? <pseudo-page>* ]!"
       },
-      "<pseudo-page>": {
+      {
+        name: "<pseudo-page>",
+        type: "type",
         value: "':' [ left | right | first | blank ]"
       }
-    }
+    ]
   },
 
   {
     title: "parses syntax value preferably",
     html: `<div>
       <p>
-        <dfn data-dfn-type="function" data-lt="&lt;toto()>">&lt;toto(A)></dfn> is a super function.</dfn>
+        <dfn data-dfn-type="function" data-lt="toto()">&lt;toto(A)></dfn> is a super function.</dfn>
       </p>
       <pre class="prod"><code>
         &lt;toto()> = toto( &lt;integer> )
       </code></pre>`,
-    propertyName: "valuespaces",
-    css: {
-      "<toto()>": {
+    propertyName: "values",
+    css: [{
+        name: "toto()",
+        type: "function",
         prose: "<toto(A)> is a super function.",
         value: "toto( <integer> )"
-      }
-    }
+    }]
   },
 
   {
@@ -569,21 +606,29 @@ that spans multiple lines */
         <dfn data-dfn-type="type">&lt;same-level&gt;</dfn> = &lt;other-at-same-level&gt;
         <br/>
         <dfn data-dfn-type="type">&lt;other-at-same-level&gt;</dfn> = foo`,
-    propertyName: "valuespaces",
-    css: {
-      "<step-easing-function>": {
+    propertyName: "values",
+    css: [
+      {
+        name: "<step-easing-function>",
+        type: "type",
         value: "step-start | step-end | steps(<integer>[, <step-position>]?)"
       },
-      "<step-position>": {
+      {
+        name: "<step-position>",
+        type: "type",
         value: "jump-start | jump-end | jump-none | jump-both | start | end"
       },
-      "<same-level>": {
+      {
+        name: "<same-level>",
+        type: "type",
         value: "<other-at-same-level>"
       },
-      "<other-at-same-level>": {
+      {
+        name: "<other-at-same-level>",
+        type: "type",
         value: "foo"
       }
-    }
+    ]
   },
 
   {
@@ -594,15 +639,19 @@ that spans multiple lines */
         <br/>
         <dfn data-dfn-type="type">&lt;also-equal&gt;</dfn> = '=' | equal
       </div>`,
-    propertyName: "valuespaces",
-    css: {
-      "<equal>": {
+    propertyName: "values",
+    css: [
+      {
+        name: "<equal>",
+        type: "type",
         value: "equal | '='"
       },
-      "<also-equal>": {
+      {
+        name: "<also-equal>",
+        type: "type",
         value: "'=' | equal"
       }
-    }
+    ]
   },
 
   {
@@ -615,12 +664,12 @@ that spans multiple lines */
         as per the following logarithmic equation:
         volume(dB) = 20 × log10(<var>a1</var> / <var>a0</var>).</p>
       </div>`,
-    propertyName: "valuespaces",
-    css: {
-      "<decibel>": {
+    propertyName: "values",
+    css: [{
+        name: "<decibel>",
+        type: "type",
         prose: "The <decibel> type denotes a dimension with a \"dB\" (decibel unit) unit identifier. Decibels represent the ratio of the squares of the new signal amplitude a1 and the current amplitude a0, as per the following logarithmic equation: volume(dB) = 20 × log10(a1 / a0)."
-      }
-    }
+    }]
   }
 ];
 

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -625,14 +625,19 @@ that spans multiple lines */
     title: "parses selectors definitions",
     html: `
     <p>
-      The <dfn data-dfn-type="selector">:open</dfn> pseudo-class represents an
+      The <dfn data-dfn-type="selector" data-export>:open</dfn> pseudo-class represents an
       element that has both “open” and “closed” states, and which is currently
       in the “open” state.
     </p>
     <p>
-      The <dfn data-dfn-type="selector">:closed</dfn> pseudo-class represents an
+      The <dfn data-dfn-type="selector" data-export>:closed</dfn> pseudo-class represents an
       element that has both “open” and “closed” states, and which is currently
       in the “closed” state.
+    </p>
+    <p>
+      The <dfn data-dfn-type="selector">:schrödinger</dfn> internal pseudo-class represents an
+      element that has both “open” and “closed” states, and which is currently
+      in an undetermined state.
     </p>
     `,
     propertyName: "selectors",


### PR DESCRIPTION
The CSS extraction logic was grounded on production rules, did not include possible values of a property, did not know how to deal with functions and types that are namespaced to a property or to another type, and did not include selectors. Also, likely anomalies in the spec were reported to the console but not in the extract itself.

This update changes all of that:
- Selectors are now reported under a `selectors` property at the root level.
- Possible values that some definition may take are now reported under a `values` property directly within the definition.
- Functions and types that are namespaced to some other definition are included in the list of `values` of that definition.
- Anomalies detected in the spec are now reported under a `warnings` property at the root of the extract. Four types of anomalies are reported:
  1. **Missing definition**: when a production rule was found but when the spec does not include a corresponding `<dfn>` (or when that `<dfn>` does not have a `data-dfn-type` attribute that identifies a CSS construct)
  2. **Duplicate definition**: when the spec defines the same term twice.
  3. **Unmergeable definition**: when the spec defines the same property twice and both definitions cannot be merged.
  4. **Dangling value**: when the spec defines a CSS "value" definition (`value`, `function` or `type`) for something and that something cannot be found in the spec

**Breaking changes** along the way:
1. Arrays are now used throughout instead of indexed objects because that's easier to deal with in code. It is easy to create an index from an array in JavaScript if someone needs it.
2. Function names are no longer enclosed in `<` and `>` because they are not defined in specs with these characters (as opposed to types). Beware though, references to functions in value syntax do use enclosing `<` and `>` characters.
3. The property `valuespaces` at the root level was replaced with a `values` property (and an array is also used there). This `values` property lists both `function` and `type` definitions that are not namespaced to anything in particular. There are no `value` definitions at the root level because `value` definitions are always namespaced to some other definition. And yes, naming is hard.

Some additional non-breaking changes:
- To distinguish between `function`, `type` and `value` definitions listed in a `values` property, definitions that appear in a `values` property have a `type` property.
- Only namespaced values associated with a definition are listed under its `values` property. Non-namespaced values are not. For instance, `<quote>` is not listed as a value of the `<content-list>` type, even though its value syntax references it. This avoids duplicating constructs in the extracts.
- Values are only listed under the deepest definition to which they apply. For instance, `open-quote` is only listed as a value of `<quote>` but neither as a value of the `<content-list>` type that references `<quote>` nor as a value of the `content` property that references `<content-list>`. This is also to avoid duplicating constructs in the extracts.
- Some of the extracts contain things that may look weird at first, but that's because the spec itself is weird. For instance, [CSS Will change](https://drafts.csswg.org/css-will-change-1/) defines a [`<custom-ident>`](https://drafts.csswg.org/css-will-change-1/#valdef-will-change-custom-ident) `value` construct whose actual value is the `<custom-ident>` `type` construct defined in CSS Values. Having both a namespaced `value` and a non-namespaced `<type>` is somewhat common in CSS specs.

Tests and schema were adjusted to the new structure and new tests were added to test values, selectors and warnings.

To validate the code, I wrote a small conversion script that takes the new structure, generates the "legacy" one out of it, and compares the result with a crawl result. See below for the code. I reviewed the differences. As far as I can tell, they are all net improvements:
- New extract files get generated now that the selectors are also extracted (e.g. `css-nesting-1`, `css-pseudo-4`, `css-scoping-1`).
- Namespaced values that used to be reported as global "valuespaces" are now properly reported under the property, at-rule, selector, descriptor, type or function for which they are valid.
- Some type and function declarations for which a proper definition is missing are now reported as warnings.

<details>
  <summary>Conversion script</summary>

  ```js
  const path = require('path');
  const fs = require('fs').promises;
  const assert = require('node:assert').strict;

  // To be adjusted to local context!
  const sourceFolder = path.join(__dirname, 'reports', 'ed', 'css');
  const legacyFolder = path.join(__dirname, '..', 'webref', 'ed', 'css');

  function convertDescriptor(desc) {
    const res = Object.assign({}, desc);
    if (res.values) {
      delete res.values;
    }
    return res;
  }

  function convertProperty(prop) {
    const res = Object.assign({}, prop);
    if (res.values) {
      delete res.values;
    }
    return res;
  }

  function convertAtrule(rule) {
    const res = Object.assign({}, rule);
    delete res.name;
    if (res.values) {
      delete res.values;
    }
    if (res.descriptors) {
      res.descriptors = res.descriptors.map(convertDescriptor);
    }
    if (res.prose && res.value) {
      delete res.prose;
    }
    return res;
  }

  function convertValue(value) {
    const res = Object.assign({}, value);
    delete res.name;
    delete res.type;
    if (res.values) {
      delete res.values;
    }
    return res;
  }

  function convert(extract) {
    const res = {
      spec: extract.spec,
      properties: {},
      atrules: {},
      valuespaces: {}
    };

    for (const prop of extract.properties) {
      res.properties[prop.name] = convertProperty(prop);
    }

    for (const rule of extract.atrules) {
      res.atrules[rule.name] = convertAtrule(rule);
    }

    for (const value of extract.values) {
      const name = value.name.startsWith('<') ? value.name : `<${value.name}>`;
      res.valuespaces[name] = convertValue(value);
    }

    return res;
  }

  async function readFiles(folder) {
    const res = {};
    const files = await fs.readdir(folder);
    for (const f of files) {
      if (f.endsWith('.json') && f !== 'package.json') {
        const text = await fs.readFile(path.join(folder, f), 'utf8');
        res[path.basename(f, '.json')] = JSON.parse(text);
      }
    }
    return res;
  }

  async function main() {
    const source = await readFiles(sourceFolder);
    const converted = {};
    for (const [filename, extract] of Object.entries(source)) {
      converted[filename] = convert(extract);
    }

    const legacy = await readFiles(legacyFolder);

    for (const shortname of Object.keys(converted)) {
      try {
        assert(legacy[shortname], `"${shortname}" not in legacy result`);
      }
      catch (err) {
        console.log(converted[shortname].spec.url, err.message);
      }
    }

    for (const shortname of Object.keys(legacy)) {
      try {
        assert(converted[shortname], `"${shortname}" not in new result`);
      }
      catch (err) {
        console.log(legacy[shortname].spec.url, err.message);
      }
    }

    for (const [shortname, extract] of Object.entries(converted)) {
      if (legacy[shortname]) {
        try {
          assert.deepEqual(extract, legacy[shortname]);
        }
        catch (err) {
          console.log(`\n${shortname}\n${extract.spec.url}\n`, err.message);
        }
      }
    }
  }

  main();
  ```
</details>

<details>
  <summary>Example of a new extract: CSS View Transitions Module Level 1</summary>

  ```json
  {
    "spec": {
      "title": "CSS View Transitions Module Level 1",
      "url": "https://drafts.csswg.org/css-view-transitions-1/"
    },
    "properties": [
      {
        "name": "view-transition-name",
        "value": "none | <custom-ident>",
        "initial": "none",
        "appliesTo": "all elements",
        "inherited": "no",
        "percentages": "n/a",
        "computedValue": "as specified",
        "canonicalOrder": "per grammar",
        "animationType": "discrete",
        "values": [
          {
            "name": "none",
            "prose": "The element will not participate in a view transition.",
            "type": "value",
            "value": "none"
          },
          {
            "name": "<custom-ident>",
            "prose": "The element can participate in a view transition, as either an old or new element, with a view transition name equal to the <custom-ident>'s value.",
            "type": "value",
            "value": "<custom-ident>"
          }
        ],
        "styleDeclaration": [
          "view-transition-name",
          "viewTransitionName"
        ]
      }
    ],
    "atrules": [],
    "selectors": [
      {
        "name": "::view-transition",
        "prose": "This pseudo-element is the grouping container of all the other view-transition pseudo-elements. Its originating element is the document’s document element. The following user-agent origin styles apply to this element: html::view-transition { position: fixed; inset: 0; }"
      },
      {
        "name": "::view-transition-group( <pt-name-selector> )",
        "prose": "One of these pseudo-elements exists for each view-transition-name in a view transition, and holds the rest of the pseudo-elements corresponding to this view-transition-name. Its originating element is the ::view-transition pseudo-element. The following user-agent origin styles apply to this element: html::view-transition-group(*) { position: absolute; top: 0; left: 0; animation-duration: 0.25s; animation-fill-mode: both; } The selector for this and subsequently defined pseudo-elements is likely to change to indicate position in the pseudo-tree hierarchy."
      },
      {
        "name": "::view-transition-image-pair( <pt-name-selector> )",
        "prose": "One of these pseudo-elements exists for each view-transition-name being in a view transition, and holds the images of the old and new elements. Its originating element is the ::view-transition-group() pseudo-element with the same transition-name. The following user-agent origin styles apply to this element: html::view-transition-image-pair(*) { position: absolute; inset: 0; animation-duration: inherit; animation-fill-mode: inherit; } In addition to above, styles in the user-agent origin add isolation: isolate to this pseudo-element if it has both ::view-transition-new() and ::view-transition-old() as children. Isolation is only necessary to get the right cross-fade between new and old image pixels. Would it be simpler to always add it and try to optimize in the implementation?"
      },
      {
        "name": "::view-transition-old( <pt-name-selector> )",
        "prose": "One of these pseudo-elements exists for each element in the old DOM being animated by the view transition, and is a replaced element displaying the old element’s snapshot image. It has natural dimensions equal to the snapshot’s size. Its originating element is the ::view-transition-image-pair() pseudo-element with the same transition-name. The following user-agent origin styles apply to this element: html::view-transition-old(*) { position: absolute; inset-block-start: 0; inline-size: 100%; block-size: auto; animation-duration: inherit; animation-fill-mode: inherit; } In addition to above, styles in the user-agent origin add mix-blend-mode: plus-lighter to this pseudo element if the ancestor ::view-transition-image-pair() has both ::view-transition-new() and ::view-transition-old() as descendants. Additional user-agent origin styles added to animate these pseudo-elements are detailed in Animate a view transition."
      },
      {
        "name": "::view-transition-new( <pt-name-selector> )",
        "prose": "Identical to ::view-transition-old(), except it deals with the new element instead."
      }
    ],
    "values": [
      {
        "name": "<pt-name-selector>",
        "type": "type",
        "value": "'*' | <custom-ident>"
      }
    ]
  }
  ```
</details>

Note Webref and tools that process `@webref/css` contents will need to be adjusted to process the new structure (for Webref, the de-deduplication logic needs to be re-visited and the description of the package should be updated).