### PR TITLE
Extract HTML attributes for each element

### DIFF
--- a/src/browserlib/extract-elements.mjs
+++ b/src/browserlib/extract-elements.mjs
@@ -60,7 +60,7 @@ export default function (spec) {
             // 'Contexts in which this element can be used': 'contexts',
             // 'Content model': 'contents',
             // 'Tag omission in text/html': 'omission',
-            // 'Content attributes': 'attributes',
+            'Content attributes': 'attributes',
             // 'Accessibility considerations': 'accessibility',
             'DOM interface': 'interface'
           })[getText(dt).replace(/:$/, '')];
@@ -119,6 +119,25 @@ export default function (spec) {
             }
             else {
               throw new Error('Could not link element to interface, missing dd for ' + res.name);
+            }
+          } else if (prop === "attributes") {
+            res[prop] = [];
+            let dd = dt.nextElementSibling;
+            while (dd && dd.nodeName !== "DT") {
+              if (dd.nodeName === "DD") {
+                // To count as an attribute, we look for:
+                // - the first child is a CODE element,
+                // - and its first child is an A element
+                // - and its href contains a fragment starting with "attr"
+                if (
+                  dd.firstChild?.nodeName === "CODE" &&
+                  dd.firstChild?.firstChild?.nodeName === "A" &&
+                  new URL(dd.firstChild?.firstChild).hash.startsWith("#attr")
+                ) {
+                  res[prop].push(getText(dd.firstChild?.firstChild));
+                }
+              }
+              dd = dd.nextElementSibling;
             }
           }
           else if (prop) {


### PR DESCRIPTION
I don't know if this is viable really but thought it was worth asking. From a conversation in the MDN Discord I thought we could try to add attributes to the extracts for HTML elements.

This PR thinks a `<dd>` item under "Content attributes:" is an attribute if:

- its first child is a `<code>` element
- whose first child is an `<a>` element
- whose href has a fragment beginning `attr`

This is intended to be quite strict, as I thought it's better to exclude legit attributes than to include nonsense.

Anyway, with this test I find the following items excluded (apart from "Global attributes", which they all have):

*************

[`<link>`](https://html.spec.whatwg.org/multipage/semantics.html#the-link-element)
- "Also, the title attribute has special semantics on this element:  Title of the link;  CSS style sheet set name\n     "

[`<style>`](https://html.spec.whatwg.org/multipage/semantics.html#the-style-element)
- "Also, the title attribute has special semantics on this element:  CSS style sheet set name\n     "

[`<body>`](https://html.spec.whatwg.org/multipage/sections.html#the-body-element)
- "onafterprint",
- "onbeforeprint",
- "onbeforeunload",
- "onhashchange",
- "onlanguagechange",
- "onmessage",
- "onmessageerror",
- "onoffline",
- "ononline",
- "onpageswap",
- "onpagehide",
- "onpagereveal",
- "onpageshow",
- "onpopstate",
- "onrejectionhandled",
- "onstorage",
- "onunhandledrejection",
- "onunload"

[`<li>`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element)
- "If the element is not a child of an ul or menu element: value —  Ordinal value of the list item\n     "

[`<a>`](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element)
- "ping —  URLs to ping\n     ",

[`<dfn>`](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element)
- "Also, the title attribute has special semantics on this element:  Full term or expansion of abbreviation\n     "

[`<abbr>`](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-abbr-element)
- "Also, the title attribute has special semantics on this element:  Full term or expansion of abbreviation\n     "

[`<bdi>`](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdi-element)
- "Also, the dir global attribute has special semantics on this element."

[`<bdo>`](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element)
- "Also, the dir global attribute has special semantics on this element."

[`<embed>`](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element)
- "Any other attribute that has no namespace (see prose)."

[`<area>`](https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element)
- "ping —  URLs to ping\n     ",

[`<input>`](https://html.spec.whatwg.org/multipage/input.html#the-input-element)
- "Also, the title attribute has special semantics on this element:  Description of pattern (when used with pattern attribute)\n     "

[`<fencedframe>`](https://wicg.github.io/fenced-frame/#elementdef-fencedframe)
- "allow — Permissions policy to be applied to the fencedframe's contents\n    "

**************

All the "Also, the XYZ attribute" seem right to exclude: they're not adding a new attribute but qualifying an existing one. The event handler attributes on `<body>` seem right to exclude, unless there's some reason the spec lists these only for `<body>`.

That leaves us with a few that are a bit trickier:

- [`<a>`](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element) and [`<area>`](https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element) list `ping`, but the fragment ID does not start with `"attr"`, it's just `"ping"`. I'm not sure if there's a good reason for this or if it is fixable in the spec.
- [`<fencedframe>`](https://wicg.github.io/fenced-frame/#elementdef-fencedframe) lists `allow` but again its fragment does not start with `"attr"`, it's `"element-attrdef-fencedframe-allow"`.
- [`<li>`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element) does not list the attribute first - perhaps it could be rewritten like "`value` - If the element is not a child of an ul or menu element, represents the ordinal value of the list item"?
- [`<embed>`](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element) has "Any other attribute that has no namespace (see prose)." I didn't really understand this, even after referring to the prose. Perhaps it would be OK to omit this? The MDN page for `<embed>` makes no mention of any extra attributes, either.