### PR TITLE
Add crude dfns patching mechanism

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -260,6 +260,8 @@ export default function (spec, idToHeading = {}) {
       return node;
     })
     .filter(hasValidType)
+    // Exclude IDL terms defined in a block that is flagged as to be excluded
+    .filter(node => !node.closest('.exclude'))
     // When the whole term links to an external spec, the definition is an
     // imported definition. Such definitions are not "real" definitions, let's
     // skip them.

--- a/src/lib/post-processor.js
+++ b/src/lib/post-processor.js
@@ -60,7 +60,8 @@ const modules = {
   events: require('../postprocessing/events'),
   idlnames: require('../postprocessing/idlnames'),
   idlparsed: require('../postprocessing/idlparsed'),
-  annotatelinks: require('../postprocessing/annotate-links')
+  annotatelinks: require('../postprocessing/annotate-links'),
+  patchdfns: require('../postprocessing/patch-dfns')
 };
 
 

--- a/src/postprocessing/patch-dfns.js
+++ b/src/postprocessing/patch-dfns.js
@@ -1,0 +1,40 @@
+/**
+ * Post-processing module that can be used to patch definition extracts,
+ * typically to drop problematic duplicate definitions they may contain.
+ * 
+ * This post-processing module should only be considered as last resort because
+ * it requires manual maintenance over time. Goal is to hardcode things here
+ * only when duplicate terms create actual referencing issues, not to resolve
+ * all duplicate definitions conflicts.
+ *
+ * The module runs at the spec level.
+ */
+
+module.exports = {
+  dependsOn: ['dfns'],
+  input: 'spec',
+  property: 'dfns',
+
+  run: async function (spec, options) {
+    // Note the spec object passed to post-processing modules does not contain
+    // any specific detail on the spec other than the crawled URL, so no direct
+    // way to match spec on its shortname
+    if (spec.crawled && spec.dfns) {
+      // https://github.com/w3c/webref/blob/main/ed/idlpatches/orientation-event.idl.patch
+      if (spec.crawled.includes('/deviceorientation/') ||
+          spec.crawled.includes('/TR/orientation-event/')) {
+        spec.dfns = spec.dfns.filter(dfn =>
+          !dfn.linkingText.includes('PermissionState') &&
+          !dfn.for.includes('PermissionState'));
+      }
+
+      // https://github.com/w3c/webref/blob/main/ed/idlpatches/portals.idl.patch
+      else if (spec.crawled.includes('/portals/')) {
+        spec.dfns = spec.dfns.filter(dfn =>
+          dfn.linkingText[0] !== 'MessageEventSource');
+      }
+    }
+
+    return spec;
+  }
+};


### PR DESCRIPTION
This completes dfns extraction rules to ignore IDL terms defined in "exclude" blocks (for Trusted Types), and introduces a post-processing module to patch problematic dfns. The post-processing module only patches two specs for the time being: `orientation-event` which redefines `PermissionState` and `portals`, which redefines `MessageEventSource`.

Goal is to only add dfn patches when the dfns create actual referencing issues, not to solve all dfns issues, as that would be hard to maintain on a day to day basis.

(Webref's crawling job will need to be updated to call the new module for this to affect Webref data)

For additional context, see https://github.com/w3c/webref/issues/306 and https://github.com/tabatkins/bikeshed/pull/2426#issuecomment-1353888578