### PR TITLE
Bump required version of Node.js to >=20.12.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
     - run: npm ci
     - run: npm test

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The code features a generic crawler that can fetch Web specifications and genera
 
 ### Pre-requisites
 
-To install Reffy, you need [Node.js](https://nodejs.org/en/) 18 or greater (the crawler itself may still run with earlier versions of Node.js, but version 18 is needed to run tests).
+To install Reffy, you need [Node.js](https://nodejs.org/en/) 20.12.1 or greater (the crawler itself may still run with earlier versions of Node.js but without any guarantee).
 
 ### Installation
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.12.1"
   },
   "main": "index.js",
   "bin": "./reffy.js",


### PR DESCRIPTION
That was missed when bumping the version of Respec used as a dependency last week, but Respec now requires Node.js >=20.12.1. I'm not sure that we really need that version ourselves, but doing so at least avoids getting scary "Unsupported engine" messages for Respec when installing Reffy.