### PR TITLE
Fix determination of path to the webidl2 module

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -61,23 +61,16 @@ function requireFromWorkingDirectory(filename) {
 
 
 /**
- * Determine the path to the "node_modules" folder to resolve relative links
- * in the ES6 browser lib modules. The path depends on whether Reffy is run
- * directly, or installed as a library.
+ * Path to the "webidl2" folder to resolve relative links in the ES6 browser
+ * lib modules. The path depends on whether Reffy is run directly, or installed
+ * as a library.
  *
- * @function
- * @return {String} Path to the node_modules folder.
+ * Code relies on the "require.resolve" function, but note that, when given a
+ * simple module name, that function returns the path to the file targeted by
+ * the "main" property in "package.json" which, in the case of the webidl2
+ * module, is "dist/webidl2.js".
  */
-function getModulesFolder() {
-    const rootFolder = path.resolve(__dirname, '../..');
-    let folder = path.resolve(rootFolder, 'node_modules');
-    if (existsSync(folder)) {
-        return folder;
-    }
-    folder = path.resolve(rootFolder, '..');
-    return folder;
-}
-const modulesFolder = getModulesFolder();
+const webidl2Folder = path.resolve(path.dirname(require.resolve('webidl2')), '..');
 
 
 /**
@@ -381,7 +374,7 @@ async function processSpecification(spec, processFunction, args, options) {
                         body = Buffer.from(browserlib);
                     }
                     else if (request.url.includes(webidl2Path)) {
-                        const file = path.resolve(modulesFolder, 'webidl2',
+                        const file = path.resolve(webidl2Folder,
                             request.url.substring(request.url.indexOf(webidl2Path) + webidl2Path.length));
                         body = await fs.readFile(file);
                     }


### PR DESCRIPTION
Code that runs in the page needs to import the WebIDL2 parser. This is done with a fake script URL that gets intercepted and converted to the contents of the right webidl2 module file.

The conversion from the fake script URL to the webidl2 module file used some dedicated logic to find the supposed `node_modules` folder that contains installed modules. However, that logic assumed that all modules would be installed at the same level. That is (no longer) always the case: when different versions of the same dependency are used, some of the versions may be installed in nested `node_modules` folders.

That typically happens in Webref: Reffy currently depends on commander v11.1.0 while another module depends on commander v11.0.0. Reffy's version of commander gets installed under a `node_modules` subfolder within Reffy's folder as a result (but not webidl2). This confused the conversion logic.

The code now rather uses `require.resolve` to determine the path of the webidl2 module.