### PR TITLE
CSS extracts: handle function dfns on right hand side of production rules

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -586,6 +586,7 @@ const extractTypedDfn = dfn => {
   const dfnType = dfn.getAttribute('data-dfn-type');
   const dfnFor = dfn.getAttribute('data-dfn-for');
   const parent = dfn.parentNode.cloneNode(true);
+  const fnRegExp = /^([a-zA-Z_][a-zA-Z0-9_\-]+)\([^\)]+\)$/;
 
   // Remove note references as in:
   // https://drafts.csswg.org/css-syntax-3/#the-anb-type
@@ -611,8 +612,8 @@ const extractTypedDfn = dfn => {
       // side of a production rule, as in the definition of "linear()" in
       // css-easing-2: https://drafts.csswg.org/css-easing-2/#funcdef-linear
       // In such a case, we still want to extract the function parameters
-      if (dfn.textContent.trim().match(/^[a-zA-Z_][a-zA-Z0-9_\-]+\([^\)]+\)$/)) {
-        const fn = dfn.textContent.trim().match(/^([a-zA-Z_][a-zA-Z0-9_\-]+)\([^\)]+\)$/)[1];
+      if (dfn.textContent.trim().match(fnRegExp)) {
+        const fn = dfn.textContent.trim().match(fnRegExp)[1];
         res = parseProductionRule(`${fn}() = ${dfn.textContent.trim()}`, { pureSyntax: false });
       }
       else {
@@ -630,9 +631,9 @@ const extractTypedDfn = dfn => {
       res = { name: getDfnName(dfn), prose: text.replace(/\s+/g, ' ') };
     }
   }
-  else if (dfn.textContent.trim().match(/^[a-zA-Z_][a-zA-Z0-9_\-]+\([^\)]+\)$/)) {
+  else if (dfn.textContent.trim().match(fnRegExp)) {
     // Definition is "prod(foo bar)", create a "prod() = prod(foo bar)" entry
-    const fn = dfn.textContent.trim().match(/^([a-zA-Z_][a-zA-Z0-9_\-]+)\([^\)]+\)$/)[1];
+    const fn = dfn.textContent.trim().match(fnRegExp)[1];
     res = parseProductionRule(`${fn}() = ${dfn.textContent.trim()}`, { pureSyntax: false });
   }
   else if (parent.nodeName === 'DT') {

--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -607,7 +607,17 @@ const extractTypedDfn = dfn => {
       // Don't attempt to parse pre tags at this stage, they are tricky to
       // split, we'll parse them as text and map them to the right definitions
       // afterwards.
-      res = { name: getDfnName(dfn) };
+      // That said, we may be looking at a function definition on the right hand
+      // side of a production rule, as in the definition of "linear()" in
+      // css-easing-2: https://drafts.csswg.org/css-easing-2/#funcdef-linear
+      // In such a case, we still want to extract the function parameters
+      if (dfn.textContent.trim().match(/^[a-zA-Z_][a-zA-Z0-9_\-]+\([^\)]+\)$/)) {
+        const fn = dfn.textContent.trim().match(/^([a-zA-Z_][a-zA-Z0-9_\-]+)\([^\)]+\)$/)[1];
+        res = parseProductionRule(`${fn}() = ${dfn.textContent.trim()}`, { pureSyntax: false });
+      }
+      else {
+        res = { name: getDfnName(dfn) };
+      }
     }
     else if (prod) {
       res = parseProductionRule(prod, { pureSyntax: true });

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -1188,6 +1188,28 @@ that spans multiple lines */
     easy.</p>
     `,
     error: 'Found multiple linking texts for dfn without any obvious one: a, b, c'
+  },
+
+  {
+    title: 'extracts a function value from the right hand side of a production rule',
+    html: `
+    <pre class="prod">
+      <dfn data-dfn-type="type" data-export="">&lt;linear-easing-function&gt;</dfn> = <dfn data-dfn-type="function" data-export="" data-lt="linear()">linear(&lt;linear-stop-list&gt;)</dfn>
+    </pre>
+    `,
+    propertyName: 'values',
+    css: [
+      {
+        name: '<linear-easing-function>',
+        type: 'type',
+        value: 'linear(<linear-stop-list>)'
+      },
+      {
+        name: 'linear()',
+        type: 'function',
+        value: 'linear(<linear-stop-list>)'
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Via https://github.com/w3c/webref/issues/808#issuecomment-1331836527

Once in a while, function definitions appear in the right hand side of a production rule, as in css-easing-2:

```
<linear-easing-function> = linear(<linear-stop-list>)
```
https://drafts.csswg.org/css-easing-2/#funcdef-linear

The code did not extract the function parameters in such cases, leading to an reported object without a `value` property:

```json
{
  "name": "linear()",
  "type": "function"
}
```

This update fixes that, meaning the final extract will now contain:

```json
{
  "name": "linear()",
  "type": "function",
  "value": "linear(<linear-stop-list>)"
}
```