### PR TITLE
Accept singular for "new value" in partial CSS dfns

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -333,7 +333,10 @@ const dfnLabel2Property = label => label.trim()
   .map((str, idx) => (idx === 0) ?
     str.toLowerCase() :
     str.charAt(0).toUpperCase() + str.slice(1))
-  .join('');
+  .join('')
+  // Spec may use singular when there is only one new value
+  // (e.g. new value of "text-transform" in MathML Core)
+  .replace(/^newValue$/, 'newValues');
 
 
 /**

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -1354,6 +1354,48 @@ that spans multiple lines */
       name: '::blah()',
       value: '::blah( <my-type> )'
     }]
+  },
+
+  {
+    title: 'parses a partial property definition',
+    html: `<table class="def propdef partial">
+      <tbody>
+        <tr>
+          <th>Name:</th>
+          <td>text-transform</td>
+        </tr>
+        <tr class="value">
+          <th>New values:</th>
+          <td class="prod">math-auto</td>
+        </tr>
+      </tbody>
+    </table>
+    `,
+    css: [{
+      name: 'text-transform',
+      newValues: 'math-auto'
+    }]
+  },
+
+  {
+    title: 'parses a partial property definition that (singular variant)',
+    html: `<table class="def propdef partial">
+      <tbody>
+        <tr>
+          <th>Name:</th>
+          <td>text-transform</td>
+        </tr>
+        <tr class="value">
+          <th>New value:</th>
+          <td class="prod">math-auto</td>
+        </tr>
+      </tbody>
+    </table>
+    `,
+    css: [{
+      name: 'text-transform',
+      newValues: 'math-auto'
+    }]
   }
 ];
 


### PR DESCRIPTION
When a spec extends the values of a CSS property, the new values appear in a "New Values" row in the definition table. The MathML Core specification decided to use the singular form "New Value" for `text-transform` because it only creates one new value. That seems fine and worth supporting in Reffy. This update makes Reffy generate a proper `newValues` field even when singular is used.

A couple of tests were added along the way, one for the new behavior, and one for newValues in general as there was no actual test on that.