### PR TITLE
Headings extraction - ignore empty IDs

### DIFF
--- a/src/browserlib/extract-headings.mjs
+++ b/src/browserlib/extract-headings.mjs
@@ -33,8 +33,8 @@ export default function (spec, idToHeading) {
     // headings not to create a mess in the outline). In practice, this only
     // really happens so far for WHATWG spec titles that (correctly) group the
     // title and subtitle headings in a <hgroup>.
-    const idAttr = n.hasAttribute('id') ? 'id' : 'name';
-    const headingEl = n.hasAttribute('id') ? n : n.parentNode;
+    const idAttr = n.id ? 'id' : 'name';
+    const headingEl = n.id ? n : n.parentNode;
     const href = getAbsoluteUrl(n, { singlePage, attribute: idAttr });
     const heading = idToHeading[href] || {
       id: n.getAttribute(idAttr),

--- a/src/browserlib/map-ids-to-headings.mjs
+++ b/src/browserlib/map-ids-to-headings.mjs
@@ -81,7 +81,7 @@ export default function () {
     // Compute the absolute URL with fragment
     // (Note the crawler merges pages of a multi-page spec in the first page
     // to ease parsing logic, and we want to get back to the URL of the page)
-    const idAttr = node.hasAttribute('id') ? 'id' : 'name';
+    const idAttr = node.id ? 'id' : 'name';
     const nodeid = getAbsoluteUrl(node, { singlePage, attribute: idAttr });
     let href = nodeid;
 
@@ -89,7 +89,7 @@ export default function () {
       let id;
 
       const heading = parentSection.heading;
-      if (heading.hasAttribute('id')) {
+      if (heading.id) {
         id = heading.id;
         href = getAbsoluteUrl(heading, { singlePage });
       }
@@ -101,7 +101,7 @@ export default function () {
         }
       }
 
-      if (parentSection.root && parentSection.root.hasAttribute('id')) {
+      if (parentSection.root && parentSection.root.id) {
         id = parentSection.root.id;
         href = getAbsoluteUrl(parentSection.root, { singlePage });
       }

--- a/tests/extract-headings.js
+++ b/tests/extract-headings.js
@@ -49,7 +49,12 @@ const testHeadings = [
     title: "ignores test annotations in the heading",
     html: "<h2 id=title><div class='annotation'>18 tests</div>2.3 Title</a></h2>",
     res: [{id: "title", "href": "about:blank#title", title: "Title", number: "2.3", level: 2}]
-  }
+  },
+  {
+    title: "ignores an empty id if there's a better one",
+    html: "<section id><h1 id=title>Heading in a section with empty id</h1>",
+    res: [{id: "title", "href": "about:blank#title", title: "Heading in a section with empty id", level: 1}]
+  },
 ];
 
 describe("Test headings extraction", function () {


### PR DESCRIPTION
Clunky specs may wrap a heading with an ID in a section that has an empty ID, as currently happens for one heading in the EME spec.

The code thought the presence of an `id` attribute was sufficient and extracted the heading without id as a result. It now makes sure that it is not empty.