### PR TITLE
Make refs extraction more flexible and stable, add tests

### DIFF
--- a/src/browserlib/extract-references.mjs
+++ b/src/browserlib/extract-references.mjs
@@ -68,13 +68,19 @@ function getExtractionRules(generator) {
  * @function
  * @private
  * @param {Node} node The DOM node to use as starting point
- * @param {String} name The sibling name to find
+ * @param {String} name The sibling name to find, "heading" to match any heading
+ * @param {Node} until The optional DOM sibling at which to stop no matter what
  * @return {Node} The next sibling with the given name, null if not found
  */
-function nextTag(node, name) {
+function nextTag(node, name, until) {
   let nextEl = node.nextElementSibling;
-  while(nextEl && nextEl.tagName !== name.toUpperCase()) {
+  while (nextEl && nextEl !== until &&
+      ((name === 'heading' && !nextEl.tagName.match(/^(H\d$|HGROUP)$/)) ||
+       (name !== 'heading' && nextEl.tagName !== name.toUpperCase()))) {
     nextEl = nextEl.nextElementSibling;
+  }
+  if (nextEl === until) {
+    nextEl = null;
   }
   return nextEl;
 }
@@ -94,23 +100,45 @@ function nextTag(node, name) {
 function parseReferences(referenceList, options) {
   var defaultRef = [], informativeRef = [];
   options = options || {};
-  [].forEach.call(referenceList.querySelectorAll("dt"), function (dt) {
-    var ref = {};
-    ref.name = dt.textContent.replace(/[\[\] \n]/g, '');
-    var desc = nextTag(dt, "dd");
-    if (!desc || !ref.name) {
-      return;
-    }
-    const url = desc.querySelector('a[href*="://"]')?.href;
-    if (url) {
-      ref.url = url;
-    }
-    if (options.filterInformative &&
-        desc.textContent.match(/non-normative/i)) {
-      return informativeRef.push(ref);
-    }
-    defaultRef.push(ref);
-  });
+  if (referenceList.tagName === "DL") {
+    [...referenceList.childNodes]
+      .filter(child => child.tagName === "DT")
+      .forEach(function (dt) {
+        var ref = {};
+        ref.name = dt.textContent.replace(/[\[\] \n]/g, '');
+        var desc = nextTag(dt, "dd");
+        if (!desc || !ref.name) {
+          return;
+        }
+        const url = desc.querySelector('a[href*="://"]')?.href;
+        if (url) {
+          ref.url = url;
+        }
+        if (options.filterInformative &&
+            desc.textContent.match(/non-normative/i)) {
+          return informativeRef.push(ref);
+        }
+        defaultRef.push(ref);
+      });
+  }
+  else if (referenceList.tagName === "UL") {
+    [...referenceList.childNodes]
+      .filter(child => child.tagName === "LI")
+      .forEach(function (li) {
+        li = li.cloneNode(true);
+        [...li.querySelectorAll("ul")].map(el => el.remove());
+        var anchor = li.querySelector("a[href]");
+        var ref = {};
+        if (anchor) {
+          ref.name = anchor.innerText.trim();
+          ref.url = anchor.getAttribute("href");
+        }
+        else {
+          ref.name = li.innerText.trim();
+        }
+        defaultRef.push(ref);
+      });
+  }
   return [defaultRef, informativeRef];
 };
 
@@ -130,38 +158,75 @@ function extractReferencesWithoutRules() {
     informative: []
   };
   const anchors = [...document.querySelectorAll("h1, h2, h3")];
-  const referenceHeadings = anchors.filter(textMatch(/references/i));
-  if (!referenceHeadings.length) {
-    return references;
-  }
-  if (referenceHeadings.length > 1) {
-    const normative = referenceHeadings.find(textMatch(/normative/i));
-    if (normative) {
-      const nList = nextTag(normative, "dl");
-      if (nList) {
-        references.normative = parseReferences(nList)[0];
-      }
+  console.log('[reffy]', 'extract refs without rules');
+
+  // Look for a "Normative references" heading
+  const normative = anchors.findLast(
+    textMatch(/^\s*((\w|\d+)(\.\d+)*\.?)?\s*normative\s+references\s*$/i));
+  if (normative) {
+    console.log('[reffy]', 'normative references section found', normative.textContent);
+    const nextHeading = nextTag(normative, "heading");
+    let nList = nextTag(normative, "dl", nextHeading);
+    if (!nList) {
+      nList = nextTag(normative, "ul", nextHeading);
     }
-    const informative = referenceHeadings.find(textMatch(/informative/i));
-    if (informative) {
-      const iList = nextTag(informative, "dl");
-      if (iList) {
-        references.informative = parseReferences(iList)[0];
-      }
-    }
-    if (informative || normative) {
-      return references;
+    if (nList) {
+      references.normative = parseReferences(nList)[0];
     }
   }
 
-  // If there are still multiple reference headings,
-  // keep only the last one
-  const referenceHeading = referenceHeadings.pop();
-  const list = nextTag(referenceHeading, "dl");
-  if (list) {
-    const refs = parseReferences(list, { filterInformative: true });
-    references.normative = refs[0];
-    references.informative = refs[1];
+  // Look for an "Informative references" heading
+  const informative = anchors.findLast(
+    textMatch(/^\s*((\w|\d+)(\.\d+)*\.?)?\s*(informative|non-normative)\s+references\s*$/i));
+  if (informative) {
+    const nextHeading = nextTag(informative, "heading");
+    let iList = nextTag(informative, "dl", nextHeading);
+    if (!iList) {
+      iList = nextTag(informative, "ul", nextHeading);
+    }
+    if (iList) {
+      references.informative = parseReferences(iList)[0];
+    }
+  }
+
+  if (informative || normative) {
+    return references;
+  }
+
+  // Look for a generic "references" heading
+  const refHeading = anchors.findLast(textMatch(/references/i));
+  if (refHeading) {
+    const nextSection = nextTag(refHeading, refHeading.tagName);
+    const subHeadingLevel = "h" + (parseInt(refHeading.tagName.substring(1), 10) + 1);
+    let subHeading = refHeading;
+    while (subHeading = nextTag(subHeading, subHeadingLevel, nextSection)) {
+      if (subHeading.textContent.match(/normative/i) ||
+          subHeading.textContent.match(/informative/i)) {
+        let list = nextTag(subHeading, "dl", nextSection);
+        if (!list) {
+          list = nextTag(subHeading, "ul", nextSection);
+        }
+        if (list) {
+          const type = subHeading.textContent.match(/normative/i) ?
+            "normative" : "informative";
+          references[type] = parseReferences(list)[0];
+        }
+      }
+    }
+
+    if (references.normative.length === 0 &&
+        references.informative.length === 0) {
+      // No subheading, flat list of references
+      let list = nextTag(refHeading, "dl", nextSection);
+      if (!list) {
+        list = nextTag(refHeading, "ul", nextSection);
+      }
+      if (list) {
+        const refs = parseReferences(list, { filterInformative: true });
+        references.normative = refs[0];
+        references.informative = refs[1];
+      }
+    }
   }
   return references;
 }

--- a/tests/extract-references.js
+++ b/tests/extract-references.js
@@ -1,0 +1,278 @@
+const { assert } = require('chai');
+const puppeteer = require('puppeteer');
+const path = require('path');
+const rollup = require('rollup');
+const { getSchemaValidationFunction } = require('../src/lib/util');
+
+const testRefs = [
+  {
+    title: "extracts normative references",
+    html: `
+<section>
+  <h3>F.1 Normative references</h3>
+  <dl>
+    <dt id="bib-dom">[dom]</dt>
+    <dd><a href="https://dom.spec.whatwg.org/"><cite>DOM Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a></dd>
+  </dl>
+</section>`,
+    res: {
+      normative: [{ name: "dom", url: "https://dom.spec.whatwg.org/" }],
+      informative: []
+    }
+  },
+
+  {
+    title: "extracts informative references",
+    html: `
+<section>
+  <h2>F. References</h2>
+  <section>
+    <h3>F.2 Informative references</h3>
+    <dl>
+      <dt id="bib-webrtc">[webrtc]</dt>
+      <dd><a href="https://www.w3.org/TR/webrtc/"><cite>WebRTC: Real-Time Communication in Browsers</cite></a>. Cullen Jennings; Florent Castelli; Henrik Boström; Jan-Ivar Bruaroey.  W3C. 6 March 2023. W3C Recommendation. URL: <a href="https://www.w3.org/TR/webrtc/">https://www.w3.org/TR/webrtc/</a></dd>
+    </dl>
+  </section>
+</section>`,
+    res: {
+      normative: [],
+      informative: [{ name: "webrtc", url: "https://www.w3.org/TR/webrtc/" }]
+    }
+  },
+
+  {
+    title: "extracts normative/informative references",
+    html: `
+<section>
+  <h2>F. References</h2>
+  <section>
+    <h3>F.1 Normative references</h3>
+    <dl>
+      <dt id="bib-dom">[dom]</dt>
+      <dd><a href="https://dom.spec.whatwg.org/"><cite>DOM Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a></dd>
+    </dl>
+  </section>
+  <section>
+    <h3>F.2 Informative references</h3>
+    <dl>
+      <dt id="bib-webrtc">[webrtc]</dt>
+      <dd><a href="https://www.w3.org/TR/webrtc/"><cite>WebRTC: Real-Time Communication in Browsers</cite></a>. Cullen Jennings; Florent Castelli; Henrik Boström; Jan-Ivar Bruaroey.  W3C. 6 March 2023. W3C Recommendation. URL: <a href="https://www.w3.org/TR/webrtc/">https://www.w3.org/TR/webrtc/</a></dd>
+    </dl>
+  </section>
+</section>`,
+    res: {
+      normative: [{ name: "dom", url: "https://dom.spec.whatwg.org/" }],
+      informative: [{ name: "webrtc", url: "https://www.w3.org/TR/webrtc/" }]
+    }
+  },
+
+  {
+    title: "extracts a flat list of references",
+    html: `
+<h2>F. References</h2>
+<p>All references are normative unless marked "Non-normative".</p>
+<dl>
+  <dt id="refsABNF">[ABNF]</dt>
+  <dd><cite><a href="https://www.rfc-editor.org/rfc/rfc5234">Augmented BNF for Syntax Specifications: ABNF</a></cite>, D. Crocker, P. Overell. IETF.</dd>
+  <dt id="refsAPNG">[APNG]</dt>
+  <dd>(Non-normative) <cite><a href="https://wiki.mozilla.org/APNG_Specification">APNG Specification</a></cite>. S. Parmenter, V. Vukicevic, A. Smith. Mozilla.</dd>
+</dl>`,
+    res: {
+      normative: [{ name: "ABNF", url: "https://www.rfc-editor.org/rfc/rfc5234" }],
+      informative: [{ name: "APNG", url: "https://wiki.mozilla.org/APNG_Specification" }]
+    }
+  },
+
+  {
+    title: "does not get confused by the absence of sections",
+    html: `
+<h2>References</h2>
+<h3>Normative References</h3>
+<dl>
+   <dt id="biblio-css-align-3">[CSS-ALIGN-3]</dt>
+   <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://drafts.csswg.org/css-align/"><cite>CSS Box Alignment Module Level 3</cite></a>. URL: <a href="https://drafts.csswg.org/css-align/">https://drafts.csswg.org/css-align/</a></dd>
+</dl>
+<h3>Informative References</h3>
+<dl>
+  <dt>[CSS-MULTICOL-1]</dt>
+  <dd>Florian Rivoal; Rachel Andrew. <a href="https://drafts.csswg.org/css-multicol/"><cite>CSS Multi-column Layout Module Level 1</cite></a>. URL: <a href="https://drafts.csswg.org/css-multicol/">https://drafts.csswg.org/css-multicol/</a></dd>
+</dl>`,
+    res: {
+      normative: [{ name: "CSS-ALIGN-3", url: "https://drafts.csswg.org/css-align/" }],
+      informative: [{ name: "CSS-MULTICOL-1", url: "https://drafts.csswg.org/css-multicol/" }]
+    }
+  },
+
+  {
+    title: "does not get confused by further lists",
+    html: `
+<h2>Normative references</h2>
+<p>No references.</p>
+<h2>A few terms</h2>
+<dl>
+   <dt>A term</dt>
+   <dd>but not a ref</dd>
+</dl>`,
+    res: null
+  },
+
+  {
+    title: "extracts references defined in ul lists",
+    html: `
+<h2>11 References</h2>
+<h3>11.1 Normative References</h3>
+<ul>
+  <li>
+    <p><a href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf">AV1</a> <strong>AV1 Bitstream &amp; Decoding Process Specification, Version 1.0.0 with Errata 1</strong>, January 2019.</p>
+  </li>
+</ul>
+<h3>11.2 Informative References</h3>
+<ul>
+  <li>
+    <p><a href="https://tools.ietf.org/html/rfc3711">RFC3711</a> <strong>The Secure Real-time Transport Protocol (SRTP)</strong>, M. Baugher, D. McGrew, M. Naslund, E. Carrara, and K. Norrman, March 2004.</p>
+  </li>
+</ul>`,
+    res: {
+      normative: [{ name: "AV1", url: "https://aomediacodec.github.io/av1-spec/av1-spec.pdf" }],
+      informative: [{ name: "RFC3711", url: "https://tools.ietf.org/html/rfc3711" }]
+    }
+  },
+
+  {
+    title: "looks for references in the last candidate section",
+    html: `
+<h2>Named character references</h2>
+<dl>
+  <dt>A name</dt>
+  <dd>Not a ref</dd>
+</dl>
+<h2>References</h2>
+<dl>
+  <dt id="refsABNF">[ABNF]</dt>
+  <dd><cite><a href="https://www.rfc-editor.org/rfc/rfc5234">Augmented BNF for Syntax Specifications: ABNF</a></cite>, D. Crocker, P. Overell. IETF.</dd>
+  <dt id="refsAPNG">[APNG]</dt>
+  <dd>(Non-normative) <cite><a href="https://wiki.mozilla.org/APNG_Specification">APNG Specification</a></cite>. S. Parmenter, V. Vukicevic, A. Smith. Mozilla.</dd>
+</dl>`,
+    res: {
+      normative: [{ name: "ABNF", url: "https://www.rfc-editor.org/rfc/rfc5234" }],
+      informative: [{ name: "APNG", url: "https://wiki.mozilla.org/APNG_Specification" }]
+    }
+  },
+
+  {
+    title: "does not extract nested links to sections of a reference",
+    html: `
+<h2>Normative references</h2>
+<ul>
+  <li>
+    <a href="https://unicode.org/reports/tr35/">Unicode Locale Data Markup Language (LDML)</a>
+    <ul>
+      <li>
+        <a href="https://unicode.org/reports/tr35/#Unicode_Language_and_Locale_Identifiers">Part 1 Core, Section 3 Unicode Language and Locale Identifiers</a>
+      </li>
+    </ul>
+  </li>
+</ul>`,
+    res: {
+      normative: [{ name: "Unicode Locale Data Markup Language (LDML)", url: "https://unicode.org/reports/tr35/" }],
+      informative: []
+    }
+  },
+
+  {
+    title: "does not use a nested URL as URL of a reference",
+    html: `
+<h2>Normative references</h2>
+<ul>
+  <li>
+    ISO/IEC 10646:2014
+    <ul>
+      <li><a href="https://www.iso.org/iso/catalogue_detail.htm?csnumber=63182">https://www.iso.org/iso/catalogue_detail.htm?csnumber=63182</a></li>
+    </ul>
+  </li>
+</ul>`,
+    res: {
+      normative: [{ name: 'ISO/IEC 10646:2014' }],
+      informative: []
+    }
+  },
+
+  {
+    title: "finds references in the right section",
+    html: `
+<h2>  12.1. Normative
+  References
+</h2>
+<dl>
+  <dt id="refsABNF">[ABNF]</dt>
+  <dd><cite><a href="https://www.rfc-editor.org/rfc/rfc5234">Augmented BNF for Syntax Specifications: ABNF</a></cite>, D. Crocker, P. Overell. IETF.</dd>
+</dl>
+<h2>C.1 Changes to section 12.1. Normative References</h2>
+<dl>
+   <dt>A term</dt>
+   <dd>but not a ref</dd>
+</dl>`,
+    res: {
+      normative: [{ name: "ABNF", url: "https://www.rfc-editor.org/rfc/rfc5234" }],
+      informative: []
+    }
+  },
+
+  {
+    title: "finds 'non-normative' references",
+    html: `
+<h2>Non-normative references</h2>
+<dl>
+  <dt>[CSS-MULTICOL-1]</dt>
+  <dd>Florian Rivoal; Rachel Andrew. <a href="https://drafts.csswg.org/css-multicol/"><cite>CSS Multi-column Layout Module Level 1</cite></a>. URL: <a href="https://drafts.csswg.org/css-multicol/">https://drafts.csswg.org/css-multicol/</a></dd>
+</dl>`,
+    res: {
+      normative: [],
+      informative: [{ name: "CSS-MULTICOL-1", url: "https://drafts.csswg.org/css-multicol/" }]
+    }
+  }
+
+];
+
+describe("References extraction", function () {
+  this.slow(5000);
+
+  let browser;
+  let extractRefsCode;
+  const validateSchema = getSchemaValidationFunction('extract-refs');
+
+  before(async () => {
+    const extractRefsBundle = await rollup.rollup({
+      input: path.resolve(__dirname, '../src/browserlib/extract-references.mjs')
+    });
+    const extractRefsOutput = (await extractRefsBundle.generate({
+      name: 'extractIds',
+      format: 'iife'
+    })).output;
+    extractRefsCode = extractRefsOutput[0].code;
+
+    browser = await puppeteer.launch({ headless: true });
+  });
+
+  testRefs.forEach(t => {
+    it(t.title, async () => {
+      const page = await browser.newPage();
+      page.setContent(t.html);
+      await page.addScriptTag({ content: extractRefsCode });
+
+      const extractedRefs = await page.evaluate(async () => extractIds());
+      await page.close();
+      assert.deepEqual(extractedRefs, t.res);
+
+      if (extractedRefs) {
+        const errors = validateSchema(extractedRefs);
+        assert.strictEqual(errors, null, JSON.stringify(errors, null, 2));
+      }
+    });
+  });
+
+
+  after(async () => {
+    await browser.close();
+  });
+});

--- a/tests/extract-references.js
+++ b/tests/extract-references.js
@@ -180,19 +180,19 @@ const testRefs = [
   },
 
   {
-    title: "does not use a nested URL as URL of a reference",
+    title: "skips nested references as they usually target subparts of the main reference",
     html: `
 <h2>Normative references</h2>
 <ul>
   <li>
-    ISO/IEC 10646:2014
+    RFC3711
     <ul>
-      <li><a href="https://www.iso.org/iso/catalogue_detail.htm?csnumber=63182">https://www.iso.org/iso/catalogue_detail.htm?csnumber=63182</a></li>
+      <li><a href="https://tools.ietf.org/html/rfc3711#section-2">RFC3711 - Section 2</a></li>
     </ul>
   </li>
 </ul>`,
     res: {
-      normative: [{ name: 'ISO/IEC 10646:2014' }],
+      normative: [{ name: "RFC3711" }],
       informative: []
     }
   },
@@ -246,7 +246,7 @@ describe("References extraction", function () {
       input: path.resolve(__dirname, '../src/browserlib/extract-references.mjs')
     });
     const extractRefsOutput = (await extractRefsBundle.generate({
-      name: 'extractIds',
+      name: 'extractRefs',
       format: 'iife'
     })).output;
     extractRefsCode = extractRefsOutput[0].code;
@@ -260,7 +260,7 @@ describe("References extraction", function () {
       page.setContent(t.html);
       await page.addScriptTag({ content: extractRefsCode });
 
-      const extractedRefs = await page.evaluate(async () => extractIds());
+      const extractedRefs = await page.evaluate(async () => extractRefs());
       await page.close();
       assert.deepEqual(extractedRefs, t.res);
 


### PR DESCRIPTION
There were not tests for the extraction of references! 😱

Adding tests revealed that some cases were not properly covered. Not a big deal when extraction missed a few references. More problematic when extraction starts extracting terms it should not. The latter happens when crawling some of the AOM specs that are about to be added to browser-specs, see: https://github.com/w3c/browser-specs/issues/1088

The extraction now also supports flat lists (used in some AOM specs and in few older or external specs) and is more resilient to situations where "references" appears in headings that are *not* about references per se (e.g., a change log that contains a section entitled "Changes to informative references").

The code is not perfect but manages to extract a few references that were previously missed, such as those in ECMA-402. It also works better with AOM specs.

Further improvements are still possible. Typically, the code could be tied with `create-outline.mjs` to scope sections more correctly.