### PR TITLE
CSS extracts: normalize function-like selectors names

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -580,7 +580,7 @@ const extractTypedDfn = dfn => {
   const dfnType = dfn.getAttribute('data-dfn-type');
   const dfnFor = dfn.getAttribute('data-dfn-for');
   const parent = dfn.parentNode.cloneNode(true);
-  const fnRegExp = /^([a-zA-Z_][a-zA-Z0-9_\-]+)\([^\)]+\)$/;
+  const fnRegExp = /^([:a-zA-Z_][:a-zA-Z0-9_\-]+)\([^\)]+\)$/;
 
   // Remove note references as in:
   // https://drafts.csswg.org/css-syntax-3/#the-anb-type

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -1301,6 +1301,19 @@ that spans multiple lines */
         prose: '<my-type> is my type. foo is not the value of <my-type>.'
       }
     ]
+  },
+
+  {
+    title: 'normalizes function-like selectors names',
+    html: `
+    <p><dfn data-dfn-type="selector" data-export="">::blah( &lt;my-type&gt; )</dfn>
+    is a selector that takes <code>&lt;my-type&gt;</code> as input.</p>
+    `,
+    propertyName: 'selectors',
+    css: [{
+      name: '::blah()',
+      value: '::blah( <my-type> )'
+    }]
   }
 ];
 


### PR DESCRIPTION
This extends slightly the regular expression used to detect function-like constructs to also match function-like selectors. This update makes the code drop the selector's parameters in the `name` (they will rather appear in the `value` property).

Fixes #1145.