### PR TITLE
Support "name" attribute convention in headings

### DIFF
--- a/src/browserlib/create-outline.mjs
+++ b/src/browserlib/create-outline.mjs
@@ -8,7 +8,7 @@
  * As a by-product of generating the outline, the function also generates a
  * mapping between elements and the (conceptual) section that contains them in
  * the outline. To save memory, this mapping is only done for elements that have
- * an ID.
+ * an ID (or a "name" attribute).
  *
  * Both the outline and the mapping are returned.
  */
@@ -307,8 +307,9 @@ export default function (root) {
     // In addition, whenever the walk exits a node, after doing the steps above,
     // if the node is not associated with a section yet, associate the node with
     // the section current section.
-    // (we will only do that for elements that have an ID)
-    if (node.getAttribute('id') && !nodeToSection.has(node)) {
+    // (we will only do that for elements that have an ID or a "name" attribute)
+    if ((node.getAttribute('id') || node.getAttribute('name')) &&
+        !nodeToSection.has(node)) {
       nodeToSection.set(node, currentSection);
     }
   }

--- a/src/browserlib/extract-headings.mjs
+++ b/src/browserlib/extract-headings.mjs
@@ -19,7 +19,13 @@ export default function (spec, idToHeading) {
       number: headingNumber
     };
   });
-  return esHeadings.concat([...document.querySelectorAll('h1[id], h2[id], h3[id], h4[id], h5[id] ,h6[id]')].map(n => {
+
+  const headingsSelector = [
+    ':is(h1,h2,h3,h4,h5,h6)[id]',                 // Regular headings
+    ':is(h1,h2,h3,h4,h5,h6):not([id]) > a[name]'  // CSS 2.1 headings
+  ].join(',');
+
+  return esHeadings.concat([...document.querySelectorAll(headingsSelector)].map(n => {
     // Note: In theory, all <hX> heading elements that have an ID are associated
     // with a heading in idToHeading. One exception to the rule: when the
     // heading element appears in a <hgroup> element, the mapping is not
@@ -27,9 +33,11 @@ export default function (spec, idToHeading) {
     // headings not to create a mess in the outline). In practice, this only
     // really happens so far for WHATWG spec titles that (correctly) group the
     // title and subtitle headings in a <hgroup>.
-    const href = getAbsoluteUrl(n, { singlePage });
+    const idAttr = n.hasAttribute('id') ? 'id' : 'name';
+    const headingEl = n.hasAttribute('id') ? n : n.parentNode;
+    const href = getAbsoluteUrl(n, { singlePage, attribute: idAttr });
     const heading = idToHeading[href] || {
-      id: n.id,
+      id: n.getAttribute(idAttr),
       href,
       title: n.textContent.trim()
     };
@@ -37,7 +45,7 @@ export default function (spec, idToHeading) {
     const res = {
       id: heading.id,
       href: heading.href,
-      level: parseInt(n.tagName.slice(1), 10),
+      level: parseInt(headingEl.tagName.slice(1), 10),
       title: heading.title
     };
     if (heading.number) {

--- a/tests/extract-headings.js
+++ b/tests/extract-headings.js
@@ -24,6 +24,26 @@ const testHeadings = [
     title: "encodes the href fragment",
     html: "<h1 id='title-%'>%</h1>",
     res: [{id: "title-%", href: "about:blank#title-%25", title: "%", level: 1}]
+  },
+  {
+    title: "extracts a CSS 2.1 heading at level 1",
+    html: "<h1><a name=title>2 Title</a></h1>",
+    res: [{id: "title", "href": "about:blank#title", title: "Title", number: "2", level: 1}]
+  },
+  {
+    title: "extracts a CSS 2.1 heading at level 3",
+    html: "<h3><a name=title>4.5.1 Title</a></h1>",
+    res: [{id: "title", "href": "about:blank#title", title: "Title", number: "4.5.1", level: 3}]
+  },
+  {
+    title: "extracts a CSS 2.1 appendix heading",
+    html: "<h1><a name=title>Appendix A. Title</a></h1>",
+    res: [{id: "title", "href": "about:blank#title", title: "Title", number: "A", level: 1}]
+  },
+  {
+    title: "extracts an appendix that starts with Appendix and uses ':'",
+    html: "<h1 id=title>Appendix A: Title</a></h1>",
+    res: [{id: "title", "href": "about:blank#title", title: "Title", number: "A", level: 1}]
   }
 ];
 


### PR DESCRIPTION
Via #1223.

This extends the extraction of headings to also support the convention where the heading ID is actually embedded within a child `<a name>` anchor, as in CSS 2.1.

The numbering extraction logic was also adjusted to handle the case when a top level heading starts with a number not followed by a `.`. Again, that is the case in CSS 2.1, but note it is also the case for some IETF RFCs.

Similarly, appendix titles sometimes start with "Appendix" and may be followed by a `:`. This update also extends the logic to support that convention.