### PR TITLE
Do not choke on PDF specs

### DIFF
--- a/src/browserlib/get-title.mjs
+++ b/src/browserlib/get-title.mjs
@@ -1,10 +1,13 @@
 /**
  * Gets the title of the document
  */
-export default function () {
+export default function (spec) {
   const title = window.document.querySelector('title');
   if (title) {
     return title.textContent.replace(/\s+/g, ' ').trim();
+  }
+  else if (spec?.title) {
+    return spec.title;
   }
   else {
     return '[No title found for ' + window.location.href + ']';

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -350,6 +350,19 @@ async function processSpecification(spec, processFunction, args, options) {
                     return;
                 }
 
+                // Puppeteer does not support loading PDF files and we would
+                // not know how to parse them in any case. Let's return an
+                // empty HTML page instead.
+                if (/\.pdf$/i.test(request.url)) {
+                    await cdp.send('Fetch.fulfillRequest', {
+                        requestId,
+                        responseCode: 200,
+                        responseHeaders: [{ name: 'Content-Type', value: 'text/html' }],
+                        body: ''
+                    });
+                    return;
+                }
+
                 // Abort network requests that return a "stream", they won't
                 // play well with Puppeteer's "networkidle0" option, and our
                 // custom "fetch" function does not handle streams in any case

--- a/tests/crawl.js
+++ b/tests/crawl.js
@@ -73,7 +73,7 @@ if (global.describe && describe instanceof Function) {
         forceLocalFetch: true
       });
       const results = require(path.resolve(output, 'index.json'));
-      assert.equal(refResults.title, results.results[0].title);
+      assert.equal(results.results[0].title, 'Accelerometer');
     });
 
     it("matches spec series shortnames", async () => {


### PR DESCRIPTION
When given a PDF URL, Reffy crashed because Puppeteer rejects them.

This update makes Reffy (roughly) detect PDF URLs and silently skip them, returning empty extracts instead.

The detection of PDF URLs currently relies on them ending with `.pdf`, which is not ideal but avoids more complex code (network interception is done at the request stage. To detect a PDF mime type, the interception would rather need to be done when a response is received from the server).

Internally, a PDF URL is represented as an empty HTML document, so nothing will be extracted. The title extraction now reuses the information from browser-specs when it cannot extract the title, to avoid return "No title found for X" whereas we actually have the info.