### PR TITLE
Align shortname schema with that in browser-specs

### DIFF
--- a/schemas/common.json
+++ b/schemas/common.json
@@ -15,7 +15,7 @@
 
     "shortname": {
       "type": "string",
-      "pattern": "^[\\w\\-]+((?<=-\\d+)\\.\\d+)?$",
+      "pattern": "^[\\w\\-]+((?<=-v?\\d+)\\.\\d+)?$",
       "$comment": "Same definition as in browser-specs"
     },
 


### PR DESCRIPTION
The comment does say that the definition should be the same as that in browser-specs, but the update made to the definition in browser-specs back in September 2022 for the shortname of the FIDO spec (`fido-v2.1`) had not been copied to Reffy yet.

This is now needed because the webauthn-3 spec has started to link to the FIDO spec.