### PR TITLE
Dfns extraction: hardcode exception for "prefixed syntax"

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -265,9 +265,15 @@ export default function (spec, idToHeading = {}) {
     // When the whole term links to an external spec, the definition is an
     // imported definition. Such definitions are not "real" definitions, let's
     // skip them.
+    // One hardcoded exception-to-the-rule, see:
+    // https://github.com/w3c/webref/issues/882
+    // (pending a proper dfns curation process, see:
+    // https://github.com/w3c/webref/issues/789)
     .filter(node => {
       const link = node.querySelector('a[href^="http"]');
-      return !link || (node.textContent.trim() !== link.textContent.trim());
+      return !link ||
+        (node.textContent.trim() !== link.textContent.trim()) ||
+        (link.href === 'https://www.w3.org/TR/CSS2/syndata.html#vendor-keywords');
     })
     .map(node => definitionMapper(node, idToHeading, usesDfnDataModel))
     .filter(isNotAlreadyExported);

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -428,6 +428,22 @@ When initialize(<var>newItem</var>) is called, the following steps are run:</p>`
       definedIn: "pre"
     }],
     spec :"SVG2",
+  },
+
+  {
+    title: "includes a dfn that links to CSS2 Vendor-specific extensions section (hardcoded rule)",
+    html: `<p>The CSS2.1 specification reserves a
+    <dfn data-dfn-type="dfn" data-export="" id="prefixed-syntax">
+      <a href="https://www.w3.org/TR/CSS2/syndata.html#vendor-keywords">prefixed syntax</a>
+    </dfn>.</p>
+    `,
+    changesToBaseDfn: [{
+      id: "prefixed-syntax",
+      linkingText: ["prefixed syntax"],
+      type: "dfn",
+      access: "public",
+      definedIn: "prose"
+    }]
   }
 ];
 


### PR DESCRIPTION
Fixes https://github.com/w3c/webref/issues/882 pending a more proper dfns curation process as envisioned in https://github.com/w3c/webref/issues/789