### PR TITLE
ECMAScript spec: Fix dfn scoping and abstract op extraction

### DIFF
--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -231,13 +231,40 @@ const tests = [
   {
     title: 'extracts abstract operations from ecmascript spec',
     html: '<emu-clause id="sec-toprimitive" oldids="table-9" aoid="ToPrimitive"><span id="table-9"></span><h1><span class="secnum">7.1.1</span> ToPrimitive ( <var>input</var> [ , <var>preferredType</var> ] )</h1>',
-    changesToBaseDfn: [{linkingText: [ "ToPrimitive(input, preferredType)"], type: "abstract-op", access: "public", definedIn: "heading", id: "sec-toprimitive", heading: { number: "7.1.1", id: "sec-toprimitive", href: "about:blank#sec-toprimitive", title: "ToPrimitive ( input [ , preferredType ] )"}}],
+    changesToBaseDfn: [{linkingText: [ "ToPrimitive", "ToPrimitive(input, preferredType)"], type: "abstract-op", access: "public", definedIn: "heading", id: "sec-toprimitive", heading: { number: "7.1.1", id: "sec-toprimitive", href: "about:blank#sec-toprimitive", title: "ToPrimitive ( input [ , preferredType ] )"}}],
+    spec: "ecmascript"
+  },
+  {
+    title: 'extracts abstract operations with digits in their name from ecmascript spec',
+    html: '<emu-clause id="sec-toint32" aoid="ToInt32"><h1><span class="secnum">7.1.6</span> ToInt32 ( <var>argument</var> )</h1>',
+    changesToBaseDfn: [{linkingText: [ "ToInt32", "ToInt32(argument)"], type: "abstract-op", access: "public", definedIn: "heading", id: "sec-toint32", heading: { number: "7.1.6", id: "sec-toint32", href: "about:blank#sec-toint32", title: "ToInt32 ( argument )"}}],
     spec: "ecmascript"
   },
   {
     title: 'extracts abstract methods (scoped abstract ops) from ecmascript spec',
-    html: '<emu-clause id="bar"><h1>Heading</h1><figure><figcaption>Abstract Methods for <emu-xref>Scope</emu-xref></figcaption><table><tbody><tr><td>AbstractMethod()</td></tr></tbody></table></figure></emu-clause><emu-clause id="foo"><h1>AbstractMethod(param)</h1></emu-clause>',
+    html: '<emu-clause id="bar"><h1>Heading</h1><figure><figcaption>Abstract Methods for <emu-xref>Scope</emu-xref></figcaption><table><tbody><tr><td>AbstractMethod ()</td></tr></tbody></table></figure></emu-clause><emu-clause id="foo"><h1>AbstractMethod(param)</h1></emu-clause>',
     changesToBaseDfn: [{linkingText: [ "AbstractMethod(param)"], type: "abstract-op", "for": ["Scope"], access: "public", definedIn: "heading", heading: { id: "foo", href: "about:blank#foo", title: "AbstractMethod(param)"}}],
+    spec: "ecmascript"
+  },
+  {
+    title: 'extracts abstract methods in hierarchy of classes from ecmascript spec',
+    html: `<emu-clause id="bar">
+      <h1>Heading</h1>
+      <figure>
+        <figcaption>Abstract Methods for <emu-xref>Scope</emu-xref></figcaption>
+        <table><tbody><tr><td>AbstractMethod ()</td></tr></tbody></table>
+      </figure>
+    </emu-clause>
+    <emu-clause id="ab">
+      <h1>Scope</h1>
+      <emu-clause id="concrete">
+        <h1>Concrete Scope</h1>
+        <emu-clause id="foo">
+          <h1>AbstractMethod(param)</h1>
+        </emu-clause>
+      </emu-clause>
+    </emu-clause>`,
+    changesToBaseDfn: [{linkingText: [ "AbstractMethod(param)"], type: "abstract-op", "for": ["Concrete Scope"], access: "public", definedIn: "heading", heading: { id: "foo", href: "about:blank#foo", title: "AbstractMethod(param)"}}],
     spec: "ecmascript"
   },
   {


### PR DESCRIPTION
As raised in https://github.com/w3c/webref/issues/888, abstract operations were only extracted using a long form such as:
  `["AllocateArrayBuffer(constructor, byteLength)"]`

Crawler should not create linking text that does not exist in the spec. In this particular case, the spec *does* create additional linking text through the `aoid` attribute, set to the name of the abstract operation without parens, so it seems fine to use that info, even though the `aoid` attribute is flagged as legacy in the Ecmarkup documentation:
https://tc39.es/ecmarkup/#emu-clause-legacy-attributes

This update adds the parens-less variant to abstract operations when the `aoid` attribute is present. Linking text in the previous example becomes:
  `["AllocateArrayBuffer", "AllocateArrayBuffer(constructor, byteLength)"]`

The code that extracted abstract operation had a couple of issues that this update also fixes:

1. Abstract operations that contain digits such as `ToInt32()` were not extracted. Regular expressions used to extract information have been completed accordingly.

2. The code that tried to scope abstract methods to some class was not specific enough. "Environments Records" are defined as a hierarchy of classes, and methods are defined multiple times, once for each class. Extraction merely took the first occurrence, and reported duplication warnings. It now looks for the most specific class.

(Side note that the update also drops the line that set `ltNodefault`, since it was not used anywhere)

Tests adjusted accordingly.