### PR TITLE
Drop dependency on chai for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "reffy": "reffy.js"
       },
       "devDependencies": {
-        "chai": "4.3.10",
         "mocha": "10.3.0",
         "respec": "34.4.0",
         "respec-hljs": "2.1.1",
@@ -636,15 +635,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -804,24 +794,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/chai": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
-      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
-      "dev": true,
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -848,18 +820,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -1030,18 +990,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/degenerator": {
@@ -1425,15 +1373,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -1781,15 +1720,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/loupe": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
-      "dev": true,
-      "dependencies": {
-        "get-func-name": "^2.0.0"
       }
     },
     "node_modules/lru-cache": {
@@ -2194,15 +2124,6 @@
       "integrity": "sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==",
       "engines": {
         "node": "14 || >=16.14"
-      }
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/pend": {
@@ -2822,15 +2743,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
@@ -3494,12 +3406,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
     "ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -3607,21 +3513,6 @@
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
     },
-    "chai": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
-      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
-      }
-    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3641,15 +3532,6 @@
             "has-flag": "^4.0.0"
           }
         }
-      }
-    },
-    "check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
-      "requires": {
-        "get-func-name": "^2.0.2"
       }
     },
     "chokidar": {
@@ -3766,15 +3648,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
-    },
-    "deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
-      }
     },
     "degenerator": {
       "version": "5.0.1",
@@ -4052,12 +3925,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
-    "get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true
-    },
     "get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -4303,15 +4170,6 @@
       "requires": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
-      }
-    },
-    "loupe": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
-      "dev": true,
-      "requires": {
-        "get-func-name": "^2.0.0"
       }
     },
     "lru-cache": {
@@ -4596,12 +4454,6 @@
           "integrity": "sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A=="
         }
       }
-    },
-    "pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true
     },
     "pend": {
       "version": "1.2.0",
@@ -5054,12 +4906,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
     },
     "unbzip2-stream": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "webidl2": "24.4.1"
   },
   "devDependencies": {
-    "chai": "4.3.10",
     "mocha": "10.3.0",
     "respec": "34.4.0",
     "respec-hljs": "2.1.1",

--- a/tests/crawl.js
+++ b/tests/crawl.js
@@ -30,7 +30,7 @@ async function runWithAnnotatedCrawlData(path, fn) {
 }
 
 if (global.describe && describe instanceof Function) {
-  const { assert } = require('chai');
+  const assert = require('assert');
 
   describe("The crawler", function () {
     this.slow(20000);
@@ -109,7 +109,7 @@ if (global.describe && describe instanceof Function) {
           fallback
         }));
       assert.equal(results[0].title, "Change is the only constant");
-      assert.isUndefined(results[0].error);
+      assert.ifError(results[0].error);
       assert.equal(results[0].refs, "A useful list of refs");
     })
 
@@ -119,7 +119,7 @@ if (global.describe && describe instanceof Function) {
         [{ url, nightly: { url } }],
         { forceLocalFetch: true });
       assert.equal(results[0].title, "[Could not be determined, see error]");
-      assert.include(results[0].error, "Loading https://www.w3.org/TR/idontexist/ triggered HTTP status 404");
+      assert(results[0].error.includes("Loading https://www.w3.org/TR/idontexist/ triggered HTTP status 404"));
     });
 
     it("reports errors and returns fallback data when possible", async () => {
@@ -132,7 +132,7 @@ if (global.describe && describe instanceof Function) {
           fallback
         });
       assert.equal(results[0].title, "On the Internet, nobody knows you don't exist");
-      assert.include(results[0].error, "Loading https://www.w3.org/TR/idontexist/ triggered HTTP status 404");
+      assert(results[0].error.includes("Loading https://www.w3.org/TR/idontexist/ triggered HTTP status 404"));
       assert.equal(results[0].refs, "A useful list of refs");
     });
 
@@ -147,7 +147,7 @@ if (global.describe && describe instanceof Function) {
       });
       const results = require(path.resolve(output, "index.json"));
       assert.equal(results.results[0].url, "https://www.w3.org/TR/idontexist/");
