### PR TITLE
[CSS extract] Fix dl case for SVG 1.1 spec

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -435,11 +435,19 @@ const extractDlDfns = dl => {
     }));
   }
   else {
-    // Markup does not seem to contain IDs, let's extract the text instead
-    const value = normalize(cleanedLine.querySelector('td:last-child').textContent);
-    res = value.split(',').map(name => Object.assign({
-      name: normalize(name.replace(/'/g, ''))
-    }));
+    // Markup does not use definitions, let's look for an ID in the dt itself
+    const dt = dl.querySelector('dt');
+    if (dt.id) {
+      res = [{
+        name: normalize(dt.textContent.replace(/'/g, '')),
+        href: getAbsoluteUrl(dt)
+      }];
+    }
+    else {
+      res = dt.textContent.split(',').map(name => Object.assign({
+        name: normalize(name.replace(/'/g, ''))
+      }));
+    }
   }
 
   const properties = [...dl.querySelectorAll('dd table tr')]

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -1525,6 +1525,59 @@ that spans multiple lines */
       "name": "background-color",
       "value": "<color>"
    }]
+  },
+
+  {
+    title: 'extracts the definition ID from a dt element when needed (SVG11)',
+    html: `<div class="propdef">
+      <dl>
+        <dt id="lighting-color">‘lighting-color’</dt>
+        <dd>
+          <table><tbody>
+            <tr>
+              <td><em>Value:</em>&nbsp;&nbsp;</td>
+              <td>currentColor |<br> &lt;color&gt;</a> [&lt;icccolor&gt;] |<br> inherit</td>
+            </tr>
+            <tr>
+              <td><em>Initial:</em>&nbsp;&nbsp;</td>
+              <td>white</td>
+            </tr>
+          </tbody></table>
+        </dd>
+      </dl>
+    </div>`,
+   css: [{
+      "name": "‘lighting-color’",
+      "href": "about:blank#lighting-color",
+      "value": "currentColor | <color> [<icccolor>] | inherit",
+      "initial": "white"
+   }]
+  },
+
+  {
+    title: 'does not choke on the absence of a definition ID when dt elements are used (SVG11)',
+    html: `<div class="propdef">
+      <dl>
+        <dt>‘lighting-color’</dt>
+        <dd>
+          <table><tbody>
+            <tr>
+              <td><em>Value:</em>&nbsp;&nbsp;</td>
+              <td>currentColor |<br> &lt;color&gt;</a> [&lt;icccolor&gt;] |<br> inherit</td>
+            </tr>
+            <tr>
+              <td><em>Initial:</em>&nbsp;&nbsp;</td>
+              <td>white</td>
+            </tr>
+          </tbody></table>
+        </dd>
+      </dl>
+    </div>`,
+   css: [{
+      "name": "‘lighting-color’",
+      "value": "currentColor | <color> [<icccolor>] | inherit",
+      "initial": "white"
+   }]
   }
 ];
 


### PR DESCRIPTION
Hasty copy-and-paste meant the code that dealt with old CSS property definitions in a dl list (essentially, the SVG 1.1 spec) crashed.

In practice, the CSS extract of SVG 1.1 does not appear in Webref because CSS extracts are only provided for the current specification (SVG 2), so this bug did not have any visible consequence. Still, Reffy crashed on SVG 1.1.