### PR TITLE
Fix data-lt extraction for CSS values

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -552,11 +552,14 @@ const getDfnName = dfn => {
   if (dfn.getAttribute('data-lt')) {
     const names = dfn.getAttribute('data-lt').split('|').map(normalize);
     let name = names.find(n =>
-      n.startsWith('<') ||            // Looks like a "type"
-      n.startsWith('@') ||            // Looks like an "at-rule"
-      n.startsWith(':') ||            // Looks like a "descriptor"
-      n.endsWith('()')  ||            // Looks like a "function"
-      n === dfn.textContent.trim());  // Looks like the right term
+      n.startsWith('<') ||              // Looks like a "type"
+      n.startsWith('@') ||              // Looks like an "at-rule"
+      n.startsWith(':') ||              // Looks like a "descriptor"
+      n.endsWith('()'));                // Looks like a "function"
+    if (!name) {
+      // No specific type found in the list, look for the actual term
+      name = names.find(n => n === dfn.textContent.trim());
+    }
     if (!name) {
       if (names.length > 1) {
         throw new Error(`Found multiple linking texts for dfn without any obvious one: ${names.join(', ')}`);

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -1217,14 +1217,14 @@ that spans multiple lines */
   {
     title: 'extracts right linking text for a "type" definition',
     html: `
-    <p><dfn data-dfn-type="type" data-lt="identifiers|<identifier>" data-export>Identifiers</dfn>
+    <p><dfn data-dfn-type="type" data-lt="identifiers|<identifier>" data-export>identifiers</dfn>
     are a fantastic type.</p>
     `,
     propertyName: 'values',
     css: [{
       name: '<identifier>',
       type: 'type',
-      prose: 'Identifiers are a fantastic type.'
+      prose: 'identifiers are a fantastic type.'
     }]
   },
 


### PR DESCRIPTION
Via https://github.com/w3c/webref/issues/808#issuecomment-1363300495

The test should have failed. It passed "by chance" due to a case mismatch between the value in the attribute and the actual text content. Idea is to prefer the name that looks like a dedicated type over the prose-friendly name that CSS specs sometimes create.