### PR TITLE
CSS extracts: handle dfns with multiple linking texts

### DIFF
--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -1165,6 +1165,29 @@ that spans multiple lines */
         prose: 'The ::prefix represents the preceding punctuation of the ::first-letter element.'
       }]
     }]
+  },
+
+  {
+    title: 'extracts right linking text for a "type" definition',
+    html: `
+    <p><dfn data-dfn-type="type" data-lt="identifiers|<identifier>" data-export>Identifiers</dfn>
+    are a fantastic type.</p>
+    `,
+    propertyName: 'values',
+    css: [{
+      name: '<identifier>',
+      type: 'type',
+      prose: 'Identifiers are a fantastic type.'
+    }]
+  },
+
+  {
+    title: 'throws when definition defines multiple linking texts without any obvious one',
+    html: `
+    <p><dfn data-dfn-type="type" data-lt="a|b|c" data-export>ABC</dfn>, it's
+    easy.</p>
+    `,
+    error: 'Found multiple linking texts for dfn without any obvious one: a, b, c'
   }
 ];
 


### PR DESCRIPTION
Via https://github.com/w3c/webref/issues/808

CSS 2 defines the `<identifier>` type with both a prose linking text `identifiers` and the syntax linking text `<identifier>`. The code was not expecting that and extracted `identifiers|<identifier>` as a result.

The code now extracts the linking text that looks like syntax if there is more than one linking text defined. If none is found, the extraction currently throws an error (to mean "case not supported yet"). We may want to be smarter about this in the future... if that ever happens.