### PR TITLE
Schema of elements extracts: make `href` a required property

### DIFF
--- a/schemas/browserlib/extract-elements.json
+++ b/schemas/browserlib/extract-elements.json
@@ -6,7 +6,7 @@
   "items": {
     "type": "object",
     "additionalProperties": false,
-    "required": ["name"],
+    "required": ["name", "href"],
     "properties": {
       "name": { "type": "string" },
       "interface": { "$ref": "../common.json#/$defs/interface" },


### PR DESCRIPTION
With the last update, the extraction always sets the property, let's make that a guarantee in the schema.

(should have been part of PR #1495...)