### PR TITLE
Bump web-specs and make crawl skip non public specs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reffy",
-  "version": "14.6.1",
+  "version": "14.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "reffy",
-      "version": "14.6.1",
+      "version": "14.6.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "8.12.0",
@@ -15,7 +15,7 @@
         "fetch-filecache-for-crawling": "5.1.1",
         "puppeteer": "22.0.0",
         "semver": "^7.3.5",
-        "web-specs": "2.79.0",
+        "web-specs": "3.0.0",
         "webidl2": "24.4.1"
       },
       "bin": {
@@ -2896,9 +2896,9 @@
       "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="
     },
     "node_modules/web-specs": {
-      "version": "2.79.0",
-      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-2.79.0.tgz",
-      "integrity": "sha512-364IxMgYLUjWDeTPrfNtO/+zZxIJ2ZzV4STzbOdVn6DANptLBo3aNTEJ0SS2Qe2P331apSfnU0b4K6wxl6cuew=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-3.0.0.tgz",
+      "integrity": "sha512-iFIqX1Zu13dJ9slgPlnxs0ndb1v/oB3WilmTAQRIm/RxyuAdjghoxWWnG6ypYOKdr+zv9lX+q/p9JLMZ1gi1GQ=="
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -5119,9 +5119,9 @@
       "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="
     },
     "web-specs": {
-      "version": "2.79.0",
-      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-2.79.0.tgz",
-      "integrity": "sha512-364IxMgYLUjWDeTPrfNtO/+zZxIJ2ZzV4STzbOdVn6DANptLBo3aNTEJ0SS2Qe2P331apSfnU0b4K6wxl6cuew=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-3.0.0.tgz",
+      "integrity": "sha512-iFIqX1Zu13dJ9slgPlnxs0ndb1v/oB3WilmTAQRIm/RxyuAdjghoxWWnG6ypYOKdr+zv9lX+q/p9JLMZ1gi1GQ=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "fetch-filecache-for-crawling": "5.1.1",
     "puppeteer": "22.0.0",
     "semver": "^7.3.5",
-    "web-specs": "2.79.0",
+    "web-specs": "3.0.0",
     "webidl2": "24.4.1"
   },
   "devDependencies": {

--- a/src/lib/specs-crawler.js
+++ b/src/lib/specs-crawler.js
@@ -88,6 +88,11 @@ async function crawlSpec(spec, crawlOptions) {
         if (crawlOptions.useCrawl) {
             result = await expandSpecResult(spec, crawlOptions.useCrawl);
         }
+        else if (!urlToCrawl) {
+            // No nightly URL? That means the spec is not public (typical
+            // example here is ISO specs). Nothing to crawl in such cases.
+            result = {};
+        }
         else {
             result = await processSpecification(
                 urlToCrawl,
@@ -120,7 +125,9 @@ async function crawlSpec(spec, crawlOptions) {
         }
 
         // Copy results back into initial spec object
-        spec.crawled = result.crawled;
+        if (result.crawled) {
+            spec.crawled = result.crawled;
+        }
         if (result.crawlCacheInfo) {
           spec.crawlCacheInfo = result.crawlCacheInfo;
         }

--- a/tests/crawl.js
+++ b/tests/crawl.js
@@ -178,6 +178,14 @@ if (global.describe && describe instanceof Function) {
       assert.equal(results.length, 0);
     });
 
+    it("does not attempt to crawl specs without a nightly URL", async () => {
+      const url = "https://www.iso.org/standard/85253.html";
+      const results = await crawlSpecs(
+        [{ url }],
+        { forceLocalFetch: true });
+      assert.deepStrictEqual(results[0], { url, versions: [url] });
+    });
+
     after(() => {
       if (mockServer.pendingInterceptors().length > 0) {
         throw new Error("Additional network requests expected on:\n- " + mockServer.pendingInterceptors().map(miss => miss.origin + miss.path).join('\n- '));


### PR DESCRIPTION
This makes Reffy skip specs that do not have a public URL, i.e., those defined in web-specs without a `nightly` property.