### PR TITLE
Extract git revision from spec when available

### DIFF
--- a/src/browserlib/get-revision.mjs
+++ b/src/browserlib/get-revision.mjs
@@ -5,7 +5,7 @@ export default function () {
   const meta = document.querySelector('meta[name="document-revision"], meta[name="revision"]');
   const revision = meta?.content.trim();
   // git commit shas are 40 hexadecimal characters
-  if (revision && revision.match(/[0-9a-f]{40}/)) {
+  if (revision?.match(/[0-9a-f]{40}/)) {
     return revision;
   }
   return null;

--- a/src/browserlib/get-revision.mjs
+++ b/src/browserlib/get-revision.mjs
@@ -1,0 +1,12 @@
+export default function () {
+  // bikeshed uses 'document-revision'
+  // but the documented convention in https://wiki.whatwg.org/wiki/MetaExtensions
+  // is just 'revision' per https://github.com/krallin/meta-revision
+  const meta = document.querySelector('meta[name="document-revision"], meta[name="revision"]');
+  const revision = meta?.content.trim();
+  // git commit shas are 40 hexadecimal characters
+  if (revision && revision.match(/[0-9a-f]{40}/)) {
+    return revision;
+  }
+  return null;
+}

--- a/src/browserlib/reffy.json
+++ b/src/browserlib/reffy.json
@@ -15,6 +15,11 @@
     "metadata": true
   },
   {
+    "href": "./get-revision.mjs",
+    "property": "revision",
+    "metadata": true
+  },
+  {
     "href": "./extract-links.mjs",
     "property": "links"
   },

--- a/src/lib/mock-server.js
+++ b/src/lib/mock-server.js
@@ -44,7 +44,7 @@ const mockSpecs = {
     <script src='https://www.w3.org/Tools/respec/respec-w3c'></script>
     <div id=abstract></div>
     <pre class='idl'>[Exposed=Window] interface Foo { attribute DOMString bar; };</pre>`,
-  "/accelerometer/": `<html>
+  "/accelerometer/": `<html><meta name='document-revision' content='c0917d216986f88bdd43c72c0b13352c71f283aa'>
     <h2>Normative references</h2>
     <dl>
       <dt>FOO</dt>

--- a/tests/crawl-test.json
+++ b/tests/crawl-test.json
@@ -195,6 +195,7 @@
       "https://w3c.github.io/accelerometer/"
     ],
     "crawled": "https://w3c.github.io/accelerometer/",
+    "revision": "c0917d216986f88bdd43c72c0b13352c71f283aa",
     "links": {
       "https://www.w3.org/TR/Foo": {}
     },


### PR DESCRIPTION
bikeshed exports the sha of the git commit used to generate the spec when possible; that information is valuable to link a particular crawled document to a crawl output. See e.g. https://github.com/dontcallmedom/spec-check-hook/issues/11