### PR TITLE
Force interface to `Element` for EPUB elements

### DIFF
--- a/src/browserlib/extract-elements.mjs
+++ b/src/browserlib/extract-elements.mjs
@@ -216,7 +216,12 @@ export default function (spec) {
       // All elements defined in MathML Core
       // use the MathMLElement interface
       if (shortname === "mathml-core") {
-        elInfo.interface = "MathMLElement" ;
+        elInfo.interface = "MathMLElement";
+      }
+      // All elements of the Open Container Format of EPUB
+      // use the Element interface
+      else if (shortname === "epub-33") {
+        elInfo.interface = "Element";
       }
       else {
         const interfaces = [...document.querySelectorAll('dfn[data-dfn-type=interface]')]


### PR DESCRIPTION
I hadn't noticed that elements extraction now also extracts the elements of the Open Container Format from the EPUB specification: https://github.com/w3c/webref/blob/main/ed/elements/epub-33.json

That specification does not specify any API to access the elements. Using the base `Element` class as fallback.
