### PR TITLE
Expand custom logic for CSS 2.1 dfns extraction

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -698,16 +698,27 @@ function preProcessCSS21() {
       // Complete the "<dfn>" with expected attributes
       dfn.id = anchor.getAttribute('name');
       dfn.dataset.export = '';
-      if (span.getAttribute('title')) {
-        dfn.dataset.lt = span.getAttribute('title');
-      }
+      // Drop suffixes such "::definition of" and wrapping quotes,
+      // and drop possible duplicates
+      dfn.dataset.lt = (span.getAttribute('title') ?? dfn.textContent).split('|')
+        .map(normalize)
+        .map(text => text.replace(/::definition of$/, '')
+          .replace(/, definition of$/, '')
+          .replace(/^'(.*)'$/, '$1'))
+        .filter((text, idx, array) => array.indexOf(text) === idx)
+        .join('|');
       let dfnType = null;
       switch (anchor.getAttribute('class') ?? '') {
         case 'propdef-title':
           dfnType = 'property';
           break;
         case 'value-def':
-          dfnType = 'value';
+          if (dfn.dataset.lt.match(/^<.*>$/)) {
+            dfnType = 'type';
+          }
+          else {
+            dfnType = 'value';
+          }
           break;
       }
       if (dfnType) {

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -524,13 +524,13 @@ When initialize(<var>newItem</var>) is called, the following steps are run:</p>`
     title: "maps CSS 2.1 property definitions to the right type",
     html: `<dl><dt>
       <span class="index-def" title="'width'">
-        <a name="propdef-width" class="propdef-title"><strong>'width'</strong></a>
+        <a name="propdef-width" class="propdef-title"><strong>width</strong></a>
       </span>
     </dt>
     <dd>Blah</dd></dl>`,
     changesToBaseDfn: [{
       id: "propdef-width",
-      linkingText: ["'width'"],
+      linkingText: ["width"],
       access: "public",
       type: "property",
       definedIn: "dt"
@@ -540,6 +540,20 @@ When initialize(<var>newItem</var>) is called, the following steps are run:</p>`
 
   {
     title: "maps CSS 2.1 value definitions to the right type",
+    html: `<span class="index-def">
+      <a name="value" class="value-def">val</a>
+    </span>`,
+    changesToBaseDfn: [{
+      id: "value",
+      linkingText: ["val"],
+      access: "public",
+      type: "value"
+    }],
+    spec: "CSS2"
+  },
+
+  {
+    title: "maps CSS 2.1 type definitions to the right type",
     html: `<p>Some value types may have integer values (denoted by
       <span class="index-def">
         <a name="value-def-integer" class="value-def">&lt;integer&gt;</a>
@@ -549,7 +563,43 @@ When initialize(<var>newItem</var>) is called, the following steps are run:</p>`
       id: "value-def-integer",
       linkingText: ["<integer>"],
       access: "public",
-      type: "value"
+      type: "type"
+    }],
+    spec: "CSS2"
+  },
+
+  {
+    title: "suppresses wrapping quotes in CSS 2.1 property definitions",
+    html: `<dl><dt>
+      <span class="index-def" title="'width'">
+        <a name="propdef-width" class="propdef-title"><strong>'width'</strong></a>
+      </span>
+    </dt>
+    <dd>Blah</dd></dl>`,
+    changesToBaseDfn: [{
+      id: "propdef-width",
+      linkingText: ["width"],
+      access: "public",
+      type: "property",
+      definedIn: "dt"
+    }],
+    spec: "CSS2"
+  },
+
+  {
+    title: "suppresses useless suffix in CSS 2.1 property definitions",
+    html: `<dl><dt>
+      <span class="index-def" title="<integer>::definition of">
+        <a name="value-def-integer" class="value-def">&lt;integer&gt;</a>
+      </span>
+    </dt>
+    <dd>Blah</dd></dl>`,
+    changesToBaseDfn: [{
+      id: "value-def-integer",
+      linkingText: ["<integer>"],
+      access: "public",
+      type: "type",
+      definedIn: "dt"
     }],
     spec: "CSS2"
   },


### PR DESCRIPTION
Via https://github.com/w3c/webref/issues/909

This update drops wrapping quotes and weird suffixes from dfn linking texts. It also gives type definitions a proper `"type"` definition type.