### PR TITLE
Fix Chrome install in job through npm ci foreground option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,5 @@ jobs:
       with:
         node-version: '18'
         cache: 'npm'
-    - run: npm ci
+    - run: npm ci --foreground-scripts=true
     - run: npm test


### PR DESCRIPTION
It seems that Puppeteer loses itself in its local cache (under the user's folder on Windows, in `.cache\puppeteer`) when two versions of Chrome are used as dependencies: first version installs correctly, second one ends up with just a manifest file that actually references the first version. Reffy cannot run as a result.

Reffy currently has the issue because it depends on Puppeteer v21.0.1 directly, and indirectly on v20.9.0 through ReSpec. Using the `--foreground-scripts` option seems to fix the install issue locally, probably because that serializes the Chrome installations. Trying to see whether that fixes the job as well.

Even if it does, we need a proper fix: it should be possible to run `npm ci` without options!