### PR TITLE
Drop legacyValue extraction logic

### DIFF
--- a/schemas/browserlib/extract-cssdfn.json
+++ b/schemas/browserlib/extract-cssdfn.json
@@ -81,7 +81,6 @@
           "type": { "type": "string", "enum": ["type", "function"] },
           "prose": { "type": "string" },
           "value": { "$ref": "../common.json#/$defs/cssValue" },
-          "legacyValue": { "$ref": "../common.json#/$defs/cssValue" },
           "values": { "$ref": "../common.json#/$defs/cssValues" }
         }
       }

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -50,7 +50,6 @@
           "type": { "type": "string", "enum": ["type", "function", "value", "selector"] },
           "prose": { "type": "string" },
           "value": { "$ref": "#/$defs/cssValue" },
-          "legacyValue": { "$ref": "#/$defs/cssValue" },
           "values": { "$ref": "#/$defs/cssValues" }
         }
       }

--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -158,9 +158,6 @@ export default function () {
       rootDfns.find(matchName(rule.name, { approx: true }));
     if (dfn) {
       dfn.value = rule.value;
-      if (rule.legacyValue) {
-        dfn.legacyValue = rule.legacyValue;
-      }
     }
     else {
       let matchingValues = values.filter(matchName(rule.name));
@@ -169,9 +166,6 @@ export default function () {
       }
       for (const matchingValue of matchingValues) {
         matchingValue.value = rule.value;
-        if (rule.legacyValue) {
-          matchingValue.legacyValue = rule.legacyValue;
-        }
       }
       if (matchingValues.length === 0) {
         // Dangling production rule. That should never happen for properties,
@@ -526,14 +520,7 @@ const parseProductionRule = (rule, { res = [], pureSyntax = false }) => {
     // Second definition found. Typically happens for the statement and
     // block @layer definitions in css-cascade-5. We'll combine the values
     // as alternative.
-    // Hardcoded exception: re-definitions of rgb() and hsl() are legacy
-    // constructs, stored separately not to pollute `value`.
-    if (name === '<rgb()>' || name === '<hsl()>') {
-      entry.legacyValue = normalizedValue;
-    }
-    else {
-      entry.value += ` | ${normalizedValue}`;
-    }
+    entry.value += ` | ${normalizedValue}`;
   }
 
   return entry;

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -298,28 +298,6 @@ const tests = [
   },
 
   {
-    title: "knows that second definition of rgb() is legacy",
-    html: `
-      <p>The <dfn data-dfn-type="function">rgb()</dfn> function has a
-      legacy value.</p>
-      <pre class="prod">
-        &lt;rgb()> = rgb( modern )
-      </pre>
-      <pre class="prod">
-        &lt;rgb()> = rgb( legacy )
-      </pre>
-    `,
-    propertyName: "values",
-    css: [{
-        "name": "rgb()",
-        "type": "function",
-        "prose": "The rgb() function has a legacy value.",
-        "value": "rgb( modern )",
-        "legacyValue": "rgb( legacy )"
-    }]
-  },
-
-  {
     title: "extracts an at-rule syntax",
     html: `
       <dfn data-dfn-type="at-rule">@layer</dfn> is an at-rule.


### PR DESCRIPTION
As reported in #1215, the `legacyValue` logic is no longer needed since CSS Color 4 no longer uses it. The /TR version of the spec still uses it but... the code stopped working a few months ago when we switched to function names without surrounding `<>`, meaning that Webref data already does not have `legacyValue` anymore.

This update drops that custom logic entirely. Code continues to concatenate values if more than one definition is found.