### PR TITLE
Skip requests on SVG and CSS resources

### DIFF
--- a/src/lib/mock-server.js
+++ b/src/lib/mock-server.js
@@ -119,18 +119,6 @@ mockAgent
 
 mockAgent
   .get("https://www.w3.org")
-  .intercept({ method: "GET", path: "/StyleSheets/TR/2021/base.css" })
-  .reply(200, '')
-  .persist();
-
-mockAgent
-  .get("https://www.w3.org")
-  .intercept({ method: "GET", path: "/StyleSheets/TR/2021/dark.css" })
-  .reply(200, '')
-  .persist();
-
-mockAgent
-  .get("https://www.w3.org")
   .intercept({ method: "GET", path: "/Tools/respec/respec-highlight" })
   .reply(200, respecHiglight, {
     headers: { "Content-Type": "application/js" }

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -292,14 +292,6 @@ async function teardownBrowser() {
  * done loading), and that does not work with a file cache approach either.
  * These requests get intercepted.
  *
- * A couple of additional notes:
- * - Requests to CSS stylesheets are not intercepted because Respec dynamically
- * loads a few CSS resources, and intercepting them could perhaps impact the
- * rest of the generation.
- * - SVG images are not intercepted because a couple of specs have a PNG
- * fallback mechanism that, when interception is on, make the browser spin
- * forever, see discussion in: https://github.com/w3c/accelerometer/pull/55
- *
  * Strictly speaking, intercepting request is only needed to be able to use the
  * "networkidle0" option. The whole interception logic could be dropped (and
  * "networkidle2" could be used instead) if it proves too unstable.
@@ -345,7 +337,7 @@ async function processSpecification(spec, processFunction, args, options) {
         return async function ({ requestId, request }) {
             try {
                 // Abort network requests to common image formats
-                if (/\.(gif|ico|jpg|jpeg|png|ttf|woff)$/i.test(request.url)) {
+                if (/\.(gif|ico|jpg|jpeg|png|ttf|woff|svg|css)$/i.test(request.url)) {
                     await cdp.send('Fetch.failRequest', { requestId, errorReason: 'Failed' });
                     return;
                 }


### PR DESCRIPTION
SVG resources were loaded because a couple of specs have a weird PNG fallback mechanism. The Accelerometer spec still had an issue, but that's now fixed, and crawl now works well without having to load SVG resources.

CSS resources were loaded mostly out of fear that not doing so would break something. I skipped them and ran a crawl locally. I could not spot anything problematic.

(I'll report this to browser-specs as well)