### PR TITLE
Add links back to spec in idlparsed extracts

### DIFF
--- a/schemas/postprocessing/idlparsed.json
+++ b/schemas/postprocessing/idlparsed.json
@@ -32,7 +32,8 @@
             "required": ["fragment", "type"],
             "properties": {
               "fragment": { "type": "string" },
-              "type": { "$ref": "../common.json#/$defs/interfacetype" }
+              "type": { "$ref": "../common.json#/$defs/interfacetype" },
+              "href": { "$ref": "../common.json#/$defs/url" }
             }
           }
         },

--- a/schemas/postprocessing/idlparsed.json
+++ b/schemas/postprocessing/idlparsed.json
@@ -48,7 +48,8 @@
               "required": ["fragment", "type"],
               "properties": {
                 "fragment": { "type": "string" },
-                "type": { "$ref": "../common.json#/$defs/extensiontype" }
+                "type": { "$ref": "../common.json#/$defs/extensiontype" },
+                "href": { "$ref": "../common.json#/$defs/url" }
               }
             }
           }

--- a/src/postprocessing/idlparsed.js
+++ b/src/postprocessing/idlparsed.js
@@ -8,17 +8,170 @@
 const webidlParser = require('../cli/parse-webidl');
 
 module.exports = {
-  dependsOn: ['idl'],
+  dependsOn: ['dfns', 'idl'],
   input: 'spec',
   property: 'idlparsed',
 
   run: async function(spec, options) {
+    function getHref(idl, member) {
+      let dfnType;
+      let dfnFor;
+      let dfnOverload = 0;
+      let dfnName;
+      if (member) {
+        if (['iterable', 'maplike', 'setlike'].includes(member.type) ||
+            ['getter', 'setter', 'stringifier', 'deleter'].includes(member.special)) {
+          // No dfns of these types in any spec as of Feb 2024, or at least no
+          // no dfns that we can easily map to (for example, the HTML spec
+          // tends to use generic "dfn" for these).
+          return null;
+        }
+        if (member.type === 'operation') {
+          dfnType = 'method';
+          dfnOverload = idl.members
+            .filter(m => m.type === member.type && m.name === member.name)
+            .findIndex(m => m === member);
+        }
+        else if (member.type === 'field') {
+          dfnType = 'dict-member';
+        }
+        else {
+          dfnType = member.type;
+        }
+        if (!['constructor', 'method', 'attribute', 'enum-value', 'dict-member', 'const'].includes(dfnType)) {
+          console.error(`[error] Found unexpected IDL member type "${dfnType}" in ${spec.shortname}`);
+        }
+        dfnName = member.name ?? member.value;
+        dfnFor = idl.name;
+      }
+      else {
+        // The type of the dfn to look for is the same as the IDL type, except
+        // that composed IDL types ("interface mixin", "callback interface")
+        // only have the basic type in definitions.
+        dfnType = idl.type.split(' ')[0];
+        dfnName = idl.name;
+      }
+
+      const dfnNames = [];
+      if (dfnType === 'enum-value') {
+        // Bikeshed keeps wrapping quotes in the dfn linking text, not ReSpec.
+        dfnNames.push(dfnName);
+        dfnNames.push(`"${dfnName}"`);
+      }
+      else if (dfnType === 'method') {
+        // Bikeshed adds "..." for variadic arguments, not ReSpec. Let's try
+        // both variants. For overloads, Bikeshed essentially expects arguments
+        // to have different names, while ReSpec adds "!overload-x" to
+        // overloaded methods. We'll test all possibilities in order. If the
+        // spec only has a dfn for the most basic method, it's possible that we
+        // end up linking to that dfn from the overloaded methods too, but that
+        // seems good enough in practice.
+        // Last, method definitions sometimes appear without arguments (notably
+        // in the HTML spec).
+        const argsVariadic = member.arguments.map(arg => (arg.variadic ? '...' : '') + arg.name);
+        const args = member.arguments.map(arg => arg.name);
+        dfnNames.push(`${dfnName}!overload-${dfnOverload}(${args.join(', ')})`);
+        dfnNames.push(`${dfnName}(${argsVariadic.join(', ')})`);
+        dfnNames.push(`${dfnName}(${args.join(', ')})`);
+        dfnNames.push(`${dfnName}()`);
+      }
+      else if (dfnType === 'constructor') {
+        // Same as for methods
+        const argsVariadic = member.arguments.map(arg => (arg.variadic ? '...' : '') + arg.name);
+        const args = member.arguments.map(arg => arg.name);
+        dfnNames.push(`constructor!overload-${dfnOverload}(${args.join(', ')})`);
+        dfnNames.push(`constructor(${argsVariadic.join(', ')})`);
+        dfnNames.push(`constructor(${args.join(', ')})`);
+        dfnNames.push(`constructor()`);
+      }
+      else {
+        dfnNames.push(dfnName);
+      }
+
+      // Look for definitions that look like good initial candidates
+      const candidateDfns = spec.dfns
+        .filter(dfn => dfn.type === dfnType && !dfn.informative &&
+          (dfnFor ? dfn.for.includes(dfnFor) : true));
+
+      // Look for names in turn in that list of candidates.
+      for (const name of dfnNames) {
+        const dfns = candidateDfns.filter(dfn => dfn.linkingText.includes(name));
+        if (dfns.length > 0) {
+          if (dfns.length > 1) {
+            const forLabel = dfnFor ? ` for \`${dfnFor}\`` : '';
+            console.warn(`[warn] More than one dfn for ${dfnType} \`${dfnName}\`${forLabel} in [${spec.shortname}](${spec.crawled}).`);
+            return null;
+          }
+          else {
+            return dfns[0].href;
+          }
+        }
+      }
+
+      // Report missing dfns except for specs that we know already lack them
+      if (!['webgl1', 'webgl2', 'svg-animations', 'SVG2'].includes(spec.shortname)) {
+        const forLabel = dfnFor ? ` for \`${dfnFor}\`` : '';
+        console.warn(`[warn] No dfn for ${dfnType} \`${dfnName}\`${forLabel} in [${spec.shortname}](${spec.crawled})`);
+      }
+      return null;
+    }
+
     if (!spec?.idl) {
       return spec;
     }
     try {
       spec.idlparsed = await webidlParser.parse(spec.idl);
       spec.idlparsed.hasObsoleteIdl = webidlParser.hasObsoleteIdl(spec.idl);
+
+      if (spec.dfns) {
+        for (const idl of Object.values(spec.idlparsed.idlNames)) {
+          const href = getHref(idl);
+          if (href) {
+            idl.href = href;
+          }
+
+          if (idl.values) {
+            for (const value of idl.values) {
+              const href = getHref(idl, value);
+              if (href) {
+                value.href = href;
+              }
+            }
+          }
+
+          if (idl.members) {
+            for (const member of idl.members) {
+              const href = getHref(idl, member);
+              if (href) {
+                member.href = href;
+              }
+            }
+          }
+        }
+
+        for (const extendedIdl of Object.values(spec.idlparsed.idlExtendedNames)) {
+          for (const idl of extendedIdl) {
+            // No dfn for the extension, we can only link specific members
+            if (idl.values) {
+              for (const value of idl.values) {
+                const href = getHref(idl, value);
+                if (href) {
+                  value.href = href;
+                }
+              }
+            }
+
+            if (idl.members) {
+              for (const member of idl.members) {
+                const href = getHref(idl, member);
+                if (href) {
+                  member.href = href;
+                }
+              }
+            }
+          }
+        }
+      }
     }
     catch (err) {
       // IDL content is invalid and cannot be parsed.

--- a/tests/generate-idlparsed.js
+++ b/tests/generate-idlparsed.js
@@ -33,4 +33,44 @@ describe('The parsed IDL generator', function () {
 intraface foo {};
 ^ Unrecognised tokens`);
   });
+
+
+  function getIdlSpecWithDfn(type) {
+    return {
+      dfns: [{
+        href: 'about:blank/#foo',
+        linkingText: ['foo'],
+        localLinkingText: [],
+        type: type.split(' ')[0],
+        for: [],
+        access: 'public',
+        informative: false
+      }],
+      idl: `${type} foo {};`
+    };
+  }
+
+  // Note: we could also test "enum", "typedef" and "callback" IDL types, but
+  // the IDL syntax would need to be different (e.g., "enum foo {}" is invalid)
+  for (const type of [
+    'dictionary', 'interface', 'interface mixin',
+    'callback interface', 'namespace'
+  ]) {
+    it(`links back to the definition in the spec when available (${type})`, async () => {
+      const spec = getIdlSpecWithDfn(type);
+      const result = await run(spec);
+      assert.deepEqual(result?.idlparsed?.idlNames, {
+        foo: {
+          extAttrs: [],
+          fragment: `${type} foo {};`,
+          inheritance: null,
+          members: [],
+          name: 'foo',
+          partial: false,
+          type: type,
+          href: 'about:blank/#foo'
+        }
+      });
+    });
+  }
 });


### PR DESCRIPTION
With this update, the idlparsed postprocessing module completes the parsed structures with an `href` property that links back to the definition of the IDL construct in the spec wherever possible.

The logic should already handle variations between Bikeshed and Respec, and seems to work well with overloaded methods in particular.

Linking back to dfns is not always possible. That should signal a problem with the spec. Main reasons why linking back to dfns may not be possible:
- The spec simply does not have the definitions. That happens for a number of enumeration values and constructors for instance.
- The spec does not use the appropriate dfn convention for IDL members. That's the case for WebGL specs but also still a problem for some attributes and methods in the HTML spec.
- The IDL in Webref is patched (for good reasons), and no longer matches what's defined in the spec.
- The spec has an informative/normative hiccup: it defines the IDL as normative but the actual dfns are in an informative section.

See below for a full list of missing definitions when running the module on recent Webref curated data. Note the code does not report issues for webgl1, webgl2, and svg-animations because these specs do not follow the right pattern at all for IDL definitions. Among the other reported problems:
- web-bluetooth: definitions are in an *informative* note, 
- crash-reporting: that's a side effect of "exclude" / "extract" hiccup in the spec
- mediacapture-viewport: normal side effect of the IDL patch we have in Webref
- payment-handler: normal side effect of the IDL patch we have in Webref

Tests are minimal for now, proper testing would require more advanced logic to generate the right spec markup. That's more effort ;)

From a Webref perspective, there's no real guarantee that we can provide: the `href` is best effort, it will be set in 99% of cases in practice (fewer than 300 missing links) but there will likely remain exceptions in the foreseeable future.

<details>
 <summary>List of missing dfns in today's Webref curated data</summary>

 - enum-value `loading` for `DocumentReadyState` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `interactive` for `DocumentReadyState` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `complete` for `DocumentReadyState` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `visible` for `DocumentVisibilityState` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `hidden` for `DocumentVisibilityState` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLElement` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `inert` for `HTMLElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLHtmlElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLHeadElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLTitleElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLBaseElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLLinkElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLMetaElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLStyleElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLBodyElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLHeadingElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLParagraphElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLHRElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLPreElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLQuoteElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLOListElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLUListElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLMenuElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLLIElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLDListElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLDivElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLAnchorElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLDataElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLTimeElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLSpanElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLBRElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLModElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLPictureElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLSourceElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLImageElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLIFrameElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLEmbedElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLObjectElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLVideoElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLAudioElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLTrackElement` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `` for `CanPlayTypeResult` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `subtitles` for `TextTrackKind` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `captions` for `TextTrackKind` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `descriptions` for `TextTrackKind` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `chapters` for `TextTrackKind` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `metadata` for `TextTrackKind` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `TrackEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `track` for `TrackEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLMapElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLAreaElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLTableElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLTableCaptionElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLTableColElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLTableSectionElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLTableRowElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLTableCellElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLFormElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLLabelElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLInputElement` in [html](https://html.spec.whatwg.org/multipage/)
 - method `setRangeText` for `HTMLInputElement` in [html](https://html.spec.whatwg.org/multipage/)
 - method `setRangeText` for `HTMLInputElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLButtonElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLSelectElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLDataListElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLOptGroupElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLOptionElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLTextAreaElement` in [html](https://html.spec.whatwg.org/multipage/)
 - method `setRangeText` for `HTMLTextAreaElement` in [html](https://html.spec.whatwg.org/multipage/)
 - method `setRangeText` for `HTMLTextAreaElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLOutputElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLProgressElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLMeterElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLFieldSetElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLLegendElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `SubmitEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `submitter` for `SubmitEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `FormDataEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `formData` for `FormDataEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLDetailsElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLDialogElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLScriptElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLTemplateElement` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `shadowRootMode` for `HTMLTemplateElement` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `shadowRootDelegatesFocus` for `HTMLTemplateElement` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `shadowRootClonable` for `HTMLTemplateElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLSlotElement` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `flatten` for `AssignedNodesOptions` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLCanvasElement` in [html](https://html.spec.whatwg.org/multipage/)
 - method `drawFocusIfNeeded` for `CanvasUserInterface` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `butt` for `CanvasLineCap` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `round` for `CanvasLineCap` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `square` for `CanvasLineCap` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `round` for `CanvasLineJoin` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `bevel` for `CanvasLineJoin` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `miter` for `CanvasLineJoin` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `letterSpacing` for `CanvasTextDrawingStyles` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `wordSpacing` for `CanvasTextDrawingStyles` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `ImageData` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `ImageData` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `Path2D` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `type` for `ImageEncodeOptions` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `quality` for `ImageEncodeOptions` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `2d` for `OffscreenRenderingContextId` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `bitmaprenderer` for `OffscreenRenderingContextId` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `webgl` for `OffscreenRenderingContextId` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `webgl2` for `OffscreenRenderingContextId` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `webgpu` for `OffscreenRenderingContextId` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `OffscreenCanvas` in [html](https://html.spec.whatwg.org/multipage/)
 - method `commit` for `OffscreenCanvasRenderingContext2D` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `canvas` for `OffscreenCanvasRenderingContext2D` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `extends` for `ElementDefinitionOptions` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `states` for `ElementInternals` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `valueMissing` for `ValidityStateFlags` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `typeMismatch` for `ValidityStateFlags` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `patternMismatch` for `ValidityStateFlags` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `tooLong` for `ValidityStateFlags` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `tooShort` for `ValidityStateFlags` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `rangeUnderflow` for `ValidityStateFlags` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `rangeOverflow` for `ValidityStateFlags` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `stepMismatch` for `ValidityStateFlags` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `badInput` for `ValidityStateFlags` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `customError` for `ValidityStateFlags` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `name` for `VisibilityStateEntry` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `entryType` for `VisibilityStateEntry` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `startTime` for `VisibilityStateEntry` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `duration` for `VisibilityStateEntry` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `ToggleEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `oldState` for `ToggleEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `newState` for `ToggleEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `CloseWatcher` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `DataTransfer` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `DragEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `dataTransfer` for `DragEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `popoverTargetElement` for `PopoverInvokerElement` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `popoverTargetAction` for `PopoverInvokerElement` in [html](https://html.spec.whatwg.org/multipage/)
 - method `navigate` for `Navigation` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `state` for `NavigationReloadOptions` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `NavigateEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - method `getState` for `NavigationDestination` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `NavigationCurrentEntryChangeEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `PopStateEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HashChangeEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `oldURL` for `HashChangeEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `newURL` for `HashChangeEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `PageRevealEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `PageTransitionEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `persisted` for `PageTransitionEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `ErrorEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `message` for `ErrorEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `filename` for `ErrorEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `lineno` for `ErrorEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `colno` for `ErrorEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `error` for `ErrorEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `PromiseRejectionEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `promise` for `PromiseRejectionEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `reason` for `PromiseRejectionEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - method `createImageBitmap` for `WindowOrWorkerGlobalScope` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `DOMParser` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `text/html` for `DOMParserSupportedType` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `text/xml` for `DOMParserSupportedType` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `application/xml` for `DOMParserSupportedType` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `application/xhtml+xml` for `DOMParserSupportedType` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `image/svg+xml` for `DOMParserSupportedType` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `from-image` for `ImageOrientation` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `MessageEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `EventSource` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `MessageChannel` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `BroadcastChannel` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `Worker` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `type` for `WorkerOptions` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `credentials` for `WorkerOptions` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `name` for `WorkerOptions` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `classic` for `WorkerType` in [html](https://html.spec.whatwg.org/multipage/)
 - enum-value `module` for `WorkerType` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `SharedWorker` in [html](https://html.spec.whatwg.org/multipage/)
 - attribute `hardwareConcurrency` for `NavigatorConcurrentHardware` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `StorageEvent` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `key` for `StorageEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `oldValue` for `StorageEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `newValue` for `StorageEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `url` for `StorageEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `storageArea` for `StorageEventInit` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLMarqueeElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLFrameSetElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLFrameElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLDirectoryElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLFontElement` in [html](https://html.spec.whatwg.org/multipage/)
 - constructor for `HTMLParamElement` in [html](https://html.spec.whatwg.org/multipage/)
 - method `write` for `Document` in [html](https://html.spec.whatwg.org/multipage/)
 - method `writeln` for `Document` in [html](https://html.spec.whatwg.org/multipage/)
 - method `execCommand` for `Document` in [html](https://html.spec.whatwg.org/multipage/)
 - method `queryCommandEnabled` for `Document` in [html](https://html.spec.whatwg.org/multipage/)
 - method `queryCommandIndeterm` for `Document` in [html](https://html.spec.whatwg.org/multipage/)
 - method `queryCommandState` for `Document` in [html](https://html.spec.whatwg.org/multipage/)
 - method `queryCommandSupported` for `Document` in [html](https://html.spec.whatwg.org/multipage/)
 - method `queryCommandValue` for `Document` in [html](https://html.spec.whatwg.org/multipage/)
 - dict-member `services` for `BluetoothLEScanFilterInit` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - dict-member `name` for `BluetoothLEScanFilterInit` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - dict-member `namePrefix` for `BluetoothLEScanFilterInit` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - dict-member `manufacturerData` for `BluetoothLEScanFilterInit` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - dict-member `serviceData` for `BluetoothLEScanFilterInit` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - dict-member `filters` for `RequestDeviceOptions` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - dict-member `exclusionFilters` for `RequestDeviceOptions` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - dict-member `optionalServices` for `RequestDeviceOptions` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - dict-member `optionalManufacturerData` for `RequestDeviceOptions` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - dict-member `acceptAllDevices` for `RequestDeviceOptions` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `id` for `BluetoothDevice` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `name` for `BluetoothDevice` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `watchingAdvertisements` for `BluetoothDevice` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `device` for `BluetoothAdvertisingEvent` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `uuids` for `BluetoothAdvertisingEvent` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `name` for `BluetoothAdvertisingEvent` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `appearance` for `BluetoothAdvertisingEvent` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `txPower` for `BluetoothAdvertisingEvent` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `rssi` for `BluetoothAdvertisingEvent` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `manufacturerData` for `BluetoothAdvertisingEvent` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `serviceData` for `BluetoothAdvertisingEvent` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `device` for `BluetoothRemoteGATTServer` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `connected` for `BluetoothRemoteGATTServer` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `device` for `BluetoothRemoteGATTService` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `uuid` for `BluetoothRemoteGATTService` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `isPrimary` for `BluetoothRemoteGATTService` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `service` for `BluetoothRemoteGATTCharacteristic` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `uuid` for `BluetoothRemoteGATTCharacteristic` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `properties` for `BluetoothRemoteGATTCharacteristic` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `value` for `BluetoothRemoteGATTCharacteristic` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `characteristic` for `BluetoothRemoteGATTDescriptor` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `uuid` for `BluetoothRemoteGATTDescriptor` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - attribute `value` for `BluetoothRemoteGATTDescriptor` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - typedef `BluetoothServiceUUID` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - typedef `BluetoothCharacteristicUUID` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - typedef `BluetoothDescriptorUUID` in [web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth/)
 - dict-member `keepRepeatedDevices` for `BluetoothLEScanOptions` in [web-bluetooth-scanning](https://webbluetoothcg.github.io/web-bluetooth
 - dict-member `acceptAllAdvertisements` for `BluetoothLEScanOptions` in [web-bluetooth-scanning](https://webbluetoothcg.github.io/
 - interface `CrashReportBody` in [crash-reporting](https://wicg.github.io/crash-reporting/)
 - method `toJSON` for `CrashReportBody` in [crash-reporting](https://wicg.github.io/crash-reporting/)
 - attribute `reason` for `CrashReportBody` in [crash-reporting](https://wicg.github.io/crash-reporting/)
 - attribute `processingStart` for `PerformanceEventTiming` in [event-timing](https://w3c.github.io/event-timing/)
 - attribute `processingEnd` for `PerformanceEventTiming` in [event-timing](https://w3c.github.io/event-timing/)
 - attribute `cancelable` for `PerformanceEventTiming` in [event-timing](https://w3c.github.io/event-timing/)
 - attribute `interactionId` for `PerformanceEventTiming` in [event-timing](https://w3c.github.io/event-timing/)
 - dictionary `ViewportMediaStreamConstraints` in [mediacapture-viewport](https://w3c.github.io/mediacapture-viewport/)
 - dict-member `video` for `ViewportMediaStreamConstraints` in [mediacapture-viewport](https://w3c.github.io/mediacapture-viewport/)
 - dict-member `audio` for `ViewportMediaStreamConstraints` in [mediacapture-viewport](https://w3c.github.io/mediacapture-viewport/)
 - dictionary `AddressInit` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `country` for `AddressInit` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `addressLine` for `AddressInit` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `region` for `AddressInit` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `city` for `AddressInit` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `dependentLocality` for `AddressInit` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `postalCode` for `AddressInit` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `sortingCode` for `AddressInit` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `organization` for `AddressInit` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `recipient` for `AddressInit` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `phone` for `AddressInit` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dictionary `PaymentOptions` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `requestPayerName` for `PaymentOptions` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `requestBillingAddress` for `PaymentOptions` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `requestPayerEmail` for `PaymentOptions` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `requestPayerPhone` for `PaymentOptions` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `requestShipping` for `PaymentOptions` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `shippingType` for `PaymentOptions` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dictionary `PaymentShippingOption` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `id` for `PaymentShippingOption` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `label` for `PaymentShippingOption` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `amount` for `PaymentShippingOption` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `selected` for `PaymentShippingOption` in [payment-handler](https://w3c.github.io/payment-handler/)
 - enum `PaymentShippingType` in [payment-handler](https://w3c.github.io/payment-handler/)
 - enum-value `shipping` for `PaymentShippingType` in [payment-handler](https://w3c.github.io/payment-handler/)
 - enum-value `delivery` for `PaymentShippingType` in [payment-handler](https://w3c.github.io/payment-handler/)
 - enum-value `pickup` for `PaymentShippingType` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dictionary `AddressErrors` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `addressLine` for `AddressErrors` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `city` for `AddressErrors` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `country` for `AddressErrors` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `dependentLocality` for `AddressErrors` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `organization` for `AddressErrors` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `phone` for `AddressErrors` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `postalCode` for `AddressErrors` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `recipient` for `AddressErrors` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `region` for `AddressErrors` in [payment-handler](https://w3c.github.io/payment-handler/)
 - dict-member `sortingCode` for `AddressErrors` in [payment-handler](https://w3c.github.io/payment-handler/)
 - method `toJSON` for `PaymentResponse` in [payment-request-1.1](https://w3c.github.io/payment-request/)
</details>