### PR TITLE
[css extraction] Ignore empty lines in table definitions

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -364,11 +364,19 @@ const extractTableDfn = table => {
       const cleanedLine = line.cloneNode(true);
       const annotations = cleanedLine.querySelectorAll(asideSelector);
       annotations.forEach(n => n.remove());
-      return {
-        name: dfnLabel2Property(cleanedLine.querySelector(':first-child').textContent),
-        value: normalize(cleanedLine.querySelector('td:last-child').textContent)
-      };
-    });
+      const nameEl = cleanedLine.querySelector(':first-child');
+      const valueEl = cleanedLine.querySelector('td:last-child');
+      if (nameEl && valueEl) {
+        return {
+          name: dfnLabel2Property(nameEl.textContent),
+          value: normalize(valueEl.textContent)
+        };
+      }
+      else {
+        return null;
+      }
+    })
+    .filter(line => !!line);
   for (let prop of lines) {
     res[prop.name] = prop.value;
   }

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -1484,6 +1484,28 @@ that spans multiple lines */
       type: 'type',
       prose: 'Determines the gradient center of the gradient.'
     }]
+  },
+
+  {
+    title: 'ignores empty lines in table definitions',
+    html: `<table class="propdef">
+    <tbody>
+     <tr>
+      <th>Name:</th>
+      <td>background-color</td>
+     </tr>
+     <tr>
+      <th><a href="#values">Value</a>:</th>
+      <td>&lt;color&gt;</td>
+     </tr>
+     <tr>
+      <th></th>
+     </tr>
+    </tbody></table>`,
+   css: [{
+      "name": "background-color",
+      "value": "<color>"
+   }]
   }
 ];
 


### PR DESCRIPTION
I cannot reproduce it, but Bikeshed generated an empty line at the end of the table definition of `font-style` in css-fonts-4. The extraction logic did not expect that and crashed.

This update makes the extraction logic more resilient by ignoring empty lines.

Via https://github.com/w3c/webref/issues/1130