### PR TITLE
Remove HTML comments from extracting htmlProse for definitions

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -138,6 +138,13 @@ function getHtmlProseDefinition(proseEl) {
     el.remove();
   }
 
+  // Remove comments
+  const commentsIterator = document.createNodeIterator(proseEl, NodeFilter.SHOW_COMMENT);
+  let c;
+  while ((c = commentsIterator.nextNode())) {
+    c.remove();
+  }
+
   // Keep simple grouping content and text-level semantics elements
   const keepSelector = [
     'blockquote', 'dd', 'div', 'dl', 'dt', 'figcaption', 'figure', 'hr', 'li',

--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -140,9 +140,9 @@ function getHtmlProseDefinition(proseEl) {
 
   // Remove comments
   const commentsIterator = document.createNodeIterator(proseEl, NodeFilter.SHOW_COMMENT);
-  let c;
-  while ((c = commentsIterator.nextNode())) {
-    c.remove();
+  let comment;
+  while ((comment = commentsIterator.nextNode())) {
+    comment.remove();
   }
 
   // Keep simple grouping content and text-level semantics elements

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -708,7 +708,18 @@ When initialize(<var>newItem</var>) is called, the following steps are run:</p>`
     changesToBaseDfn: [{
       htmlProse: "<dfn>Foo</dfn> <i>enters</i> a <a>bar</a>."
     }]
-  }
+  },
+
+  {
+    title: "skips HTML comments when it extracts the prose that defines a term",
+    html: `<p data-defines='#foo'>
+      <!-- No comment -->
+      <dfn id='foo' data-dfn-type='dfn'>Foo</dfn> enters a bar.
+    </p>`,
+    changesToBaseDfn: [{
+      htmlProse: "<dfn>Foo</dfn> enters a bar."
+    }]
+  },
 ];
 
 describe("Test definition extraction", function () {


### PR DESCRIPTION
Avoid bloat, esp. since ReSpec use comments expansively