### PR TITLE
Fix Puppeteer instance teardown

### DIFF
--- a/src/lib/specs-crawler.js
+++ b/src/lib/specs-crawler.js
@@ -504,7 +504,7 @@ async function crawlList(speclist, crawlOptions) {
 
     // Close Puppeteer instance
     if (!crawlOptions.useCrawl) {
-        teardownBrowser();
+        await teardownBrowser();
     }
 
     return results;


### PR DESCRIPTION
The code was not waiting for the browser instance to get properly closed. That did not affect the result of the crawl, but the OS could report an error message such as "A child process was not properly killed" when the crawl command exited.