### PR TITLE
Encode URI fragments

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -154,7 +154,7 @@ function definitionMapper(el, idToHeading, usesDfnDataModel) {
   // to ease parsing logic, and we want to get back to the URL of the page)
   const page = el.closest('[data-reffy-page]')?.getAttribute('data-reffy-page');
   const url = new URL(page ?? window.location.href);
-  url.hash = '#' + el.getAttribute('id');
+  url.hash = '#' + encodeURIComponent(el.getAttribute('id'));
   const href = url.toString();
 
   return {

--- a/src/browserlib/get-absolute-url.mjs
+++ b/src/browserlib/get-absolute-url.mjs
@@ -18,7 +18,7 @@ export default function (node, { singlePage, attribute } =
   const url = new URL(page ?? window.location.href);
   const hashid = node.getAttribute(attribute);
   if (hashid) {
-    url.hash = '#' + hashid;
+    url.hash = '#' + encodeURIComponent(hashid);
   }
   return url.toString();
 }

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -104,6 +104,11 @@ const tests = [
    changesToBaseDfn: [{}]
   },
 
+  {title: "encodes the href fragment",
+   html: "<dfn id='foo-%' data-dfn-type='dfn'>Foo</dfn>",
+   changesToBaseDfn: [{id: 'foo-%', href: 'about:blank#foo-%25'}]
+  },
+
   {title: "ignores a <dfn> without an id",
    html: "<dfn data-dfn-type='dfn'>Foo</dfn>",
    changesToBaseDfn: []

--- a/tests/extract-headings.js
+++ b/tests/extract-headings.js
@@ -19,6 +19,11 @@ const testHeadings = [
     title: "extracts a heading title without its section number",
     html: "<h2 id=title>2.3 Title</h2>",
     res: [{id: "title", href: "about:blank#title", title: "Title", number: "2.3", level: 2}]
+  },
+  {
+    title: "encodes the href fragment",
+    html: "<h1 id='title-%'>%</h1>",
+    res: [{id: "title-%", href: "about:blank#title-%25", title: "%", level: 1}]
   }
 ];
 

--- a/tests/extract-ids.js
+++ b/tests/extract-ids.js
@@ -12,6 +12,12 @@ const testIds = [
   },
 
   {
+    title: "encodes the href fragment",
+    html: "<h1 id='title-%'>%</h1>",
+    res: ["about:blank#title-%25"]
+  },
+
+  {
     title: "extracts all IDs",
     html: "<h1 id=title>Title <span id=subtitle>Subtitle</span></h1>",
     res: ["about:blank#title", "about:blank#subtitle"]


### PR DESCRIPTION
IDs cannot simply be prefixed with `#` and used as fragments. They need to be encoded first. Via https://github.com/w3c/webref/issues/889