### PR TITLE
CSS extraction: only extract code with a "prod" class

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -639,13 +639,8 @@ const extractTypedDfn = dfn => {
     if (!dd) {
       return;
     }
-    let code = dd.querySelector('p > code, pre.prod');
+    const code = dd.querySelector('code.prod, pre.prod');
     if (code && !code.closest(informativeSelector)) {
-      // The assumption here is that normative code in the <dd> element that
-      // follows the definition is the production rule for the definition. This
-      // is a rather bold assumption, which should probably be revisited
-      // (unrelated code could appear in the prose and not have anything to do
-      // with the definition's value)
       if (code.textContent.startsWith(`${text} = `) ||
           code.textContent.startsWith(`<${text}> = `)) {
         res = parseProductionRule(code.textContent, { pureSyntax: true });

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -1281,6 +1281,46 @@ that spans multiple lines */
   },
 
   {
+    title: 'extracts a production rule defined in code in a dd',
+    html: `
+    <dl>
+      <dt><dfn data-dfn-type="type" data-export="">&lt;my-type&gt;</dfn></dt>
+      <dd>
+        <p><code class="prod">none | auto</code> are the values.
+      </dd>
+    </dl>
+    `,
+    propertyName: 'values',
+    css: [
+      {
+        name: '<my-type>',
+        type: 'type',
+        value: 'none | auto'
+      }
+    ]
+  },
+
+  {
+    title: 'does not extract arbitrary code defined in a dd',
+    html: `
+    <dl>
+      <dt><dfn data-dfn-type="type" data-export="">&lt;my-type&gt;</dfn></dt>
+      <dd>
+        <p><code>42</code> is not a value of &lt;my-type&gt;.</p>
+      </dd>
+    </dl>
+    `,
+    propertyName: 'values',
+    css: [
+      {
+        name: '<my-type>',
+        type: 'type',
+        prose: '42 is not a value of <my-type>.'
+      }
+    ]
+  },
+
+  {
     title: 'does not get confused by informative code in dd',
     html: `
     <dl>
@@ -1288,7 +1328,7 @@ that spans multiple lines */
       <dd>
         &lt;my-type&gt; is my type.
         <div class="example">
-          <p><code>foo</code> is not the value of &lt;my-type&gt;.</p>
+          <p class="prod"><code>foo</code> is not the value of &lt;my-type&gt;.</p>
         </div>
       </dd>
     </dl>


### PR DESCRIPTION
The code considered that any kind of code appearing in a `<dd>` that followed a definition was a production rule. This is incorrect as there are cases where the prose uses code that is not meant to describe the value of the construct defined.

This updates the logic to only consider code that has a `prod` class.

Fixes #1140