### PR TITLE
Use util.inspect() to report crawl errors

### DIFF
--- a/src/lib/specs-crawler.js
+++ b/src/lib/specs-crawler.js
@@ -13,6 +13,7 @@
 const fs = require('fs');
 const path = require('path');
 const specs = require('web-specs');
+const inspect = require('util').inspect;
 const cssDfnParser = require('./css-grammar-parser');
 const postProcessor = require('./post-processor');
 const {
@@ -145,7 +146,7 @@ async function crawlSpec(spec, crawlOptions) {
     }
     catch (err) {
         spec.title = spec.title || '[Could not be determined, see error]';
-        spec.error = err.toString() + (err.stack ? ' ' + err.stack : '');
+        spec.error = inspect(err);
     }
 
     return specOrFallback(spec, fallbackFolder, crawlOptions.fallbackData?.results);

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -490,7 +490,7 @@ async function processSpecification(spec, processFunction, args, options) {
             }
             prefetchedResponse[spec.url] = response;
           } catch (err) {
-            throw new Error(`Loading ${spec.url} triggered network error ${err}`);
+            throw new Error(`Loading ${spec.url} triggered network error`, { cause: err });
           }
           if (response.status !== 200) {
             throw new Error(`Loading ${spec.url} triggered HTTP status ${response.status}`);
@@ -545,7 +545,7 @@ async function processSpecification(spec, processFunction, args, options) {
             try {
               result = await page.goto(spec.url, loadOptions);
             } catch (err) {
-              throw new Error(`Loading ${spec.url} triggered network error ${err}`);
+              throw new Error(`Loading ${spec.url} triggered network error`, { cause: err });
             }
             if ((result.status() !== 200) && (!spec.url.startsWith('file://') || (result.status() !== 0))) {
               throw new Error(`Loading ${spec.url} triggered HTTP status ${result.status()}`);


### PR DESCRIPTION
When a spec cannot be crawled, the `error` property is set to something that looked like a detailed error with a stack trace, but that actually skipped over the chain of causes that led to the final `throw` clause. In the end, when a fetch failed, the fetched URL appeared in the message but not the reason why the fetch failed.

Using `util.inspect()` gives us a more complete error message. That's targeted at debugging, and message may not be stable from one version of Node.js to another, but understanding precisely what went wrong is exactly what we need in such cases!

Practically speaking, I'm hoping that this will help me investigate the (hopefully transient) crawl fetch errors currently reported in Webref for FX and Houdini task force specs.
