### PR TITLE
CSS extracts: ignore asides in production rules

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -720,6 +720,11 @@ const extractProductionRules = root => {
     .filter(el => !el.closest(informativeSelector))
     .map(el => el.cloneNode(true))
     .map(el => {
+      [...el.querySelectorAll('aside, .mdn-anno')]
+        .map(aside => aside.parentNode.removeChild(aside));
+      return el;
+    })
+    .map(el => {
       [...el.querySelectorAll('sup')]
         .map(sup => sup.parentNode.removeChild(sup));
       return el;

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -1396,6 +1396,30 @@ that spans multiple lines */
       name: 'text-transform',
       newValues: 'math-auto'
     }]
+  },
+
+  {
+    title: 'ignores asides in production rules',
+    html: `<pre class="prod"><dfn data-dfn-type="function">anchor()</dfn> = anchor( &lt;anchor-element>? &lt;anchor-side>, &lt;length-percentage>? )
+      <dfn data-dfn-type="type">&lt;anchor-element&gt;</dfn>
+      <span><aside class="dfn-panel" role="dialog">
+        Info about the '&lt;anchor-element&gt;' definition.
+      </aside></span> = &lt;dashed-ident&gt; | implicit
+    </pre>
+    `,
+    propertyName: 'values',
+    css: [
+      {
+        name: 'anchor()',
+        type: 'function',
+        value: 'anchor( <anchor-element>? <anchor-side>, <length-percentage>? )'
+      },
+      {
+        name: '<anchor-element>',
+        type: 'type',
+        value: '<dashed-ident> | implicit'
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Bikeshed now produces aside notations in pure production rules too. They need to be dropped before theses rules get parsed as text. A new test was added to check the feature.