### PR TITLE
Associate element with interface in simple case

### DIFF
--- a/src/browserlib/extract-elements.mjs
+++ b/src/browserlib/extract-elements.mjs
@@ -216,7 +216,14 @@ export default function (spec) {
       // All elements defined in MathML Core
       // use the MathMLElement interface
       if (shortname === "mathml-core") {
-       elInfo.interface = "MathMLElement" ;
+        elInfo.interface = "MathMLElement" ;
+      }
+      else {
+        const interfaces = [...document.querySelectorAll('dfn[data-dfn-type=interface]')]
+          .filter(el => el.textContent.trim().toLowerCase() === `html${elInfo.name}element`);
+        if (interfaces.length === 1) {
+          elInfo.interface = interfaces[0].textContent.trim();
+        }
       }
       return elInfo;
       });

--- a/tests/extract-elements.js
+++ b/tests/extract-elements.js
@@ -176,6 +176,21 @@ const tests = [
         interface: "MathMLElement"
       }
     ]
+  },
+
+  {
+    title: "links an element with its interface in simple case",
+    spec: "portals",
+    html: `<p>
+      The <dfn data-dfn-type="element">portal</dfn> element uses the
+      <dfn data-dfn-type="interface">HTMLPortalElement</dfn> interface.
+    </p>`,
+    res: [
+      {
+        name: "portal",
+        interface: "HTMLPortalElement"
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
The elements extraction code did not have common logic to associate an element `Xx` with its interface. If the code finds an interface whose name is `HTMLXxElement`, it now automatically associates the element with it.

Typically useful for the `<portal>` element defined in "Portals" and the `<model>` element defined in "The `<model>` element".