-      assert.include(results.results[0].error, "Loading https://www.w3.org/TR/idontexist/ triggered HTTP status 404");
+      assert(results.results[0].error.includes("Loading https://www.w3.org/TR/idontexist/ triggered HTTP status 404"));
       assert.equal(results.results[0].refs, "refs/idontexist.json");
       const refs = require(path.resolve(output, "refs", "idontexist.json"));
       assert.equal(refs.refs, "A useful list of refs");
@@ -159,7 +159,7 @@ if (global.describe && describe instanceof Function) {
         [{ url, nightly: { url } }],
         { forceLocalFetch: true });
       assert.equal(results[0].title, "[Could not be determined, see error]");
-      assert.include(results[0].error, "CSS server issue detected");
+      assert(results[0].error.includes("CSS server issue detected"));
     });
 
     it("crawls the published spec when `--release` is set", async () => {

--- a/tests/create-outline.js
+++ b/tests/create-outline.js
@@ -1,4 +1,4 @@
-const { assert } = require('chai');
+const assert = require('assert');
 const puppeteer = require('puppeteer');
 const path = require('path');
 const rollup = require('rollup');

--- a/tests/css-grammar-parser/test.js
+++ b/tests/css-grammar-parser/test.js
@@ -1,6 +1,6 @@
 const css = require("../../src/lib/css-grammar-parser");
 const fs = require("fs");
-const expect = require('chai').expect;
+const assert = require("assert");
 
 const propDefs = fs.readFileSync("tests/css-grammar-parser/in", "utf-8").split("\n").map(def => def.trim());
 const propDefsOut = JSON.parse(fs.readFileSync("tests/css-grammar-parser/out.json", "utf-8"));
@@ -9,7 +9,7 @@ const results = propDefs.map(css.parsePropDefValue);
 describe('Parser correctly parses grammar instances', () => {
   for(let i in results) {
     it(`parses property definition ${propDefs[i]} as expected`, () => {
-      expect(results[i]).to.deep.equal(propDefsOut[i], `Parsing ${propDefs[i]} got ${JSON.stringify(results[i], null, 2)} instead of ${JSON.stringify(propDefsOut[i], null, 2)}`);
+      assert.deepStrictEqual(results[i], propDefsOut[i], `Parsing ${propDefs[i]} got ${JSON.stringify(results[i], null, 2)} instead of ${JSON.stringify(propDefsOut[i], null, 2)}`);
     });
   }
 });

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -1,4 +1,4 @@
-const { assert } = require('chai');
+const assert = require('assert');
 const puppeteer = require('puppeteer');
 const path = require('path');
 const rollup = require('rollup');

--- a/tests/extract-elements.js
+++ b/tests/extract-elements.js
@@ -1,4 +1,4 @@
-const { assert } = require('chai');
+const assert = require('assert');
 const puppeteer = require('puppeteer');
 const path = require('path');
 const rollup = require('rollup');

--- a/tests/extract-events.js
+++ b/tests/extract-events.js
@@ -1,4 +1,4 @@
-const { assert } = require('chai');
+const assert = require('assert');
 const puppeteer = require('puppeteer');
 const path = require('path');
 const rollup = require('rollup');

--- a/tests/extract-headings.js
+++ b/tests/extract-headings.js
@@ -1,4 +1,4 @@
-const { assert } = require('chai');
+const assert = require('assert');
 const puppeteer = require('puppeteer');
 const path = require('path');
 const rollup = require('rollup');

--- a/tests/extract-ids.js
+++ b/tests/extract-ids.js
@@ -1,4 +1,4 @@
-const { assert } = require('chai');
+const assert = require('assert');
 const puppeteer = require('puppeteer');
 const path = require('path');
 const rollup = require('rollup');

--- a/tests/extract-references.js
+++ b/tests/extract-references.js
@@ -1,4 +1,4 @@
-const { assert } = require('chai');
+const assert = require('assert');
 const puppeteer = require('puppeteer');
 const path = require('path');
 const rollup = require('rollup');

--- a/tests/extract-webidl.js
+++ b/tests/extract-webidl.js
@@ -1,4 +1,4 @@
-const { assert } = require('chai');
+const assert = require('assert');
 const puppeteer = require('puppeteer');
 const path = require('path');
 const rollup = require('rollup');

--- a/tests/generate-idlparsed.js
+++ b/tests/generate-idlparsed.js
@@ -1,4 +1,4 @@
-const { assert } = require('chai');
+const assert = require('assert');
 const { run } = require('../src/postprocessing/idlparsed');
 
 describe('The parsed IDL generator', function () {

--- a/tests/reffy-package.js
+++ b/tests/reffy-package.js
@@ -1,4 +1,4 @@
-const { assert } = require("chai");
+const assert = require("assert");
 const os = require("os");
 const fs = require("fs");
 const path = require("path");

--- a/tests/util.js
+++ b/tests/util.js
@@ -1,4 +1,4 @@
-const { assert } = require('chai');
+const assert = require('assert');
 
 const specs = require('web-specs');
 const {
@@ -26,36 +26,36 @@ describe('isLatestLevelThatPasses', () => {
 
   it('returns true if spec without level passes the predicate', () => {
     const spec = specs.find(spec => !spec.seriesVersion);
-    assert.isTrue(isLatestLevelThatPasses(spec, specs, _ => true));
+    assert.strictEqual(isLatestLevelThatPasses(spec, specs, _ => true), true);
   });
 
   it('returns true if spec without level and no predicate', () => {
     const spec = specs.find(spec => !spec.seriesVersion);
-    assert.isTrue(isLatestLevelThatPasses(spec, specs));
+    assert.strictEqual(isLatestLevelThatPasses(spec, specs), true);
   });
 
   it('returns false if spec does not pass the predicate', () => {
     const spec = specs.find(spec => !spec.seriesVersion);
-    assert.isFalse(isLatestLevelThatPasses(spec, specs, _ => false));
+    assert.strictEqual(isLatestLevelThatPasses(spec, specs, _ => false), false);
   });
 
   it('returns true if spec is the latest level', () => {
     const spec = specs.find(spec => spec.seriesPrevious && !spec.seriesNext &&
       (spec.seriesComposition === 'full'));
-    assert.isTrue(isLatestLevelThatPasses(spec, specs));
+    assert.strictEqual(isLatestLevelThatPasses(spec, specs), true);
   });
 
   it('returns false if spec is not the latest level', () => {
     const spec = specs.find(spec => spec.seriesNext &&
       specs.find(s => (s.shortname === spec.seriesNext) &&
         (s.seriesComposition === 'full')));
-    assert.isFalse(isLatestLevelThatPasses(spec, specs));
+    assert.strictEqual(isLatestLevelThatPasses(spec, specs), false);
   });
 
   it('returns true if greater level has another shortname', () => {
     const spec = specs.find(spec => (spec.seriesVersion === '1') &&
       (spec.seriesComposition === 'full'));
-    assert.isTrue(isLatestLevelThatPasses(spec, specs));
+    assert.strictEqual(isLatestLevelThatPasses(spec, specs), true);
   });
 
   it('returns true if delta spec is alone', () => {
@@ -63,14 +63,14 @@ describe('isLatestLevelThatPasses', () => {
     const list = spec.seriesPrevious ?
       specs.filter(s => s.shortname !== spec.seriesPrevious) :
       specs;
-    assert.isTrue(isLatestLevelThatPasses(spec, list));
+    assert.strictEqual(isLatestLevelThatPasses(spec, list), true);
   });
 
   it('returns true if greater level is a delta spec', () => {
     const delta = specs.find(spec => (spec.seriesComposition === 'delta') &&
       spec.seriesPrevious);
     const spec = specs.find(spec => spec.shortname === delta.seriesPrevious);
-    assert.isTrue(isLatestLevelThatPasses(spec, specs));
+    assert.strictEqual(isLatestLevelThatPasses(spec, specs), true);
   });
 
   it('returns true if greater level does not pass predicate', () => {
@@ -88,14 +88,14 @@ describe('isLatestLevelThatPasses', () => {
       isRecentEnough(spec) &&
       specs.find(s => (s.shortname === spec.seriesNext) &&
         (s.seriesComposition === 'full')));
-    assert.isTrue(isLatestLevelThatPasses(spec, specs, s => s === spec));
+    assert.strictEqual(isLatestLevelThatPasses(spec, specs, s => s === spec), true);
   });
 
   it('returns false if spec is too old', () => {
     const spec = specs.find(spec => spec.seriesPrevious &&
       spec.shortname === spec.series.currentSpecification);
     const previous = specs.find(s => s.shortname === spec.seriesPrevious);
-    assert.isFalse(isLatestLevelThatPasses(previous, specs, s => s === previous));
+    assert.strictEqual(isLatestLevelThatPasses(previous, specs, s => s === previous), false);
   });
 
   it('returns true for delta spec when full spec is too old', () => {
@@ -104,7 +104,7 @@ describe('isLatestLevelThatPasses', () => {
     // spec in the list.
     const old = specs.find(spec => spec.shortname === 'css-cascade-3');
     const delta = specs.find(spec => spec.shortname === 'css-cascade-6');
-    assert.isTrue(isLatestLevelThatPasses(delta, specs, s => s === delta || s === old));
+    assert.strictEqual(isLatestLevelThatPasses(delta, specs, s => s === delta || s === old), true);
   });
 });
 

--- a/tests/webidl-parser/exported-names.js
+++ b/tests/webidl-parser/exported-names.js
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+const assert = require('assert');
 
 describe('The WebIDL parser exports all IDL names', () => {
   var parse = require('../../src/cli/parse-webidl').parse;
@@ -12,13 +12,11 @@ describe('The WebIDL parser exports all IDL names', () => {
       typedef string testTypedef;
       callback interface testCallbackInterface {};
     `);
-    expect(data).to.be.an('object').with.property('idlNames');
-    expect(data.idlNames).to.have.property('testInterface');
-    expect(data.idlNames).to.have.property('testDict');
-    expect(data.idlNames).to.have.property('testEnum');
-    expect(data.idlNames).to.have.property('testCallback');
-    expect(data.idlNames).to.have.property('testTypedef');
-    expect(data.idlNames).to.have.property('testCallbackInterface');
+    assert(data?.idlNames?.testInterface, 'testInterface property is missing');
+    assert(data?.idlNames?.testDict, 'testDict property is missing');
+    assert(data?.idlNames?.testEnum, 'testEnum property is missing');
+    assert(data?.idlNames?.testCallback, 'testCallback property is missing');
+    assert(data?.idlNames?.testCallbackInterface, 'testCallbackInterface property is missing');
   });
 
   it('does not export partial named definitions', async () => {
@@ -26,8 +24,8 @@ describe('The WebIDL parser exports all IDL names', () => {
       partial interface testInterface {};
       partial dictionary testDict {};
     `);
-    expect(data).to.be.an('object').with.property('idlNames');
-    expect(data.idlNames).not.to.have.property('testInterface');
-    expect(data.idlNames).not.to.have.property('testDict');
+    assert(data?.idlNames, 'idlNames property is missing');
+    assert(!data.idlNames.testInterface, 'testInterface property should not exist');
+    assert(!data.idlNames.testDict, 'testDict property should not exist');
   });
 });

--- a/tests/webidl-parser/global.js
+++ b/tests/webidl-parser/global.js
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+const assert = require('assert');
 
 describe('For Global/Exposed attributes, the WebIDL parser', () => {
   var parse = require('../../src/cli/parse-webidl').parse;
@@ -7,13 +7,10 @@ describe('For Global/Exposed attributes, the WebIDL parser', () => {
     const data = await parse(`
       interface notExposedOnWindow {};
     `);
-    expect(data).to.have.property('jsNames');
-    expect(data.jsNames).to.have.property('functions');
-    expect(data.jsNames.functions).not.to.have.property('Window');
-    expect(data).to.have.property('globals');
-    expect(data.globals).to.deep.equal({});
-    expect(data).to.have.property('exposed');
-    expect(data.exposed).to.deep.equal({});
+    assert(data?.jsNames?.functions, 'jsNames.functions property is missing');
+    assert(!data.jsNames.functions.hasOwnProperty('Window'), 'jsNames.functions.Window should not be set');
+    assert.deepStrictEqual(data.globals, {}, 'Globals should be an empty object');
+    assert.deepStrictEqual(data.exposed, {}, 'Exposed should be an empty object');
   });
 
   it('detects a simple global definition and reference to it', async () => {
@@ -24,16 +21,9 @@ describe('For Global/Exposed attributes, the WebIDL parser', () => {
       [Exposed=primaryInterface]
       interface exposedOnPrimaryInterface {};
     `);
-    expect(data).to.have.property('globals');
-    expect(data.globals).to.have.property('primaryInterface');
-    expect(data.globals.primaryInterface).to.contain('primaryInterface');
-    expect(data).to.have.property('exposed');
-    expect(data.exposed).to.have.property('primaryInterface');
-    expect(data.exposed.primaryInterface).to.contain('exposedOnPrimaryInterface');
-    expect(data).to.have.property('jsNames');
-    expect(data.jsNames).to.have.property('functions');
-    expect(data.jsNames.functions).to.have.property('primaryInterface');
-    expect(data.jsNames.functions.primaryInterface).to.contain('exposedOnPrimaryInterface');
+    assert(data?.globals?.primaryInterface?.includes('primaryInterface'), 'globals.primaryInterface is not set or does not contain "primaryInterface"');
+    assert(data?.exposed?.primaryInterface?.includes('exposedOnPrimaryInterface'), 'exposed.primaryInterface is not set or does not contain "exposedOnPrimaryInterface"');
+    assert(data?.jsNames?.functions?.primaryInterface?.includes('exposedOnPrimaryInterface'), 'jsNames.functions.primaryInterface is not set or does not contain "exposedOnPrimaryInterface"');
   });
 
   it('uses the right name for a global interface definition', async () => {
@@ -41,18 +31,11 @@ describe('For Global/Exposed attributes, the WebIDL parser', () => {
       [Global=theInterface, Exposed=theInterface]
       interface anInterface {};
     `);
-    expect(data).to.have.property('globals');
-    expect(data.globals).to.have.property('theInterface');
-    expect(data.globals).not.to.have.property('anInterface');
-    expect(data.globals.theInterface).to.contain('anInterface');
-    expect(data).to.have.property('exposed');
-    expect(data.exposed).to.have.property('theInterface');
-    expect(data.exposed).not.to.have.property('anInterface');
-    expect(data.exposed.theInterface).to.contain('anInterface');
-    expect(data).to.have.property('jsNames');
-    expect(data.jsNames).to.have.property('functions');
-    expect(data.jsNames.functions).to.have.property('theInterface');
-    expect(data.jsNames.functions.theInterface).to.contain('anInterface');
+    assert(data?.globals?.theInterface?.includes('anInterface'), 'globals.theInterface is not set or does not contain "anInterface"');
+    assert(!data.globals.anInterface, 'globals.anInterface should not be set');
+    assert(data?.exposed?.theInterface?.includes('anInterface'), 'exposed.theInterface is not set or does not contain "anInterface"');
+    assert(!data?.exposed?.anInterface, 'exposed.anInterface should not be set');
+    assert(data?.jsNames?.functions?.theInterface?.includes('anInterface'), 'jsNames.functions.theInterfaces is not set or does not contain "anInterface"');
   });
 
   it('understands multiple names for a global interface definition', async () => {
@@ -60,22 +43,14 @@ describe('For Global/Exposed attributes, the WebIDL parser', () => {
       [Global=(theInterface,sameInterface), Exposed=theInterface]
       interface anInterface {};
     `);
-    expect(data).to.have.property('globals');
-    expect(data.globals).to.have.property('theInterface');
-    expect(data.globals).to.have.property('sameInterface');
-    expect(data.globals).not.to.have.property('anInterface');
-    expect(data.globals.theInterface).to.contain('anInterface');
-    expect(data.globals.sameInterface).to.contain('anInterface');
-    expect(data).to.have.property('exposed');
-    expect(data.exposed).to.have.property('theInterface');
-    expect(data.exposed).not.to.have.property('sameInterface');
-    expect(data.exposed).not.to.have.property('anInterface');
-    expect(data.exposed.theInterface).to.contain('anInterface');
-    expect(data).to.have.property('jsNames');
-    expect(data.jsNames).to.have.property('functions');
-    expect(data.jsNames.functions).to.have.property('theInterface');
-    expect(data.jsNames.functions).not.to.have.property('sameInterface');
-    expect(data.jsNames.functions.theInterface).to.contain('anInterface');
+    assert(data?.globals?.theInterface?.includes('anInterface'), 'globals.theInterface is not set or does not contain "anInterface"');
+    assert(data?.globals?.sameInterface?.includes('anInterface'), 'globals.sameInterface is not set or does not contain "anInterface"');
+    assert(!data?.globals?.anInterface, 'globals.anInterface should not be set');
+    assert(data?.exposed?.theInterface?.includes('anInterface'), 'exposed.theInterface is not set or does not contain "anInterface"');
+    assert(!data?.exposed?.sameInterface, 'exposed.sameInterface should not be set');
+    assert(!data?.exposed?.anInterface, 'exposed.anInterface should not be set');
+    assert(data?.jsNames?.functions?.theInterface?.includes('anInterface'), 'jsNames.functions.theInterface is not set or does not contain "anInterface"');
+    assert(!data?.jsNames?.functions?.sameInterface, 'jsNames.functions.sameInterface should not be set');
   });
 
   it('parses the Exposed=* extended attribute correctly', async () => {
@@ -83,7 +58,6 @@ describe('For Global/Exposed attributes, the WebIDL parser', () => {
       [Exposed=*]
       interface anInterface {};
     `);
-    expect(data).to.have.property('exposed');
-    expect(data.exposed).to.have.property('*');
+    assert(data?.exposed?.['*'], 'exposed is not set or does not have a "*" property');
   });
 });

--- a/tests/webidl-parser/includes.js
+++ b/tests/webidl-parser/includes.js
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+const assert = require('assert');
 
 describe('The WebIDL parser understands includes statements', () => {
   var parse = require('../../src/cli/parse-webidl').parse;
@@ -9,7 +9,6 @@ interface Base {};
 interface Extended {};
 Extended includes Base;
     `);
-    expect(data).to.have.property('idlNames');
-    expect(data.idlNames).to.have.property('Extended');
+    assert(data?.idlNames?.Extended, 'idlNames.Extended is not set');
   });
 });

--- a/tests/webidl-parser/well-known.js
+++ b/tests/webidl-parser/well-known.js
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+const assert = require('assert');
 
 describe('When it parses well-known types, the WebIDL parser', () => {
   const parse = require('../../src/cli/parse-webidl').parse;
@@ -12,11 +12,10 @@ describe('When it parses well-known types, the WebIDL parser', () => {
           ${type} doNothing();
         };
       `);
-      expect(data).to.be.an('object').with.property('dependencies');
-      expect(data.dependencies).to.have.property('test');
-      expect(data.dependencies.test).to.have.length(0);
-      expect(data).to.be.an('object').with.property('externalDependencies');
-      expect(data.externalDependencies).to.have.length(0);
+      assert(data?.dependencies?.test, 'dependencies does not list "test"');
+      assert(data?.externalDependencies, 'externalDependencies is not set');
+      assert.strictEqual(data.dependencies.test.length, 0);
+      assert.strictEqual(data.externalDependencies.length, 0);
     });
   });
 });


### PR DESCRIPTION
The Chai testing library is now ECMAScript module only (see #1487). This could have provided a good occasion to convert tests from CommonJS modules to ECMAScript modules but then, looking into actual tests, many of them used Chai where they could just have used the basic Node.js `assert` module, and the few tests that used `expect` did not look more readable thanks to that syntax compared to a more basic `assert` approach.

Instead of converting test code to ECMAScript modules, this update rather drops the dependency on Chai, rewriting tests where needed to rather call regular `assert` functions.