### PR TITLE
Bump minimal supported version of Node.js from v14 to v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: '18'
     - run: npm ci
     - run: npm test

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The code features a generic crawler that can fetch Web specifications and genera
 
 ### Pre-requisites
 
-To install Reffy, you need [Node.js](https://nodejs.org/en/) 14 or greater.
+To install Reffy, you need [Node.js](https://nodejs.org/en/) 18 or greater (the crawler itself may still run with earlier versions of Node.js, but version 18 is needed to run tests).
 
 ### Installation
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=14.18"
+    "node": ">=18"
   },
   "main": "index.js",
   "bin": "./reffy.js",


### PR DESCRIPTION
Triggered by dependency on ReSpec (#1270). Note the dependency is only in tests meaning that Reffy should continue to run with Node.js v14 for now. That said, it does not seem a good idea to maintain two different minimal versions of Node, one for the source and one for tests. Plus there would be no way to specify that in `package.json`.

A major version of Reffy will need to be released.