### PR TITLE
Extract headings without data-dfn-type that look like dfns

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -607,7 +607,7 @@ function preProcessEcmascript() {
 }
 
 function preProcessHTML() {
-  const headingSelector = ':is(h2,h3,h4,h5,h6)[id]:not(:is([data-dfn-type],[data-export],[data-noexport],[data-lt])) dfn';
+  const headingSelector = ':is(h2,h3,h4,h5,h6)[id]:not(:is([data-dfn-type],[data-dfn-for],[data-export],[data-noexport],[data-lt])) dfn';
 
   // we copy the id on the dfn when it is set on the surrounding heading
   document.querySelectorAll(headingSelector)

--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -221,31 +221,7 @@ export default function (spec, idToHeading = {}) {
     // have some other definition related attribute (because we only want to
     // extract headings that want to be seen as definitions)
     'dfn[id]:not([data-lt=""])',
-    'h2[id][data-dfn-type]:not([data-lt=""])',
-    'h3[id][data-dfn-type]:not([data-lt=""])',
-    'h4[id][data-dfn-type]:not([data-lt=""])',
-    'h5[id][data-dfn-type]:not([data-lt=""])',
-    'h6[id][data-dfn-type]:not([data-lt=""])',
-    'h2[id][data-dfn-for]:not([data-lt=""])',
-    'h3[id][data-dfn-for]:not([data-lt=""])',
-    'h4[id][data-dfn-for]:not([data-lt=""])',
-    'h5[id][data-dfn-for]:not([data-lt=""])',
-    'h6[id][data-dfn-for]:not([data-lt=""])',
-    'h2[id][data-export]:not([data-lt=""])',
-    'h3[id][data-export]:not([data-lt=""])',
-    'h4[id][data-export]:not([data-lt=""])',
-    'h5[id][data-export]:not([data-lt=""])',
-    'h6[id][data-export]:not([data-lt=""])',
-    'h2[id][data-noexport]:not([data-lt=""])',
-    'h3[id][data-noexport]:not([data-lt=""])',
-    'h4[id][data-noexport]:not([data-lt=""])',
-    'h5[id][data-noexport]:not([data-lt=""])',
-    'h6[id][data-noexport]:not([data-lt=""])',
-    'h2[id][data-lt]:not([data-lt=""])',
-    'h3[id][data-lt]:not([data-lt=""])',
-    'h4[id][data-lt]:not([data-lt=""])',
-    'h5[id][data-lt]:not([data-lt=""])',
-    'h6[id][data-lt]:not([data-lt=""])'
+    ':is(h2,h3,h4,h5,h6)[id]:is([data-dfn-type],[data-dfn-for],[data-export],[data-noexport],[data-lt]):not([data-lt=""])'
   ].join(',');
 
   const shortname = (typeof spec === 'string') ? spec : spec.shortname;
@@ -631,13 +607,7 @@ function preProcessEcmascript() {
 }
 
 function preProcessHTML() {
-  const headingSelector = [
-    'h2[id]:not([data-dfn-type]):not([data-export]):not([data-noexport]):not([data-lt]) dfn',
-    'h3[id]:not([data-dfn-type]):not([data-export]):not([data-noexport]):not([data-lt]) dfn',
-    'h4[id]:not([data-dfn-type]):not([data-export]):not([data-noexport]):not([data-lt]) dfn',
-    'h5[id]:not([data-dfn-type]):not([data-export]):not([data-noexport]):not([data-lt]) dfn',
-    'h6[id]:not([data-dfn-type]):not([data-export]):not([data-noexport]):not([data-lt]) dfn'
-  ].join(',');
+  const headingSelector = ':is(h2,h3,h4,h5,h6)[id]:not(:is([data-dfn-type],[data-export],[data-noexport],[data-lt])) dfn';
 
   // we copy the id on the dfn when it is set on the surrounding heading
   document.querySelectorAll(headingSelector)

--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -216,12 +216,36 @@ function definitionMapper(el, idToHeading, usesDfnDataModel) {
 export default function (spec, idToHeading = {}) {
   const definitionsSelector = [
     // re data-lt, see https://github.com/w3c/reffy/issues/336#issuecomment-650339747
+    // As for `<dfn>` we'll consider that headings without a `data-dfn-type`
+    // have an implicit `"data-dfn-type"="dfn"` attribute, provided they also
+    // have some other definition related attribute (because we only want to
+    // extract headings that want to be seen as definitions)
     'dfn[id]:not([data-lt=""])',
     'h2[id][data-dfn-type]:not([data-lt=""])',
     'h3[id][data-dfn-type]:not([data-lt=""])',
     'h4[id][data-dfn-type]:not([data-lt=""])',
     'h5[id][data-dfn-type]:not([data-lt=""])',
-    'h6[id][data-dfn-type]:not([data-lt=""])'
+    'h6[id][data-dfn-type]:not([data-lt=""])',
+    'h2[id][data-dfn-for]:not([data-lt=""])',
+    'h3[id][data-dfn-for]:not([data-lt=""])',
+    'h4[id][data-dfn-for]:not([data-lt=""])',
+    'h5[id][data-dfn-for]:not([data-lt=""])',
+    'h6[id][data-dfn-for]:not([data-lt=""])',
+    'h2[id][data-export]:not([data-lt=""])',
+    'h3[id][data-export]:not([data-lt=""])',
+    'h4[id][data-export]:not([data-lt=""])',
+    'h5[id][data-export]:not([data-lt=""])',
+    'h6[id][data-export]:not([data-lt=""])',
+    'h2[id][data-noexport]:not([data-lt=""])',
+    'h3[id][data-noexport]:not([data-lt=""])',
+    'h4[id][data-noexport]:not([data-lt=""])',
+    'h5[id][data-noexport]:not([data-lt=""])',
+    'h6[id][data-noexport]:not([data-lt=""])',
+    'h2[id][data-lt]:not([data-lt=""])',
+    'h3[id][data-lt]:not([data-lt=""])',
+    'h4[id][data-lt]:not([data-lt=""])',
+    'h5[id][data-lt]:not([data-lt=""])',
+    'h6[id][data-lt]:not([data-lt=""])'
   ].join(',');
 
   const shortname = (typeof spec === 'string') ? spec : spec.shortname;
@@ -608,11 +632,11 @@ function preProcessEcmascript() {
 
 function preProcessHTML() {
   const headingSelector = [
-    'h2[id]:not([data-dfn-type]) dfn',
-    'h3[id]:not([data-dfn-type]) dfn',
-    'h4[id]:not([data-dfn-type]) dfn',
-    'h5[id]:not([data-dfn-type]) dfn',
-    'h6[id]:not([data-dfn-type]) dfn'
+    'h2[id]:not([data-dfn-type]):not([data-export]):not([data-noexport]):not([data-lt]) dfn',
+    'h3[id]:not([data-dfn-type]):not([data-export]):not([data-noexport]):not([data-lt]) dfn',
+    'h4[id]:not([data-dfn-type]):not([data-export]):not([data-noexport]):not([data-lt]) dfn',
+    'h5[id]:not([data-dfn-type]):not([data-export]):not([data-noexport]):not([data-lt]) dfn',
+    'h6[id]:not([data-dfn-type]):not([data-export]):not([data-noexport]):not([data-lt]) dfn'
   ].join(',');
 
   // we copy the id on the dfn when it is set on the surrounding heading

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -272,6 +272,15 @@ const tests = [
            definedIn: "heading"}],
    spec: "html"
   },
+  {title: "handles HTML spec conventions of definitions in headings (with extra attributes)",
+   html: '<h4 id="transferable-objects" data-lt="transferable object" data-export=""><span class="secno">2.7.2</span> <dfn>Transferable objects</dfn><a href="#transferable-objects" class="self-link"></a></h4>',
+   changesToBaseDfn: [{id: "transferable-objects",
+           linkingText: ["transferable object"],
+           access: "public",
+           heading: { id: "transferable-objects", href: "about:blank#transferable-objects", title: "Transferable objects", number: "2.7.2"},
+           definedIn: "heading"}],
+   spec: "html"
+  },
   {
     "title": "ignores definitions imported in the HTML spec from other specs",
     html: '<li>The <dfn id="xmlhttprequest"><a href="https://xhr.spec.whatwg.org/#xmlhttprequest"><code>XMLHttpRequest</code></a></dfn> interface</li>',


### PR DESCRIPTION
We already consider that a `<dfn>` without a `data-dfn-type` has an implicit `"data-dfn-type"="dfn"` attribute. This update extends that principle to headings too, provided these headings have some other definition-related attribute to make it clear that they want to be considered as definitions as well.

This is typically needed for the definition of "transferable object" in HTML, that has both a `data-export` and `data-lt` attribute but no `data-dfn-type` attribute:
https://html.spec.whatwg.org/multipage/structured-data.html#transferable-objects

Without this update, Reffy would extract a private "transferable objects" term. With this update, it extracts a public "transferable object" term as intended.

In practice, the only other heading across all specs that has a definition-related attribute but no `data-dfn-type` is in the Reporting API: https://w3c.github.io/reporting/#generate-report
(That definition is a bit weird because the spec uses `data-algorithm` where we probably would prefer to see `data-lt`, but I propose to live with it for now).