### PR TITLE
Auto-legacy mode for dfns extraction

### DIFF
--- a/src/lib/nock-server.js
+++ b/src/lib/nock-server.js
@@ -32,7 +32,7 @@ const mockSpecs = {
     html: `
       <title>WOFF2</title>
       <body>
-        <dfn id='foo'>Foo</dfn>
+        <dfn id='foo' data-dfn-type="dfn">Foo</dfn>
         <a href="https://www.w3.org/TR/bar/#baz">bar</a>
         <ul class='toc'><li><a href='page.html'>page</a></ul>`,
     pages: {

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -96,16 +96,16 @@ const baseDfn = {
 };
 const tests = [
   {title: "parses a simple <dfn>",
-   html: "<dfn id='foo'>Foo</dfn>",
+   html: "<dfn id='foo' data-dfn-type='dfn'>Foo</dfn>",
    changesToBaseDfn: [{}]
   },
   {title: "normalizes whitespace and trims text in a simple <dfn>",
-   html: "<dfn id='foo'>Foo\n    \n</dfn>",
+   html: "<dfn id='foo' data-dfn-type='dfn'>Foo\n    \n</dfn>",
    changesToBaseDfn: [{}]
   },
 
   {title: "ignores a <dfn> without an id",
-   html: "<dfn>Foo</dfn>",
+   html: "<dfn data-dfn-type='dfn'>Foo</dfn>",
    changesToBaseDfn: []
   },
   {title: "marks as public a <dfn data-export>",
@@ -121,7 +121,7 @@ const tests = [
    changesToBaseDfn: [{type: 'interface'}]
   },
   {title: "detects informative definitions",
-   html: "<div class=informative><dfn id=foo>Foo</dfn></div>",
+   html: "<div class=informative><dfn id=foo data-dfn-type='dfn'>Foo</dfn></div>",
    changesToBaseDfn: [{informative: true}]
   },
   {title: "associates a definition to a namespace",
@@ -141,11 +141,11 @@ const tests = [
    changesToBaseDfn: []
   },
   {title: "uses text in data-lt as linking text",
-   html: "<dfn data-lt='foo \n   |\nbar' id=foo>Foo</dfn>",
+   html: "<dfn data-lt='foo \n   |\nbar' id=foo data-dfn-type='dfn'>Foo</dfn>",
    changesToBaseDfn: [{linkingText: ["foo", "bar"]}]
   },
   {title: "includes data-lt in its list of linking text",
-   html: "<dfn data-lt='foo \n   |\nbar' id=foo>Foo</dfn>",
+   html: "<dfn data-lt='foo \n   |\nbar' id=foo data-dfn-type='dfn'>Foo</dfn>",
    changesToBaseDfn: [{linkingText: ["foo", "bar"]}]
   },
   {title: "ignores dfns with an invalid data-dfn-type",
@@ -153,7 +153,7 @@ const tests = [
    changesToBaseDfn: []
   },
   {title: "ignores dfns already defined",
-   html: "<dfn id='foo'>Foo</dfn>. <dfn id='foo2'>Foo</dfn> is already defined.",
+   html: "<dfn id='foo' data-dfn-type='dfn'>Foo</dfn>. <dfn id='foo2'>Foo</dfn> is already defined.",
    changesToBaseDfn: [{}]
   },
   {title: "automatically fixes internal slots dfns with an invalid 'idl' data-dfn-type",
@@ -265,7 +265,7 @@ const tests = [
     spec: "ecmascript"
   },
   {title: "handles HTML spec conventions of definitions in headings",
-   html: '<h6 id="parsing-main-inselect"><span class="secno">12.2.6.4.16</span> The "<dfn>in select</dfn>" insertion mode<a href="#parsing-main-inselect" class="self-link"></a></h6>',
+   html: '<h6 id="parsing-main-inselect"><span class="secno">12.2.6.4.16</span> The "<dfn data-noexport>in select</dfn>" insertion mode<a href="#parsing-main-inselect" class="self-link"></a></h6>',
    changesToBaseDfn: [{id: "parsing-main-inselect",
            linkingText: ["in select"],
            heading: { id: "parsing-main-inselect", href: "about:blank#parsing-main-inselect", title: "The \"in select\" insertion mode", number: "12.2.6.4.16"},


### PR DESCRIPTION
Dfns extraction expected specs to always follow the data definitions model specified in Bikeshed's documentation. Older specs don't follow that model. Terms they define are still extracted but with a `private` access level.

This update makes the code peak at all definitions found in the spec. When some definition has a `data-dfn-type` attribute or some other attribute directly related to the data definitions model, extraction proceeds as before. When no definition has any of these attributes, the "legacy" extraction mode is activated and all extracted definitions are considered to be "public".

This makes a few existing dfns public that used to be private for specs such as TC39 specs, css-page-4 (see below for details), but that is precisely what we want!

This would fix #1117 the lazy way, meaning without introducing extra crawling options ;)

<details>
  <summary>css-page-4 - https://drafts.csswg.org/css-page-4/</summary>

  ```diff
  Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  {
    dfns: [
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
...
      url: 'https://drafts.csswg.org/css-page-4/'
    }
  }
  ```
</details>
<details>
  <summary>css-style-attr - https://drafts.csswg.org/css-style-attr/</summary>

  ```diff
  Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  {
    dfns: [
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'dt',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'dt',
...
      url: 'https://drafts.csswg.org/css-style-attr/'
    }
  }
  ```
</details>
<details>
  <summary>ecma-402 - https://tc39.es/ecma402/</summary>

  ```diff
  Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  {
    dfns: [
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
...
      url: 'https://tc39.es/ecma402/'
    }
  }
  ```
</details>
<details>
  <summary>html - https://html.spec.whatwg.org/multipage/</summary>

  ```diff
  Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  {
    dfns: [
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
        for: [],
        heading: {
+         href: 'https://html.spec.whatwg.org/multipage/infrastructure.html#parallelism',
+         id: 'parallelism',
+         number: '2.1.1',
+         title: 'Parallelism'
-         href: 'https://html.spec.whatwg.org/multipage/introduction.html#typographic-conventions',
-         id: 'typographic-conventions',
-         number: '1.9.2',
-         title: 'Typographic conventions'
        },
+       href: 'https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel',
+       id: 'in-parallel',
-       href: 'https://html.spec.whatwg.org/multipage/introduction.html#x-that',
-       id: 'x-that',
        informative: false,
        linkingText: [
+         'in parallel'
-         'this'
        ],
        localLinkingText: [],
        type: 'dfn'
      },
      {
+       access: 'private',
-       access: 'public',
        definedIn: 'prose',
        for: [],
...
          title: 'Parallelism'
        },
+       href: 'https://html.spec.whatwg.org/multipage/infrastructure.html#immediately',
+       id: 'immediately',
-       href: 'https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel',
-       id: 'in-parallel',
        informative: false,
        linkingText: [
+         'immediately'
-         'in parallel'
        ],
        localLinkingText: [],
        type: 'dfn'
      },
      {
+       access: 'public',
...
-       access: 'private',
...
  ```
</details>
<details>
  <summary>rfc7231 - https://httpwg.org/specs/rfc7231.html</summary>

  ```diff
  Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  {
    dfns: [
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
...
      url: 'https://httpwg.org/specs/rfc7231.html'
    }
  }
  ```
</details>
<details>
  <summary>rfc9110 - https://httpwg.org/specs/rfc9110.html</summary>

  ```diff
  Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  {
    dfns: [
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
...
      url: 'https://httpwg.org/specs/rfc9110.html'
    }
  }
  ```
</details>
<details>
  <summary>svg-integration - https://svgwg.org/specs/integration/</summary>

  ```diff
  Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  {
    dfns: [
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'dt',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'dt',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'dt',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'dt',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'dt',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'dt',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
...
      url: 'https://svgwg.org/specs/integration/'
    }
  }
  ```
</details>
<details>
  <summary>svg-strokes - https://svgwg.org/specs/strokes/</summary>

  ```diff
  Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  {
    dfns: [
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'table',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'table',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'table',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'table',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'table',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'table',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'table',
        for: [],
...
      },
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'table',
        for: [],
...
      },
      {
+       access: 'public',
...
-       access: 'private',
...
  ```
</details>
<details>
  <summary>SVG2 - https://svgwg.org/svg2-draft/</summary>

  ```diff
  Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  {
    dfns: [
...
      },
      {
+       access: 'public',
+       definedIn: 'table',
+       for: [
+         'SVGLength'
+       ],
+       heading: {
+         href: 'https://svgwg.org/svg2-draft/types.html#InterfaceSVGLength',
+         id: 'InterfaceSVGLength',
+         number: '4.5.2',
+         title: 'Interface SVGLength'
+       },
+       href: 'https://svgwg.org/svg2-draft/types.html#__svg__SVGLength__SVG_LENGTHTYPE_NUMBER',
+       id: '__svg__SVGLength__SVG_LENGTHTYPE_NUMBER',
+       informative: false,
+       linkingText: [
+         'SVG_LENGTHTYPE_NUMBER'
+       ],
+       localLinkingText: [],
+       type: 'const'
+     },
+     {
+       access: 'public',
+       definedIn: 'table',
+       for: [
...
-       access: 'private',
-       definedIn: 'prose',
-       for: [],
-       heading: {
-         href: 'https://svgwg.org/svg2-draft/types.html#InterfaceSVGLength',
-         id: 'InterfaceSVGLength',
-         number: '4.5.2',
-         title: 'Interface SVGLength'
-       },
-       href: 'https://svgwg.org/svg2-draft/types.html#LengthValue',
-       id: 'LengthValue',
-       informative: false,
-       linkingText: [
-         'value'
-       ],
-       localLinkingText: [],
-       type: 'dfn'
-     },
-     {
-       access: 'public',
-       definedIn: 'table',
-       for: [
-         'SVGLength'
-       ],
...
  ```
</details>
<details>
  <summary>tc39-decorators - https://tc39.es/proposal-decorators/</summary>

  ```diff
  Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  {
    dfns: [
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
...
      url: 'https://tc39.es/proposal-decorators/'
    }
  }
  ```
</details>
<details>
  <summary>tc39-import-assertions - https://tc39.es/proposal-import-assertions/</summary>

  ```diff
  Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  {
    dfns: [
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
...
      url: 'https://tc39.es/proposal-import-assertions/'
    }
  }
  ```
</details>
<details>
  <summary>tc39-intl-enumeration - https://tc39.es/proposal-intl-enumeration/</summary>

  ```diff
  Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  {
    dfns: [
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
...
      url: 'https://tc39.es/proposal-intl-enumeration/'
    }
  }
  ```
</details>
<details>
  <summary>tc39-intl-numberformat - https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html</summary>

  ```diff
  Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  {
    dfns: [
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
...
      url: 'https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html'
    }
  }
  ```
</details>
<details>
  <summary>tc39-shadowrealm - https://tc39.es/proposal-shadowrealm/</summary>

  ```diff
  Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  {
    dfns: [
      {
+       access: 'public',
-       access: 'private',
        definedIn: 'prose',
...
      url: 'https://tc39.es/proposal-shadowrealm/'
    }
  }
  ```
</details>

