### PR TITLE
Events: Skip asides in "fire an event" phrasing

### DIFF
--- a/src/browserlib/extract-events.mjs
+++ b/src/browserlib/extract-events.mjs
@@ -163,13 +163,7 @@ export default function (spec) {
       // Clone and drop possible annotations to avoid extracting asides.
       // (note the need to temporarily add the cloned node to the document
       // so that ranges can be used)
-      let apos = 0;
-      for (let i = 0; i < a.parentNode.children.length; i++) {
-        if (a.parentNode.children[i] === a) {
-          apos = i;
-          break;
-        }
-      }
+      const apos = [...a.parentNode.children].findIndex(c => c === a);
       const container = a.parentNode.cloneNode(true);
       const aclone = container.children[apos];
 

--- a/src/browserlib/extract-events.mjs
+++ b/src/browserlib/extract-events.mjs
@@ -160,24 +160,46 @@ export default function (spec) {
   [...document.querySelectorAll("a")]
     .filter(a => !a.closest(informativeSelector) && isFiringLink(a))
     .forEach(a => {
-      const container = a.parentNode;
-      // There can be multiple "fire an event" links in a container
-      // limiting our text parsing to content in between two such links
-      // (or the end of the container if there is only one such link)
-      const range = document.createRange();
-      range.selectNode(container);
-      range.setStart(a, 0);
-
-      let nextFiringLink, curEl = a;
-      while ((curEl = curEl.nextElementSibling)) {
-        if (curEl.tagName === "A" && isFiringLink(curEl)) {
-          nextFiringLink = curEl;
+      // Clone and drop possible annotations to avoid extracting asides.
+      // (note the need to temporarily add the cloned node to the document
+      // so that ranges can be used)
+      let apos = 0;
+      for (let i = 0; i < a.parentNode.children.length; i++) {
+        if (a.parentNode.children[i] === a) {
+          apos = i;
+          break;
         }
       }
-      if (nextFiringLink) {
-        range.setEndBefore(nextFiringLink);
+      const container = a.parentNode.cloneNode(true);
+      const aclone = container.children[apos];
+
+      const annotations = container.querySelectorAll("aside, .mdn-anno");
+      annotations.forEach(n => n.remove());
+      document.body.appendChild(container);
+
+
+      // There can be multiple "fire an event" links in a container,
+      // limiting our text parsing to content in between two such links,
+      // or to the first time aside appears (no whitespaces in Bikeshed
+      // so code would extract the beginning of the annotation otherwise),
+      // or the end of the container if neither of the above occurs.
+      const range = document.createRange();
+      range.selectNode(container);
+      range.setStart(aclone, 0);
+
+      let nextFiringEl, curEl = aclone;
+      while ((curEl = curEl.nextElementSibling)) {
+        if (curEl.tagName === "A" && isFiringLink(curEl)) {
+          nextFiringEl = curEl;
+          break;
+        }
+      }
+
+      if (nextFiringEl) {
+        range.setEndBefore(nextFiringEl);
       }
       const parsedText = range.toString();
+      document.body.removeChild(container);
       let phrasing;
       let m = parsedText.match(/fir(e|ing)\s+a(n|\s+pointer)\s+event\s+named\s+"?(?<eventName>[a-z]+)/i);
       if (m) {
@@ -225,8 +247,8 @@ export default function (spec) {
           }
         }
         if (!event.interface) {
-          let curEl = a, iface;
-          while ((curEl = curEl.nextElementSibling)) {
+          let curEl = aclone, iface;
+          while ((curEl = curEl.nextElementSibling) && curEl !== nextFiringEl) {
             if (curEl.textContent.match(/^([A-Z]+[a-z0-9]*)+Event$/)) {
               iface = curEl.textContent.trim();
               break;

--- a/tests/extract-events.js
+++ b/tests/extract-events.js
@@ -157,6 +157,14 @@ ${defaultIdl}`,
         "type": "success"
       }
     ]
+  },
+  {
+    title: "does not get confused by asides",
+    html: `<p id=success><a href='https://dom.spec.whatwg.org/#concept-event-fire'>Fire an event</a>
+      named <code>success</code><span><span class="mdn-anno">Info</span></span> using <a href=''>SuccessEvent</a> with the <code>bubbles</code> attribute initialized to <code>true</code>.</p>
+      <p id=error><a href='https://dom.spec.whatwg.org/#concept-event-fire'>Fire an event</a> named <code>error</code> using <a href=''>ErrorEvent</a> with the <code>bubbles</code> attribute initialized to <code>false</code></p>
+      ${defaultIdl}`,
+    res: defaultResults("fire an event phrasing")
   }
 ];
 


### PR DESCRIPTION
This completes the "fire an event" extraction logic to ignore annotations that Bikeshed may now add (without whitespaces) next to event names.

Note the update also adds a couple of safeguards to while loops that were not properly constrained, although this has likely not have had any impact on extracted info so far.

Fixes #1268