### PR TITLE
CSS extracts: Ignore lists of tests when extracting prose

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -340,6 +340,14 @@ const dfnLabel2Property = label => label.trim()
 
 
 /**
+ * Selector to use to exclude inner blocks that list tests, references and/or
+ * link to implementation statuses, which would provide too much detailed info
+ * in prose content.
+ */
+const asideSelector = 'aside, .mdn-anno, .wpt-tests-block';
+
+
+/**
  * Extract a CSS definition from a table
  *
  * All recent CSS specs should follow that pattern
@@ -349,7 +357,7 @@ const extractTableDfn = table => {
   const lines = [...table.querySelectorAll('tr')]
     .map(line => {
       const cleanedLine = line.cloneNode(true);
-      const annotations = cleanedLine.querySelectorAll("aside, .mdn-anno");
+      const annotations = cleanedLine.querySelectorAll(asideSelector);
       annotations.forEach(n => n.remove());
       return {
         name: dfnLabel2Property(cleanedLine.querySelector(':first-child').textContent),
@@ -593,7 +601,7 @@ const extractTypedDfn = dfn => {
   // and remove MDN annotations as well
   [...parent.querySelectorAll('sup')]
     .map(sup => sup.parentNode.removeChild(sup));
-  [...parent.querySelectorAll('aside, .mdn-anno')]
+  [...parent.querySelectorAll(asideSelector)]
     .map(annotation => annotation.parentNode.removeChild(annotation));
 
   const text = parent.textContent.trim();
@@ -668,7 +676,7 @@ const extractTypedDfn = dfn => {
       });
       [...dd.querySelectorAll('sup')]
         .map(sup => sup.parentNode.removeChild(sup));
-      [...dd.querySelectorAll('aside, .mdn-anno')]
+      [...dd.querySelectorAll(asideSelector)]
         .map(annotation => annotation.parentNode.removeChild(annotation));
 
       res = {
@@ -724,7 +732,7 @@ const extractProductionRules = root => {
     .filter(el => !el.closest(informativeSelector))
     .map(el => el.cloneNode(true))
     .map(el => {
-      [...el.querySelectorAll('aside, .mdn-anno')]
+      [...el.querySelectorAll(asideSelector)]
         .map(aside => aside.parentNode.removeChild(aside));
       return el;
     })

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -1457,6 +1457,27 @@ that spans multiple lines */
       type: 'type',
       prose: 'Determines the gradient center of the gradient.'
     }]
+  },
+
+  {
+    title: 'ignores lists of tests in dd prose',
+    html: `<dl>
+    <dt><dfn data-dfn-type="type" data-export="">&lt;position&gt;</dfn></dt>
+    <dd>
+      Determines the <dfn data-dfn-type="dfn">gradient center</dfn>
+      of the gradient.
+      <details class="wpt-tests-block">
+        <summary>Tests</summary>
+        <p>A list of tests.</p>
+      </details>
+    </dd></dl>
+    `,
+    propertyName: 'values',
+    css: [{
+      name: '<position>',
+      type: 'type',
+      prose: 'Determines the gradient center of the gradient.'
+    }]
   }
 ];
 


### PR DESCRIPTION
The code already had some logic to exclude `<details>` and other aside blocks that are the direct children of the element under consideration, but tests may now appear at more nested levels. This update processes them once and for all, as done for MDN annotations and the references popup.