### PR TITLE
Fix post-processing on specs that crawler skipped

### DIFF
--- a/src/lib/post-processor.js
+++ b/src/lib/post-processor.js
@@ -126,7 +126,7 @@ async function run(mod, crawlResult, options) {
   mod = getModule(mod);
 
   if (mod.input === 'crawl') {
-    if (crawlResult.crawled) {
+    if (crawlResult.crawled || !crawlResult.results) {
       // Post-processing module runs at the crawl level and we received
       // a spec crawl result
       return;


### PR DESCRIPTION
Reffy now skips specs that do not have a nightly URL, such as ISO specs. When that happens, the result of the crawl for the spec is an empty object.

The post-processor runs modules at the spec level and at the crawl level, and used the presence of a `crawled` property to distinguish between these levels. It thus attempted to run modules that apply at the crawl level to the empty spec crawl result.

The post-processor now also checks whether there is a `results` property. It still looks at `crawled` to account for the unlikely case where we decide to create a crawl module named `results`.