### PR TITLE
Stop fetching resources from test.csswg.org

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -369,7 +369,8 @@ async function processSpecification(spec, processFunction, args, options) {
                 if (request.url.startsWith('https://drafts.csswg.org/api/drafts/') ||
                     request.url.startsWith('https://drafts.css-houdini.org/api/drafts/') ||
                     request.url.startsWith('https://drafts.fxtf.org/api/drafts/') ||
-                    request.url.startsWith('https://api.csswg.org/shepherd/')) {
+                    request.url.startsWith('https://api.csswg.org/shepherd/') ||
+                    request.url.startsWith('https://test.csswg.org/harness/')) {
                     await cdp.send('Fetch.failRequest', { requestId, errorReason: 'Failed' });
                     return;
                 }


### PR DESCRIPTION
Same update as that done in browser-specs:
https://github.com/w3c/browser-specs/pull/1348

Resources from test.csswg.org are used to add test annotations to a CSS spec. We don't need that information (at least for now), and these resources seem to contribute to network timeouts. This update adds them to the blocklist of resources that get intercepted when the spec is loaded in Puppeteer.