### PR TITLE
[IDL extraction] Ignore asides added by Bikeshed

### DIFF
--- a/src/browserlib/extract-webidl.mjs
+++ b/src/browserlib/extract-webidl.mjs
@@ -118,13 +118,10 @@ function extractRespecIdl() {
         .filter(el => !el.closest(informativeSelector))
         .map(el => el.cloneNode(true))
         .map(el => {
-            const header = el.querySelector('.idlHeader');
-            if (header) {
-                header.remove();
-            }
-            const tests = el.querySelector('details.respec-tests-details');
-            if (tests) {
-                tests.remove();
+            for (const ignore of el.querySelectorAll([
+                'aside', '.idlHeader', 'details.respec-tests-details',
+            ].join(','))) {
+                ignore.remove();
             }
             return el;
         })

--- a/tests/extract-webidl.js
+++ b/tests/extract-webidl.js
@@ -112,6 +112,36 @@ interface GreatIdl4 {}`
 <h2 id="idl-index">IDL index</h2>index
 <pre class="idl">interface GreatIdl {}</pre>`,
     res: 'interface GreatIdl {}'
+  },
+
+  {
+    title: "ignores any embedded header",
+    html: `<h1 id=title>Title</h1>
+<pre class="idl">
+  <div class="idlHeader">Look at this great IDL</div>
+  interface GreatIdl {}
+  <div class="idlHeader">There will be more</div>
+</pre>`,
+    res: 'interface GreatIdl {}'
+  },
+
+  {
+    title: "ignores links to tests",
+    html: `<h1 id=title>Title</h1>
+<pre class="idl">
+  interface <details class="respec-tests-details"><summary>3 tests</summary>See WPT</details>GreatIdl {}
+  interface <details class="respec-tests-details"><summary>2 tests</summary>See WPT</details>AnotherGreatIdl {}
+</pre>`,
+    res: `interface GreatIdl {}
+interface AnotherGreatIdl {}`
+  },
+
+  {
+    title: "ignores asides",
+    html: `<h1 id=title>Title</h1>
+<pre class="idl">
+  interface GreatIdl<aside>The interface is referenced from...</aside> {}</pre>`,
+    res: 'interface GreatIdl {}'
   }
 ];
 


### PR DESCRIPTION
Bikeshed may add definition panels next to the IDL code. These panels were not properly ignored during the extraction, see for instance: https://github.com/w3c/webref/blob/a9bd984c13414f17677dec8d06ba4028e4f74294/ed/idl/trusted-types.idl#L55

The update makes the code ignore asides. It also generalizes the code that was dealing with such side info to exclude, and adds a few tests to check that part.