### PR TITLE
CSS extract: Ignore informative code in `<dd>` element

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -640,7 +640,12 @@ const extractTypedDfn = dfn => {
       return;
     }
     let code = dd.querySelector('p > code, pre.prod');
-    if (code) {
+    if (code && !code.closest(informativeSelector)) {
+      // The assumption here is that normative code in the <dd> element that
+      // follows the definition is the production rule for the definition. This
+      // is a rather bold assumption, which should probably be revisited
+      // (unrelated code could appear in the prose and not have anything to do
+      // with the definition's value)
       if (code.textContent.startsWith(`${text} = `) ||
           code.textContent.startsWith(`<${text}> = `)) {
         res = parseProductionRule(code.textContent, { pureSyntax: true });

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -1278,6 +1278,29 @@ that spans multiple lines */
         value: 'linear(<linear-stop-list>)'
       }
     ]
+  },
+
+  {
+    title: 'does not get confused by informative code in dd',
+    html: `
+    <dl>
+      <dt><dfn data-dfn-type="type" data-export="">&lt;my-type&gt;</dfn></dt>
+      <dd>
+        &lt;my-type&gt; is my type.
+        <div class="example">
+          <p><code>foo</code> is not the value of &lt;my-type&gt;.</p>
+        </div>
+      </dd>
+    </dl>
+    `,
+    propertyName: 'values',
+    css: [
+      {
+        name: '<my-type>',
+        type: 'type',
+        prose: '<my-type> is my type. foo is not the value of <my-type>.'
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
The extraction code assumed that code that appears in a `<dd>` element that follows a `<dt>` definition describes the production value of the definition. That seems rather bold. This update restricts it to normative code to fix #1138.

The whole assumption should probably be thoroughly re-evaluated though. The code contains a comment to that effect in the meantime.