### PR TITLE
Document newValues field in css extract schema

### DIFF
--- a/schemas/browserlib/extract-cssdfn.json
+++ b/schemas/browserlib/extract-cssdfn.json
@@ -15,6 +15,7 @@
         "properties": {
           "name": { "$ref": "../common.json#/$defs/cssPropertyName" },
           "value": { "$ref": "../common.json#/$defs/cssValue" },
+          "newValues": { "$ref": "../common.json#/$defs/cssValue" },
           "values": { "$ref": "../common.json#/$defs/cssValues" },
           "styleDeclaration": {
             "type": "array",


### PR DESCRIPTION
This adds the `newValues` field to the schema that describes CSS extracts. This field can only ever be set on property definitions.

Note the schema has `"additionalProperties": true` because we currently extract all rows that we find in the tables that define CSS properties, and these sometimes contain additional properties such as `animationType`. It would be worth studying and documenting these as well at some point.

Fixes #1158