### PR TITLE
Extract normative algorithms defined in specs

### DIFF
--- a/schemas/browserlib/extract-algorithms.json
+++ b/schemas/browserlib/extract-algorithms.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/browserlib/extract-algorithms.json",
+
+  "$defs": {
+    "step": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "html": { "type": "string" },
+        "rationale": { "type": "string" },
+        "operation": { "type": "string" },
+        "case": { "type": "string" },
+        "steps": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/step" },
+          "minItems": 1
+        },
+        "ignored": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "additional": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/step" },
+          "minItems": 1
+        }
+      }
+    }
+  },
+
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["rationale"],
+    "properties": {
+      "name": { "type": "string" },
+      "href": { "$ref": "../common.json#/$defs/url" },
+      "html": { "type": "string" },
+      "rationale": { "type": "string" },
+      "operation": { "type": "string" },
+      "case": { "type": "string" },
+      "steps": {
+        "type": "array",
+        "items": { "$ref": "#/$defs/step" }
+      }
+    }
+  }
+}

--- a/schemas/browserlib/extract-algorithms.json
+++ b/schemas/browserlib/extract-algorithms.json
@@ -44,7 +44,8 @@
       "case": { "type": "string" },
       "steps": {
         "type": "array",
-        "items": { "$ref": "#/$defs/step" }
+        "items": { "$ref": "#/$defs/step" },
+        "minItems": 1
       }
     }
   }

--- a/schemas/files/extracts/algorithms.json
+++ b/schemas/files/extracts/algorithms.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/files/extracts/algorithms.json",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["spec", "dfns"],
+  "properties": {
+    "spec": { "$ref": "../../common.json#/$defs/specInExtract" },
+    "dfns": { "$ref": "../../browserlib/extract-algorithms.json" }
+  }
+}

--- a/src/browserlib/clone-and-clean.mjs
+++ b/src/browserlib/clone-and-clean.mjs
@@ -1,0 +1,27 @@
+/**
+ * Return a copy of the given HTML element, stripped of annotations, side
+ * panels, and of HTML comments.
+ */
+export default function (element) {
+  // Apply modifications to a copy of the element
+  const copy = element.cloneNode(true);
+
+  // Drop asides that authoring tools add here and there
+  let el;
+  const asideSelector = [
+    'aside', '.note', '.annotation', '.idlHeader', '[id^=dfn-panel-]',
+    '.mdn-anno', '.wpt-tests-block', 'details.respec-tests-details'
+  ].join(',');
+  while (el = copy.querySelector(asideSelector)) {
+    el.remove();
+  }
+
+  // Remove HTML comments
+  const commentsIterator = document.createNodeIterator(copy, NodeFilter.SHOW_COMMENT);
+  let comment;
+  while ((comment = commentsIterator.nextNode())) {
+    comment.remove();
+  }
+
+  return copy;
+}

--- a/src/browserlib/clone-and-clean.mjs
+++ b/src/browserlib/clone-and-clean.mjs
@@ -1,3 +1,5 @@
+import informativeSelector from './informative-selector.mjs';
+
 /**
  * Return a copy of the given HTML element, stripped of annotations, side
  * panels, and of HTML comments.
@@ -8,12 +10,7 @@ export default function (element) {
 
   // Drop asides that authoring tools add here and there
   let el;
-  const asideSelector = [
-    'aside', '.note', '.annotation', '.idlHeader', '[id^=dfn-panel-]',
-    '.mdn-anno', '.wpt-tests-block', 'details.respec-tests-details',
-    '.example', '.informative', '.informative-bg'
-  ].join(',');
-  while (el = copy.querySelector(asideSelector)) {
+  while (el = copy.querySelector(informativeSelector)) {
     el.remove();
   }
 

--- a/src/browserlib/clone-and-clean.mjs
+++ b/src/browserlib/clone-and-clean.mjs
@@ -10,7 +10,8 @@ export default function (element) {
   let el;
   const asideSelector = [
     'aside', '.note', '.annotation', '.idlHeader', '[id^=dfn-panel-]',
-    '.mdn-anno', '.wpt-tests-block', 'details.respec-tests-details'
+    '.mdn-anno', '.wpt-tests-block', 'details.respec-tests-details',
+    '.example', '.informative', '.informative-bg'
   ].join(',');
   while (el = copy.querySelector(asideSelector)) {
     el.remove();

--- a/src/browserlib/extract-algorithms.mjs
+++ b/src/browserlib/extract-algorithms.mjs
@@ -407,7 +407,7 @@ function findIntroParagraph(algo) {
     // https://w3c.github.io/webappsec-csp/#abstract-opdef-parse-a-serialized-csp
     // TODO: improve!
     paragraph = algo.root;
-    while (paragraph && paragraph.nodeName !== 'P') {
+    while (paragraph && (paragraph.nodeName !== 'P' || paragraph.matches(informativeSelector))) {
       paragraph = paragraph.previousElementSibling;
     }
   }

--- a/src/browserlib/extract-algorithms.mjs
+++ b/src/browserlib/extract-algorithms.mjs
@@ -389,10 +389,29 @@ function getDefinedNameIn(el) {
  * there's one.
  */
 function findIntroParagraph(algo) {
-  let paragraph = algo.root;
-  while (paragraph && paragraph.nodeName !== 'P') {
-    paragraph = paragraph.previousElementSibling;
+  let paragraph;
+  let container = algo.root.closest('.algorithm');
+  while (container) {
+    const dfn = container.querySelector('dfn');
+    if (dfn) {
+      paragraph = dfn.closest('p,div');
+      break;
+    }
+    container = container.parentElement.closest('.algorithm');
   }
+
+  if (!paragraph) {
+    // Consider that the introductory paragraph is the previous paragraph.
+    // That's not going to be 100% correct. For example, we will incorrectly
+    // capture an intermediary paragraph as in:
+    // https://w3c.github.io/webappsec-csp/#abstract-opdef-parse-a-serialized-csp
+    // TODO: improve!
+    paragraph = algo.root;
+    while (paragraph && paragraph.nodeName !== 'P') {
+      paragraph = paragraph.previousElementSibling;
+    }
+  }
+
   return paragraph;
 }
 
@@ -413,6 +432,10 @@ function getAlgorithmInfo(algo, context) {
     if (container && !context?.nested) {
       if (container.getAttribute('data-algorithm')) {
         info.name = normalize(container.getAttribute('data-algorithm'));
+        if (container.getAttribute('data-algorithm-for')) {
+          info.name = normalize(container.getAttribute('data-algorithm-for')) +
+            '/' + info.name;
+        }
         if (container.id) {
           // Use the container ID as anchor
           info.href = getAbsoluteUrl(container);

--- a/src/browserlib/extract-algorithms.mjs
+++ b/src/browserlib/extract-algorithms.mjs
@@ -670,5 +670,5 @@ export default function (spec, idToHeading = {}) {
     // remove duplicate from multi-steps algorithms also detected by the
     // short form algorithms finder (relying on them being later in the
     // list)
-    .filter((algo, idx, arr) => arr.findIndex(al => !algo.html || al.html === algo.html) === idx);
+    .filter((algo, idx, arr) => !algo.html || algo.steps.length > 0 || arr.findIndex(al => al.html === algo.html) === idx);
 }

--- a/src/browserlib/extract-algorithms.mjs
+++ b/src/browserlib/extract-algorithms.mjs
@@ -1,0 +1,663 @@
+/**
+ * Extract normative algorithms defined in specs.
+ *
+ * An algorithm extract is essentially an object with the following keys:
+ * - `name`: The name of the algorithm, when one exists
+ * - `href`: The URL with fragment to reach the algorithm, when one exists
+ * - `html`: Some introductory prose for the algorithm. That prose may well
+ * contain actual algorithmic operations, e.g.: "When invoked, run the following
+ * steps in parallel". href/src attributes in the HTML have absolute URLs.
+ * - `steps`: Atomic algorithm steps.
+ * - `parallel`: A flag set to true when the steps are to run "in parallel".
+ *
+ * Each step is essentially an object that follows the same structure as an
+ * algorithm, except that it does not have a `name` and `href` keys, and may
+ * also have the following keys:
+ * - `operation`: Gives the name of the main operation performed by the step,
+ * for example "switch", "let", "set", "if", "return", "resolve", "reject",
+ * "queue a task", "fire an event", etc.
+ * - `case`: Used in switch steps to identify the switch condition that
+ * triggers the step.
+ * - `ignored`: Ordered lists found at the step level that do no look like
+ * algorithm steps. Or maybe they are? The lists should get reviewed: they
+ * usually describe inputs/outputs or conditions, but they may signal parts
+ * where the extraction logic needs to be improved. The lists are reported as
+ * text prose.
+ * - `additional`: Each step should contain one and only one algorithm. When
+ * other algorithms are found at the same level, they get reported in that
+ * property. That usually either signals that the spec could be improved
+ * because if fails to use different list items for different steps, and/or
+ * that the extraction logic needs to be smarter.
+ *
+ * TODO: flag step operation when understood (queue a task, fire an event,
+ *  run in parallel, etc.) to ease analysis.
+ *  (the property is only set for identified "switch" constructs for now)
+ * TODO: handle "read requests"
+ *  https://fetch.spec.whatwg.org/#incrementally-read-loop
+ *  https://w3c.github.io/webcodecs/#imagedecoder-fetch-stream-data-loop
+ * TODO: handle "fetch" process request/response algorithms
+ *  https://wicg.github.io/background-fetch/#complete-a-record
+ *  https://wicg.github.io/nav-speculation/prefetch.html#create-navigation-params-by-fetching
+ * TODO: support a switch without a ".switch" class
+ *  https://w3c.github.io/webcodecs/#dom-videoframe-videoframe
+ *  https://w3c.github.io/web-nfc/#dfn-map-text-to-ndef
+ * TODO: support a switch that is not phrased as a switch
+ *  https://w3c.github.io/clipboard-apis/#to-os-specific-well-known-format
+ * TODO: support a switch where cases don't have <dd>
+ *  https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#sctn-minpinlength-extension
+ * TODO: don't get confused by conditions that look like steps
+ *  (code reports them as "ignored", that's a good start, ignore them fully!)
+ *  https://w3c.github.io/webcodecs/#imagedecoder-decode-complete-frame
+ *  https://w3c.github.io/presentation-api/#dom-presentationrequest-start
+ *  https://w3c.github.io/clipboard-apis/#dom-clipboard-read
+ * TODO: don't get confused by informative "algorithms"
+ *  (noting informative sections are not flagged as such in Bikeshed)
+ *  https://drafts.csswg.org/css-view-transitions-2/#lifecycle
+ * TODO: convert branching operations to substeps when needed ("if")
+ *  https://drafts.css-houdini.org/css-layout-api-1/#construct-a-fragment-result
+ *  https://w3c.github.io/webappsec-credential-management/#dom-passwordcredential-store-slot
+ *  https://dom.spec.whatwg.org/#concept-create-element
+ * TODO: don't get confused by intermediary notes that jeopardize steps lists
+ *  (but then, the specs need fixing!)
+ *  https://w3c.github.io/secure-payment-confirmation/#sctn-steps-to-check-if-a-payment-can-be-made
+ *  https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm
+ *  https://wicg.github.io/turtledove/#dom-navigator-createauctionnonce
+ * TODO: convert inline operations to substeps when needed
+ * TODO: filter out CSS algorithms that are not JS algorithms
+ *  https://drafts.fxtf.org/filter-effects/#interpolation-of-filter-functions
+ * TODO: improve the algorithm steps detection mechanism. It's relatively easy
+ *  to miss steps.
+ * TODO: don't skip intermediary <dl> levels and/or support "struct with keys"
+ *  https://w3c.github.io/webdriver-bidi/#parse-url-pattern
+ * TODO: don't get confused by a switch that follows steps
+ *  https://w3c.github.io/geolocation/#dfn-acquire-a-position
+ * TODO: support TC39 specs with <emu-alg> clauses
+ *  https://tc39.es/ecma402/
+ * TODO: skip monkeypatching identified as such?
+ *  https://wicg.github.io/scroll-to-text-fragment/
+ *
+ * And then later:
+ * TODO: extract algorithm parameters
+ *
+ * @function
+ * @public
+ * @return {Array(Object)} An Array of algorithms
+*/
+
+import informativeSelector from './informative-selector.mjs';
+import getAbsoluteUrl from './get-absolute-url.mjs';
+
+
+/**
+ * Algorithm steps typically start with verbs that define the operation to
+ * perform.
+ *
+ * The following list of verbs is used to assess whether a set of steps "looks
+ * like" a set of algorithm steps, so as to avoid extracting lists that are not
+ * algorithms.
+ *
+ * The list is completed with a few branching operations that are not verbs:
+ * "for", "if", "while".
+ *
+ * Using a growing list of verbs may not be a good idea. That said, it is an
+ * instructive exercise to analyze the diversity of operations being used,
+ * and their meaning (or lack of).
+ *
+ * Note some steps may start with an adverb, e.g., "Additionally",
+ * "Optionally", "Asynchronously", or with contextualizations such as
+ * "In step 6". These forms are not captured here. They will be captured
+ * through the inline operations (see below) or need to be handled separately.
+ * They will be reported in the `ignored` property otherwise.
+ *
+ * Note "Asynchronously", typically used in Service Workers, does not mean much
+ * in a browsing context. It should probably rather be re-written using
+ * "in parallel"
+ *  https://w3c.github.io/ServiceWorker/
+ */
+const stepOperations = [
+  'abort',
+  'acknowledge',
+  'activate',
+  'add',
+  'adopt',
+  'advance',
+  'append',
+  'apply',
+  'ask',
+  'assert',
+  'assign',
+  'attach',
+  'attempt',
+  'batch',
+  'block',
+  'branch',
+  'call',
+  'check',
+  'cancel',
+  'cause',
+  'change',
+  'choose',
+  'clamp',
+  'clean',
+  'clear',
+  'close',
+  'collect',
+  'complete',
+  'compute',
+  'consume',
+  'continue',
+  'convert',
+  'copy',
+  'create',
+  'deactivate',
+  'decrease',
+  'decrement',
+  'decrypt',
+  'define',
+  'delete',
+  'dequeue',
+  'destroy',
+  'determine',
+  'discard',
+  'dismiss',
+  'dispatch',
+  'display',
+  'down-mix',
+  'do',
+  'dump',
+  'emit',
+  'empty',
+  'end',
+  'enqueue',
+  'ensure',
+  'error',
+  'establish',
+  'execute',
+  'extend',
+  'extract',
+  'fail',
+  'fetch',
+  'finalize',
+  'find',
+  'finish',
+  'fire',
+  'gather',
+  'generate',
+  'give',
+  'handle',
+  'hand-off',
+  'increase',
+  'increment',
+  'initialize',
+  'insert',
+  'interpret',
+  'invoke',
+  'issue',
+  'jump',
+  'let',
+  'make',
+  'mark',
+  'match',
+  'move',
+  'multiply',
+  'navigate',
+  'paint',
+  'parse',
+  'perform',
+  'place',
+  'pop',
+  'populate',
+  'prepare',
+  'prepend',
+  'process',
+  'prompt',
+  'push',
+  'query',
+  'queue',
+  'recalculate',
+  'rectify',
+  'reference',
+  'register',
+  'reinitialize',
+  'reject',
+  'release',
+  'remove',
+  'replace',
+  'reset',
+  'resolve',
+  'resolve',
+  'restore',
+  'render',
+  'remap',
+  'report',
+  'return',
+  'run',
+  'score',
+  'scroll',
+  'send',
+  'serialize',
+  'set',
+  'shuffle',
+  'skip',
+  'sort',
+  'split',
+  'spin',
+  'start',
+  'stop',
+  'store',
+  'strip',
+  'suspend',
+  'switch',
+  'take',
+  'terminate',
+  'throw',
+  'trap',
+  'try',
+  'undisplay',
+  'unset',
+  'up-mix',
+  'update',
+  'update',
+  'upgrade',
+  'use',
+  'validate',
+  'verify',
+  'visit',
+  'wait',
+
+  'for',
+  'if',
+  'while'
+];
+
+
+/**
+ * When the step does not start with a verb, or when that verb is not followed
+ * by a white space, the following constructs help detect the actual operation.
+ */
+const stepInlineOperations = [
+  'abort all these steps',
+  'abort these steps',
+  'fire a simple event',
+  'fire an event',
+  'in parallel',
+  'reject',
+  'resolve',
+  'run the following steps',
+  'run these steps',
+  'terminate these steps',
+  /queue a( \w+)? task/i
+];
+
+
+/**
+ * Additional anchors that suggest algorithm steps
+ */
+const stepAnchors = [
+  /^⌛/,
+  'in parallel',
+  /^otherwise(\,| )/i,
+];
+
+
+/**
+ * Clone HTML element, removing all annotations
+ */
+function cloneAndClean(el) {
+  const clone = el.cloneNode(true);
+  for (const ignore of clone.querySelectorAll([
+    '.note', 'aside', '.idlHeader', 'details.respec-tests-details',
+  ].join(','))) {
+    ignore.remove();
+  }
+  return clone;
+}
+
+
+/**
+ * Return the normalized text content for the given DOM element, removing all
+ * annotations
+ */
+function getTextContent(el) {
+  const clone = cloneAndClean(el);
+  return normalize(clone.textContent);
+}
+
+
+/**
+ * Return the normalized HTML content for the given DOM element, removing all
+ * annotations
+ */
+function getHTMLContent(el) {
+  // Prepare mapping table to turn relative links to absolute ones
+  // (we cannot do that once the element has been cloned because cloning
+  // removes the element from the DOM tree)
+  const relativeUrlSelector = '[href]:not([href^="http"]),[src]:not([src^="http"])';
+  const relativeToAbsolute = {};
+  const page = el.closest('[data-reffy-page]')?.getAttribute('data-reffy-page');
+  for (const href of el.querySelectorAll(relativeUrlSelector)) {
+    const attr = href.getAttribute('href') ? 'href' : 'src';
+    const url = new URL(page ?? window.location.href);
+    url.hash = href.getAttribute(attr);
+    relativeToAbsolute[href.getAttribute(attr)] = url.toString();
+  }
+
+  const clone = cloneAndClean(el);
+  for (const href of clone.querySelectorAll(relativeUrlSelector)) {
+    const attr = href.getAttribute('href') ? 'href' : 'src';
+    href.setAttribute(attr, relativeToAbsolute[href.getAttribute(attr)]);
+  }
+  return clone.innerHTML.trim();
+}
+
+/**
+ * Normalize a text for serialization purpose
+ */
+function normalize(str) {
+  return str.replace(/\r|\n/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Return the name and href of the first dfn contained in the given element
+ */
+function getDefinedNameIn(el) {
+  const dfn = el.nodeName === 'DFN' ?
+    el :
+    el.querySelector('dfn,h2[data-dfn-type],h3[data-dfn-type],h4[data-dfn-type],h5[data-dfn-type],h6[data-dfn-type]');
+  if (dfn) {
+    let name = '';
+    if (dfn.getAttribute('data-dfn-for')) {
+      name = normalize(dfn.getAttribute('data-dfn-for').split(/,(?![^\(]*\))/)[0]) + '/';
+    }
+    if (dfn.getAttribute('data-lt')) {
+      name += normalize(dfn.getAttribute('data-lt').split('|')[0]);
+    }
+    else {
+      name += getTextContent(dfn);
+    }
+    const href = dfn.id ? getAbsoluteUrl(dfn) : null;
+    return { name, href };
+  }
+  else {
+    const heading = el.querySelector('h2[id],h3[id],h4[id],h5[id],h6[id]');
+    if (heading) {
+      return { name: getTextContent(heading), href: getAbsoluteUrl(heading) };
+    }
+  }
+  return {};
+}
+
+/**
+ * Find information about an algorithm (name and href).
+ *
+ * The name is given by a nearby `dfn`. If there's no nearby `dfn`, the
+ * name is the content of the preceding paragraph.
+ */
+function getAlgorithmInfo(algo, context) {
+  // Look for a name in the algorithm container, if there's one.
+  // Note some specs add the "algorithm" class to the `<ol>` and to the
+  // wrapping container, and define the name in the wrapping container.
+  let info = {};
+  let container = algo.root.closest('.algorithm');
+  while (container) {
+    if (container && !context?.nested) {
+      if (container.getAttribute('data-algorithm')) {
+        info.name = normalize(container.getAttribute('data-algorithm'));
+        if (container.id) {
+          // Use the container ID as anchor
+          info.href = getAbsoluteUrl(container);
+        }
+        else {
+          // Container has no ID but if there's a dfn in there, that's probably
+          // the right anchor
+          const dfn = getDefinedNameIn(container);
+          if (dfn) {
+            info.href = dfn.href;
+          }
+        }
+        break;
+      }
+      else {
+        info = getDefinedNameIn(container);
+      }
+    }
+    container = container.parentElement.closest('.algorithm');
+  }
+
+  // Get the introductory prose from the previous paragraph
+  let paragraph = algo.root.previousElementSibling;
+  while (paragraph && paragraph.nodeName !== 'P') {
+    paragraph = paragraph.previousElementSibling;
+  }
+  if (paragraph) {
+    // Also look for a definition in the paragraph if we don't have a name and
+    // href already.
+    if (!context?.nested && !(info.name && info.href)) {
+      info = Object.assign(getDefinedNameIn(paragraph), info);
+    }
+    info.html = getHTMLContent(paragraph);
+  }
+  else if (['LI', 'DD', 'DIV'].includes(algo.root.parentElement.nodeName)) {
+    // If there's no paragraph, we may be in a list or definition list, the
+    // introductory prose is whatever text exists before the algorithm
+    const textEl = document.createElement('div');
+    let node = algo.root.parentElement.firstChild;
+    while (node !== algo.root) {
+      textEl.appendChild(node.cloneNode(true));
+      node = node.nextSibling;
+    }
+    if (!context?.nested && !(info.name && info.href)) {
+      info = Object.assign(getDefinedNameIn(textEl), info);
+    }
+    info.html = getHTMLContent(textEl);
+  }
+
+  if (!context?.nested && !(info.name && info.href) &&
+      algo.root.parentElement.nodeName === 'DD') {
+    let dt = algo.root.parentElement.previousElementSibling;
+    while (dt && dt.nodeName !== 'DT') {
+      dt = dt.previousElementSibling;
+    }
+    if (dt) {
+      info = Object.assign(getDefinedNameIn(dt), info);
+    }
+  }
+
+  // TODO: look for the closest heading?
+  return info;
+}
+
+/**
+ * Serialize the given algorithm
+ *
+ * Context object allows to distinguish between top-level algorithms and
+ * nested ones. Nested ones typically don't have names.
+ */
+function serializeAlgorithm(algo, context) {
+  let res = getAlgorithmInfo(algo, context);
+  res.rationale = algo.rationale;
+  res.steps = serializeSteps(algo.root);
+  return res;
+}
+
+/**
+ * Serialize the given steps contained in the given root element.
+ */
+function serializeSteps(root) {
+  if (root.nodeName === 'DL') {
+    return [
+      {
+        operation: 'switch',
+        steps: [...root.querySelectorAll('& > dt')].map(option => {
+          let dd = option.nextElementSibling;
+          while (dd && dd.nodeName !== 'DD') {
+            dd = dd.nextElementSibling;
+          }
+          if (!dd) {
+            throw new Error('Switch option without <dd> found: ' + option.textContent);
+          }
+          return {
+            'case': getTextContent(option),
+            steps: serializeSteps(dd)
+          };
+        })
+      }
+    ]
+  }
+  else if (root.nodeName === 'OL') {
+    return [...root.querySelectorAll('& > li')].map(serializeStep);
+  }
+  else {
+    return [serializeStep(root)];
+  }
+}
+
+/**
+ * Serialize an algorithm step
+ */
+function serializeStep(li) {
+  let res = {};
+  const candidateAlgorithms = findAlgorithms(li, { includeIgnored: true });
+  const algorithms = candidateAlgorithms.filter(algo => !!algo.rationale);
+  if (algorithms.length > 0) {
+    res = serializeAlgorithm(algorithms[0], { nested: true });
+  }
+  if (!res.html) {
+    res.html = getHTMLContent(li);
+  }
+  if (algorithms.length > 1) {
+    res.additional = algorithms.slice(1)
+      .map(algo => serializeAlgorithm(algo, { nested: true }));
+  }
+  const ignoredAlgorithms = candidateAlgorithms
+    .filter(algo => !algo.rationale)
+    .map(algo => getTextContent(algo.root));
+  if (ignoredAlgorithms.length > 0) {
+    res.ignored = ignoredAlgorithms;
+  }
+  return res;
+}
+
+/**
+ * Parse a list element looking for algorithmic operations or other anchors
+ * that should allow us to assess that the steps are indeed part of an
+ * algorithm. Return a string representation of that rationale.
+ */
+function findRationale(ol) {
+  let rationale = null;
+
+  if (ol.matches('.algorithm')) {
+    return '.algorithm';
+  }
+  const text = getTextContent(ol).toLowerCase();
+  rationale = stepOperations.find(op => {
+    return text.match(new RegExp(`^${op}(\\.|:| )`, 'i'));
+  });
+
+  if (!rationale) {
+    rationale = stepInlineOperations.find(op => {
+      if (typeof op === 'string') {
+        return text.includes(op);
+      }
+      else {
+        return text.match(op);
+      }
+    });
+  }
+
+  if (!rationale) {
+    rationale = stepAnchors.find(anchor => {
+      if (typeof anchor === 'string') {
+        return text.includes(anchor);
+      }
+      else {
+        return text.match(anchor);
+      }
+    });
+  }
+
+  return rationale?.toString();
+}
+
+
+/**
+ * Return true if element has the given parent as ancestor
+ */
+function hasParent(el, parent) {
+  let curr = el.parentElement;
+  while (curr && curr !== parent) {
+    curr = curr.parentElement;
+  }
+  return !!curr;
+}
+
+
+/**
+ * Find the list of normative algorithms defined in the document's section
+ */
+function findAlgorithms(section, { includeIgnored } = { includeIgnored: false }) {
+  // Well-behaved algorithms have an "algorithm" class and start with an <ol>,
+  // or they have a "switch" class, à la:
+  // https://dom.spec.whatwg.org/#locate-a-namespace
+  const actual = [...section.querySelectorAll('.algorithm,.switch')]
+    .filter(el => !el.closest(informativeSelector))
+    .map(el => Object.assign({
+      rationale: el.matches('.algorithm') ? '.algorithm' : '.switch',
+      root: el
+    }))
+    .map(algo => {
+      if (algo.root.nodeName !== 'DL' && algo.root.nodeName !== 'OL') {
+        algo.root = algo.root.querySelector('ol');
+      }
+      return algo;
+    })
+    .filter(algo => !!algo.root);
+
+  // Probable algorithms do not have an "algorithm" class but start with an <ol>
+  const probable = [...section.querySelectorAll('ol')]
+    .filter(ol => !ol.closest(informativeSelector))
+    .filter(ol => !ol.closest('nav,.toc,#toc'))
+    .filter(ol => !actual.find(algo => algo.root === ol))
+    .filter(ol => !actual.find(algo => hasParent(ol, algo.root)))
+    // Find an interesting anchor in there to filter out
+    // lists that don't look like steps
+    .map(ol => {
+      const rationale = findRationale(ol);
+      return { rationale: rationale?.toString(), root: ol };
+    })
+    .filter(algo => includeIgnored || !!algo.rationale);
+
+  const all = actual.concat(probable);
+  let filtered = all.filter(algo1 => !all.find(algo2 => hasParent(algo1.root, algo2.root)));
+  filtered = filtered.filter((algo, idx) => filtered.findIndex(al => al.root === algo.root) === idx);
+
+  // Consider algorithms in document order
+  // (if we find more than one at the same level, first one will be reported as
+  // the actual algorithm, the other ones as "additional" algorithms)
+  filtered.sort((algo1, algo2) => {
+    if (algo1.rationale && !algo2.rationale) {
+      return -1;
+    }
+    if (algo2.rationale && !algo1.rationale) {
+      return 1;
+    }
+    const cmp = algo1.root.compareDocumentPosition(algo2.root);
+    if (cmp & Node.DOCUMENT_POSITION_PRECEDING) {
+      return 1;
+    }
+    else if (algo1.root !== algo2.root) {
+      return -1;
+    }
+  });
+  return filtered;
+}
+
+
+export default function (spec, idToHeading = {}) {
+  // ECMA specs typically use <emu-alg> clauses, not supported for now.
+  if (spec.organization === 'Ecma International') {
+    return [];
+  }
+  const algorithms = findAlgorithms(document);
+  return algorithms.map(algo => serializeAlgorithm(algo));
+}

--- a/src/browserlib/extract-algorithms.mjs
+++ b/src/browserlib/extract-algorithms.mjs
@@ -336,6 +336,10 @@ function getHTMLContent(el) {
   }
 
   const clone = cloneAndClean(el);
+  let ol;
+  while (ol = clone.querySelector('ol')) {
+    ol.remove();
+  }
   for (const linkEl of clone.querySelectorAll(relativeUrlSelector)) {
     const attr = linkEl.getAttribute('href') ? 'href' : 'src';
     linkEl.setAttribute(attr, relativeToAbsolute[linkEl.getAttribute(attr)]);
@@ -522,11 +526,10 @@ function serializeStep(li) {
     res.additional = algorithms.slice(1)
       .map(algo => serializeAlgorithm(algo, { nested: true }));
   }
-  const ignoredAlgorithms = candidateAlgorithms
-    .filter(algo => !algo.rationale)
-    .map(algo => getTextContent(algo.root));
+  const ignoredAlgorithms = candidateAlgorithms.filter(algo => !algo.rationale);
   if (ignoredAlgorithms.length > 0) {
-    res.ignored = ignoredAlgorithms;
+    res.ignored = ignoredAlgorithms.map(algo => getTextContent(algo.root));
+
   }
   return res;
 }

--- a/src/browserlib/extract-algorithms.mjs
+++ b/src/browserlib/extract-algorithms.mjs
@@ -330,8 +330,7 @@ function getHTMLContent(el) {
   const page = el.closest('[data-reffy-page]')?.getAttribute('data-reffy-page');
   for (const linkEl of el.querySelectorAll(relativeUrlSelector)) {
     const attr = linkEl.getAttribute('href') ? 'href' : 'src';
-    const url = new URL(page ?? window.location.href);
-    url.hash = linkEl.getAttribute(attr);
+    const url = new URL(linkEl.getAttribute(attr), page ?? window.location.href);
     relativeToAbsolute[linkEl.getAttribute(attr)] = url.toString();
   }
 

--- a/src/browserlib/extract-algorithms.mjs
+++ b/src/browserlib/extract-algorithms.mjs
@@ -479,7 +479,7 @@ function serializeAlgorithm(algo, context) {
 /**
  * Serialize the given steps contained in the given root element.
  */
-function serializeSteps(root) {
+function serializeSteps(root, level = 0) {
   if (root.nodeName === 'DL') {
     return [
       {
@@ -494,24 +494,28 @@ function serializeSteps(root) {
           }
           return {
             'case': getTextContent(option),
-            steps: serializeSteps(dd)
+            steps: serializeSteps(dd, level + 1)
           };
         })
       }
     ]
   }
   else if (root.nodeName === 'OL') {
-    return [...root.querySelectorAll('& > li')].map(serializeStep);
+    return [...root.querySelectorAll('& > li')].map(li => serializeStep(li, level +1));
   }
   else {
-    return [serializeStep(root)];
+    if (level === 0) {
+      return [];
+    } else {
+      return [serializeStep(root, level + 1)];
+    }
   }
 }
 
 /**
  * Serialize an algorithm step
  */
-function serializeStep(li) {
+function serializeStep(li, level) {
   let res = {};
   const candidateAlgorithms = findAlgorithms(li, { includeIgnored: true });
   const algorithms = candidateAlgorithms.filter(algo => !!algo.rationale);

--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -36,6 +36,8 @@ import {parse} from "../../node_modules/webidl2/index.js";
  * @return {Array(Object)} An Array of definitions
 */
 
+import cloneAndClean from './clone-and-clean.mjs';
+
 function normalize(str) {
   return str.trim().replace(/\s+/g, ' ');
 }
@@ -125,25 +127,8 @@ function isNotAlreadyExported(dfn, idx, list) {
 // Extract the element's inner HTML content, removing any complex structure,
 // so that the result can be injected elsewhere without creating problems.
 function getHtmlProseDefinition(proseEl) {
-  // Apply modifications to a copy of the element
-  proseEl = proseEl.cloneNode(true);
-
-  // Drop asides that authoring tools add here and there
-  let el;
-  const asideSelector = [
-    'aside', '.mdn-anno', '.wpt-tests-block', '.annotation',
-    '[id^=dfn-panel-]'
-  ].join(',');
-  while (el = proseEl.querySelector(asideSelector)) {
-    el.remove();
-  }
-
-  // Remove comments
-  const commentsIterator = document.createNodeIterator(proseEl, NodeFilter.SHOW_COMMENT);
-  let comment;
-  while ((comment = commentsIterator.nextNode())) {
-    comment.remove();
-  }
+  // Strip element of all annotations
+  proseEl = cloneAndClean(proseEl);
 
   // Keep simple grouping content and text-level semantics elements
   const keepSelector = [
@@ -153,6 +138,7 @@ function getHtmlProseDefinition(proseEl) {
     'i', 'kbd', 'mark', 'q', 'rp', 'rt', 'ruby', 's', 'samp', 'small', 'span',
     'strong', 'sub', 'sup', 'time', 'u', 'var', 'wbr'
   ].join(',');
+  let el;
   while (el = proseEl.querySelector(`:not(${keepSelector})`)) {
     // The content is more complex than anticipated. It may be worth checking
     // the definition to assess whether the extraction logic needs to become

--- a/src/browserlib/extract-webidl.mjs
+++ b/src/browserlib/extract-webidl.mjs
@@ -1,5 +1,6 @@
 import getGenerator from './get-generator.mjs';
 import informativeSelector from './informative-selector.mjs';
+import cloneAndClean from './clone-and-clean.mjs';
 
 /**
  * Extract the list of WebIDL definitions in the current spec
@@ -116,15 +117,7 @@ function extractRespecIdl() {
         .filter(el => el !== idlEl)
         .filter((el, idx, self) => self.indexOf(el) === idx)
         .filter(el => !el.closest(informativeSelector))
-        .map(el => el.cloneNode(true))
-        .map(el => {
-            for (const ignore of el.querySelectorAll([
-                'aside', '.idlHeader', 'details.respec-tests-details',
-            ].join(','))) {
-                ignore.remove();
-            }
-            return el;
-        })
+        .map(cloneAndClean)
         .map(el => trimIdlSpaces(el.textContent))
         .join('\n\n');
 

--- a/src/browserlib/informative-selector.mjs
+++ b/src/browserlib/informative-selector.mjs
@@ -7,11 +7,19 @@
  */
 export default [
   '.informative',
+  '.informative-bg',
   '.note',
   '.issue',
   '.example',
   '.ednote',
+  '.annotation',
   '.practice',
   '.introductory',
-  '.non-normative'
+  '.non-normative',
+  'aside',
+  '.idlHeader',
+  '[id^=dfn-panel-]',
+  '.mdn-anno',
+  '.wpt-tests-block',
+  'details.respec-tests-details'
 ].join(',');

--- a/src/browserlib/reffy.json
+++ b/src/browserlib/reffy.json
@@ -20,6 +20,10 @@
     "metadata": true
   },
   {
+    "href": "./extract-algorithms.mjs",
+    "property": "algorithms"
+  },
+  {
     "href": "./extract-links.mjs",
     "property": "links"
   },

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -141,7 +141,7 @@ function expandBrowserModules(modules) {
             if (mod.endsWith('.mjs')) {
                 const name = getCamelCaseName(mod);
                 return {
-                    href: path.relative(browserlibPath, path.join(process.cwd(), mod)).replace(/\\/g, '/'),
+                    href: './' + path.relative(browserlibPath, path.join(process.cwd(), mod)).replace(/\\/g, '/'),
                     name,
                     property: name,
                     expanded: true
@@ -172,7 +172,7 @@ function expandBrowserModules(modules) {
             if (!mod.href) {
                 throw new Error('Browserlib module does not have an "href" property');
             }
-            mod.href = path.relative(browserlibPath, path.join(process.cwd(), mod.href)).replace(/\\/g, '/');
+            mod.href = './' + path.relative(browserlibPath, path.join(process.cwd(), mod.href)).replace(/\\/g, '/');
             if (!mod.name) {
                 mod.name = getCamelCaseName(mod.href);
             }

--- a/tests/crawl-test.json
+++ b/tests/crawl-test.json
@@ -15,14 +15,15 @@
     "links": {
       "autolinks": {},
       "rawlinks": {
-	"https://www.w3.org/TR/bar/": {
-	  "anchors": [
+        "https://www.w3.org/TR/bar/": {
+          "anchors": [
             "baz"
-	  ]
-	}
+          ]
+        }
       }
     },
     "title": "WOFF2",
+    "algorithms": [],
     "css": {
       "atrules": [],
       "properties": [],
@@ -75,15 +76,15 @@
     "links": {
       "autolinks": {
         "https://webidl.spec.whatwg.org/": {
-  	  "anchors": [
+            "anchors": [
             "Exposed",
             "idl-DOMString"
-	  ]
-	}
+          ]
+        }
       },
       "rawlinks": {
         "https://webidl.spec.whatwg.org/": {
-	}
+        }
       }
     },
     "refs": {
@@ -97,6 +98,7 @@
     },
     "title": "No Title",
     "generator": "respec",
+    "algorithms": [],
     "css": {
       "atrules": [],
       "properties": [],
@@ -221,6 +223,7 @@
       "informative": []
     },
     "title": "[No title found for https://w3c.github.io/accelerometer/]",
+    "algorithms": [],
     "css": {
       "atrules": [],
       "properties": [],

--- a/tests/extract-algorithms.js
+++ b/tests/extract-algorithms.js
@@ -42,7 +42,7 @@ const tests = [
   {
     title: 'extracts a switch marked as such',
     html: `
-      <p>To be or not to be, given <var>will</var>:</p>
+      <p>To <dfn id="be">be or not to be</dfn>, given <var>will</var>:</p>
       <dl class="switch">
         <dt>to be</dt>
         <dd>Do something.</dd>
@@ -51,7 +51,9 @@ const tests = [
       </dl>`,
     algorithms: [
       {
-        html: 'To be or not to be, given <var>will</var>:',
+        name: 'be or not to be',
+        href: 'about:blank#be',
+        html: 'To <dfn id=\"be\">be or not to be</dfn>, given <var>will</var>:',
         rationale: '.switch',
         steps: [
           {
@@ -73,7 +75,7 @@ const tests = [
   },
 
   {
-    title: 'extracts a set of steps when an operation is found (return)',
+    title: 'extracts an algorithm when an operation is found (return)',
     html: `
       <ol><li>Return foo.</li></ol>`,
     algorithms: [
@@ -85,7 +87,7 @@ const tests = [
   },
 
   {
-    title: 'extracts a set of steps when an operation is found (throw)',
+    title: 'extracts an algorithm when an operation is found (throw)',
     html: `
       <ol>
         <li>To start with, just relax.</li>
@@ -98,6 +100,33 @@ const tests = [
           { html: 'To start with, just relax.' },
           { html: 'Throw a TooMuchWork exception.' }
         ]
+      }
+    ]
+  },
+
+  {
+    title: 'extracts multiple algorithms',
+    html: `
+      <div>
+        <p>To do nothing, run these steps:</p>
+        <ol class="algorithm" data-algorithm="my algo" id="algo-id"><li><p>Nothing.</p></li></ol>
+      </div>
+      <p>To <dfn id="another-algo">do something</dfn>, run these steps:</p>
+      <ol><li>Do something.</li></ol>`,
+    algorithms: [
+      {
+        name: 'my algo',
+        href: 'about:blank#algo-id',
+        html: 'To do nothing, run these steps:',
+        rationale: '.algorithm',
+        steps: [ { html: '<p>Nothing.</p>' } ]
+      },
+      {
+        name: 'do something',
+        href: 'about:blank#another-algo',
+        html: 'To <dfn id="another-algo">do something</dfn>, run these steps:',
+        rationale: 'do',
+        steps: [ { html: 'Do something.' } ]
       }
     ]
   },
@@ -118,6 +147,91 @@ const tests = [
         <ol><li>Return foo</li></ol>
       </div>`,
     algorithms: []
+  },
+
+  {
+    title: 'reports nested algorithms only once',
+    html: `
+      <ol class="algorithm">
+        <li>
+          Run the following steps in parallel:
+          <ol class="algorithm"><li>Do good.</li></ol>
+        </li>
+      </ol>`,
+    algorithms: [
+      {
+        rationale: '.algorithm',
+        steps: [
+          {
+            rationale: '.algorithm',
+            html: 'Run the following steps in parallel:',
+            steps: [ { html: 'Do good.' } ]
+          }
+        ]
+      }
+    ]
+  },
+
+  {
+    title: 'reports additional steps at the same level',
+    html: `
+      <ol class="algorithm">
+        <li>
+          <p>Run the following steps in parallel:</p>
+          <ol><li>Do good.</li></ol>
+          <p>If that does not do any good, run:</p>
+          <ol><li>Do evil.</li></ol>
+        </li>
+      </ol>`,
+    algorithms: [
+      {
+        rationale: '.algorithm',
+        steps: [
+          {
+            rationale: 'do',
+            html: 'Run the following steps in parallel:',
+            steps: [ { html: 'Do good.' } ],
+            additional: [
+              {
+                rationale: 'do',
+                html: 'If that does not do any good, run:',
+                steps: [ { html: 'Do evil.' }]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+
+  {
+    title: 'reports sets of steps that were ignored',
+    html: `
+      <ol class="algorithm">
+        <li>
+          Run the following steps in parallel:
+          <ol><li>Blah</li></ol>
+        </li>
+        <li>
+          Then, run:
+          <ol><li>Foo bar</li></ol>
+        </li>
+      </ol>`,
+    algorithms: [
+      {
+        rationale: '.algorithm',
+        steps: [
+          {
+            html: 'Run the following steps in parallel:',
+            ignored: ['Blah']
+          },
+          {
+            html: 'Then, run:',
+            ignored: ['Foo bar']
+          }
+        ]
+      }
+    ]
   },
 ];
 

--- a/tests/extract-algorithms.js
+++ b/tests/extract-algorithms.js
@@ -67,8 +67,7 @@ const tests = [
         name: 'do nothing',
         href: 'about:blank#algo-id',
         html: 'To <dfn data-export="" data-dfn-type="dfn" id="algo-id">do nothing</dfn>, keep calm and carry on.',
-        rationale: 'To <dfn>',
-        steps: [ ]
+        rationale: 'To <dfn>'
       }
     ]
   },
@@ -95,11 +94,11 @@ const tests = [
             steps: [
               {
                 'case': 'to be',
-                steps: [ { html: 'Do something.' } ]
+                html: 'Do something.'
               },
               {
                 'case': 'not to be',
-                steps: [ { html: 'Do nothing.' } ]
+                html: 'Do nothing.'
               }
             ]
           }
@@ -139,19 +138,19 @@ const tests = [
   },
 
   {
-    title: 'extracts multiple algorithms',
+    title: 'extracts multiple algorithms, in document order',
     html: `
       <div>
         <p>To do nothing, run these steps:</p>
         <ol class="algorithm" data-algorithm="my algo" id="algo-id"><li><p>Nothing.</p></li></ol>
       </div>
+      <p>To <dfn id=everything data-export data-dfn-type=abstract-op>do everything</dfn>, repeat <a href="#another-algo">do something</a> on everything.</p>
       <p>To <dfn data-export data-dfn-type=dfn id="another-algo">do something</dfn>, run these steps:</p>
       <ol><li>Do something.</li></ol>
       <p>When this method is invoked, run the following steps:</p>
       <ol><li>Do it.</li><li>Stop doing it.</li></ol>
       <p>When this method is invoked, run the following steps:</p>
-      <ol><li>Do it carefully.</li><li>Stop doing it at once.</li></ol>
-      <p>To <dfn id=everything data-export data-dfn-type=abstract-op>do everything</dfn>, repeat <a href="#another-algo">do something</a> on everything.</p>`,
+      <ol><li>Do it carefully.</li><li>Stop doing it at once.</li></ol>`,
     algorithms: [
       {
         name: 'my algo',
@@ -159,6 +158,12 @@ const tests = [
         html: 'To do nothing, run these steps:',
         rationale: '.algorithm',
         steps: [ { html: '<p>Nothing.</p>' } ]
+      },
+      {
+        name: 'do everything',
+        href: 'about:blank#everything',
+        html: 'To <dfn id="everything" data-export="" data-dfn-type="abstract-op">do everything</dfn>, repeat <a href="about:blank#another-algo">do something</a> on everything.',
+        rationale: 'To <dfn>'
       },
       {
         name: 'do something',
@@ -176,13 +181,6 @@ const tests = [
         html: 'When this method is invoked, run the following steps:',
         rationale: 'do',
         steps: [ { html: 'Do it carefully.' }, { html: 'Stop doing it at once.' } ]
-      },
-      {
-        name: 'do everything',
-        href: 'about:blank#everything',
-        html: 'To <dfn id="everything" data-export="" data-dfn-type="abstract-op">do everything</dfn>, repeat <a href="about:blank#another-algo">do something</a> on everything.',
-        rationale: 'To <dfn>',
-        steps: []
       }
     ]
   },

--- a/tests/extract-algorithms.js
+++ b/tests/extract-algorithms.js
@@ -40,6 +40,24 @@ const tests = [
   },
 
   {
+    title: 'extracts correct URL for an algorithm in a multi-page spec',
+    html: `
+      <section data-reffy-page="https://example.com/page1">
+        <p>To <dfn id="algo-id">do nothing</dfn>, run these steps:</p>
+        <ol class=algorithm><li><p>Nothing.</p></li></ol>
+      </div>`,
+    algorithms: [
+      {
+        name: 'do nothing',
+        href: 'https://example.com/page1#algo-id',
+        html: 'To <dfn id="algo-id">do nothing</dfn>, run these steps:',
+        rationale: '.algorithm',
+        steps: [ { html: '<p>Nothing.</p>' } ]
+      }
+    ]
+  },
+
+  {
     title: 'extracts a switch marked as such',
     html: `
       <p>To <dfn id="be">be or not to be</dfn>, given <var>will</var>:</p>

--- a/tests/extract-algorithms.js
+++ b/tests/extract-algorithms.js
@@ -56,6 +56,24 @@ const tests = [
       }
     ]
   },
+  {
+    title: 'extracts one-paragraph algorithms',
+    html: `
+      <section>
+        <p>To <dfn data-export data-dfn-type=dfn id="algo-id">do nothing</dfn>, keep calm and carry on.</p>
+      </section>`,
+    algorithms: [
+      {
+        name: 'do nothing',
+        href: 'about:blank#algo-id',
+        html: 'To <dfn data-export="" data-dfn-type="dfn" id="algo-id">do nothing</dfn>, keep calm and carry on.',
+        rationale: '"To <dfn>"',
+        steps: [ {
+	  html: 'To <dfn data-export="" data-dfn-type="dfn" id="algo-id">do nothing</dfn>, keep calm and carry on.'
+	}]
+      }
+    ]
+  },
 
   {
     title: 'extracts a switch marked as such',

--- a/tests/extract-algorithms.js
+++ b/tests/extract-algorithms.js
@@ -287,6 +287,67 @@ const tests = [
       }
     ]
   },
+
+  {
+    title: 'takes data-algorithm-for into account to namespace an algorithm',
+    html: `
+      <ol class="algorithm" data-algorithm="hello" data-algorithm-for="world">
+        <li>Hello world!</li>
+      </ol>
+      <ol class="algorithm" data-algorithm="hello" data-algorithm-for="you">
+        <li>Hello you!</li>
+      </ol>`,
+    algorithms: [
+      {
+        name: 'world/hello',
+        rationale: '.algorithm',
+        steps: [ { html: 'Hello world!' } ]
+      },
+      {
+        name: 'you/hello',
+        rationale: '.algorithm',
+        steps: [ { html: 'Hello you!' } ]
+      }
+    ]
+  },
+
+  {
+    title: 'captures the first dfn in an algorithm as algorithm name',
+    html: `
+      <div class="algorithm">
+        <p>This is the <dfn data-export="" data-dfn-type="dfn" id="do-something">do something</dfn> algorithm. Please run these steps:</p>
+        <p>An annoying paragraph between the actual intro and the steps.</p>
+        <ol><li>Do something.</li></ol>
+      </div>`,
+    algorithms: [
+      {
+        name: 'do something',
+        href: 'about:blank#do-something',
+        rationale: '.algorithm',
+        html: 'This is the <dfn data-export="" data-dfn-type="dfn" id="do-something">do something</dfn> algorithm. Please run these steps:',
+        steps: [ { html: 'Do something.' } ]
+      }
+    ]
+  },
+
+  {
+    title: 'ignores a "To <dfn>" algorithm with same name as another algorithm',
+    html: `
+      <div class="algorithm">
+        <p>To <dfn data-export="" data-dfn-type="dfn" id="do-something">do something</dfn>, run these steps:</p>
+        <p>An annoying paragraph between the actual intro and the steps.</p>
+        <ol><li>Do something.</li></ol>
+      </div>`,
+    algorithms: [
+      {
+        name: 'do something',
+        href: 'about:blank#do-something',
+        rationale: '.algorithm',
+        html: 'To <dfn data-export="" data-dfn-type="dfn" id="do-something">do something</dfn>, run these steps:',
+        steps: [ { html: 'Do something.' } ]
+      }
+    ]
+  },
 ];
 
 describe('The algorithms extraction module', function () {

--- a/tests/extract-algorithms.js
+++ b/tests/extract-algorithms.js
@@ -145,8 +145,9 @@ const tests = [
         <p>To do nothing, run these steps:</p>
         <ol class="algorithm" data-algorithm="my algo" id="algo-id"><li><p>Nothing.</p></li></ol>
       </div>
-      <p>To <dfn id="another-algo">do something</dfn>, run these steps:</p>
-      <ol><li>Do something.</li></ol>`,
+      <p>To <dfn data-export data-dfn-type=dfn id="another-algo">do something</dfn>, run these steps:</p>
+      <ol><li>Do something.</li></ol>
+      <p>To <dfn id=everything data-export data-dfn-type=abstract-op>do everything</dfn>, repeat <a href="#another-algo">do something</a> on everything.</p>`,
     algorithms: [
       {
         name: 'my algo',
@@ -158,9 +159,16 @@ const tests = [
       {
         name: 'do something',
         href: 'about:blank#another-algo',
-        html: 'To <dfn id="another-algo">do something</dfn>, run these steps:',
+        html: 'To <dfn data-export="" data-dfn-type="dfn" id="another-algo">do something</dfn>, run these steps:',
         rationale: 'do',
         steps: [ { html: 'Do something.' } ]
+      },
+      {
+        name: 'do everything',
+        href: 'about:blank#everything',
+        html: 'To <dfn id="everything" data-export="" data-dfn-type="abstract-op">do everything</dfn>, repeat <a href="about:blank#another-algo">do something</a> on everything.',
+        rationale: 'To <dfn>',
+        steps: []
       }
     ]
   },

--- a/tests/extract-algorithms.js
+++ b/tests/extract-algorithms.js
@@ -147,6 +147,10 @@ const tests = [
       </div>
       <p>To <dfn data-export data-dfn-type=dfn id="another-algo">do something</dfn>, run these steps:</p>
       <ol><li>Do something.</li></ol>
+      <p>When this method is invoked, run the following steps:</p>
+      <ol><li>Do it.</li><li>Stop doing it.</li></ol>
+      <p>When this method is invoked, run the following steps:</p>
+      <ol><li>Do it carefully.</li><li>Stop doing it at once.</li></ol>
       <p>To <dfn id=everything data-export data-dfn-type=abstract-op>do everything</dfn>, repeat <a href="#another-algo">do something</a> on everything.</p>`,
     algorithms: [
       {
@@ -162,6 +166,16 @@ const tests = [
         html: 'To <dfn data-export="" data-dfn-type="dfn" id="another-algo">do something</dfn>, run these steps:',
         rationale: 'do',
         steps: [ { html: 'Do something.' } ]
+      },
+      {
+        html: 'When this method is invoked, run the following steps:',
+        rationale: 'do',
+        steps: [ { html: 'Do it.' }, { html: 'Stop doing it.' } ]
+      },
+      {
+        html: 'When this method is invoked, run the following steps:',
+        rationale: 'do',
+        steps: [ { html: 'Do it carefully.' }, { html: 'Stop doing it at once.' } ]
       },
       {
         name: 'do everything',

--- a/tests/extract-algorithms.js
+++ b/tests/extract-algorithms.js
@@ -67,10 +67,8 @@ const tests = [
         name: 'do nothing',
         href: 'about:blank#algo-id',
         html: 'To <dfn data-export="" data-dfn-type="dfn" id="algo-id">do nothing</dfn>, keep calm and carry on.',
-        rationale: '"To <dfn>"',
-        steps: [ {
-	  html: 'To <dfn data-export="" data-dfn-type="dfn" id="algo-id">do nothing</dfn>, keep calm and carry on.'
-	}]
+        rationale: 'To <dfn>',
+        steps: [ ]
       }
     ]
   },

--- a/tests/extract-algorithms.js
+++ b/tests/extract-algorithms.js
@@ -348,6 +348,25 @@ const tests = [
       }
     ]
   },
+
+  {
+    title: 'ignores informative prose when it looks for introductory paragraph',
+    html: `
+      <p>To <dfn data-export="" data-dfn-type="dfn" id="do-something">do something</dfn>, run these steps:</p>
+      <p class="note">Hello there, it's Clippy. How can I be of any help?</p>
+      <ol class="algorithm"><li>Do something.</li></ol>
+      </div>`,
+    algorithms: [
+      {
+        name: 'do something',
+        href: 'about:blank#do-something',
+        rationale: '.algorithm',
+        html: 'To <dfn data-export="" data-dfn-type="dfn" id="do-something">do something</dfn>, run these steps:',
+        steps: [ { html: 'Do something.' } ]
+      }
+    ]
+  },
+
 ];
 
 describe('The algorithms extraction module', function () {

--- a/tests/extract-algorithms.js
+++ b/tests/extract-algorithms.js
@@ -1,0 +1,185 @@
+const assert = require('assert');
+const puppeteer = require('puppeteer');
+const path = require('path');
+const rollup = require('rollup');
+const { getSchemaValidationFunction } = require('../src/lib/util');
+
+const tests = [
+  {
+    title: 'extracts an algorithm marked as such (set of steps)',
+    html: `
+      <p>To do nothing, run these steps:</p>
+      <ol class="algorithm" data-algorithm="my algo" id="algo-id"><li><p>Nothing.</p></li></ol>`,
+    algorithms: [
+      {
+        name: 'my algo',
+        href: 'about:blank#algo-id',
+        html: 'To do nothing, run these steps:',
+        rationale: '.algorithm',
+        steps: [ { html: '<p>Nothing.</p>' } ]
+      }
+    ]
+  },
+
+  {
+    title: 'extracts an algorithm marked as such (container)',
+    html: `
+      <div class="algorithm" data-algorithm="my algo" id="algo-id">
+        <p>To do nothing, run these steps:</p>
+        <ol><li><p>Nothing.</p></li></ol>
+      </div>`,
+    algorithms: [
+      {
+        name: 'my algo',
+        href: 'about:blank#algo-id',
+        html: 'To do nothing, run these steps:',
+        rationale: '.algorithm',
+        steps: [ { html: '<p>Nothing.</p>' } ]
+      }
+    ]
+  },
+
+  {
+    title: 'extracts a switch marked as such',
+    html: `
+      <p>To be or not to be, given <var>will</var>:</p>
+      <dl class="switch">
+        <dt>to be</dt>
+        <dd>Do something.</dd>
+        <dt>not to be</dt>
+        <dd>Do nothing.</dd>
+      </dl>`,
+    algorithms: [
+      {
+        html: 'To be or not to be, given <var>will</var>:',
+        rationale: '.switch',
+        steps: [
+          {
+            operation: 'switch',
+            steps: [
+              {
+                'case': 'to be',
+                steps: [ { html: 'Do something.' } ]
+              },
+              {
+                'case': 'not to be',
+                steps: [ { html: 'Do nothing.' } ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+
+  {
+    title: 'extracts a set of steps when an operation is found (return)',
+    html: `
+      <ol><li>Return foo.</li></ol>`,
+    algorithms: [
+      {
+        rationale: 'return',
+        steps: [ { html: 'Return foo.' } ]
+      }
+    ]
+  },
+
+  {
+    title: 'extracts a set of steps when an operation is found (throw)',
+    html: `
+      <ol>
+        <li>To start with, just relax.</li>
+        <li>Throw a TooMuchWork exception.</li>
+      </ol>`,
+    algorithms: [
+      {
+        rationale: 'throw',
+        steps: [
+          { html: 'To start with, just relax.' },
+          { html: 'Throw a TooMuchWork exception.' }
+        ]
+      }
+    ]
+  },
+
+  {
+    title: 'skips the table of contents',
+    html: `
+      <div class="toc">
+        <ol><li>Return foo</li></ol>
+      </div>`,
+    algorithms: []
+  },
+
+  {
+    title: 'skips informative algorithms',
+    html: `
+      <div class="note">
+        <ol><li>Return foo</li></ol>
+      </div>`,
+    algorithms: []
+  },
+];
+
+describe('The algorithms extraction module', function () {
+  this.slow(5000);
+
+  let browser;
+  let mapIdsToHeadingsCode;
+  let extractAlgorithmsCode;
+  const validateSchema = getSchemaValidationFunction('extract-algorithms');
+
+  async function assertExtractedAlgorithms(html, algorithms, spec) {
+    const page = await browser.newPage();
+    let pageContent = html + `<script>let spec = "${spec}";</script>`;
+    page.on('console', message =>
+      console.error(`${message.type().substr(0, 3).toUpperCase()} ${message.text()}`));
+    page.setContent(pageContent);
+    await page.addScriptTag({ content: mapIdsToHeadingsCode });
+    await page.addScriptTag({ content: extractAlgorithmsCode });
+
+    const extractedAlgorithms = await page.evaluate(async () => {
+      const idToHeading = mapIdsToHeadings();
+      return extractAlgorithms(spec, idToHeading);
+    });
+    await page.close();
+
+    assert.deepEqual(extractedAlgorithms, algorithms);
+
+    const errors = validateSchema(extractedAlgorithms);
+    assert.strictEqual(errors, null, JSON.stringify(errors, null, 2));
+  }
+
+  before(async () => {
+    const extractAlgorithmsBundle = await rollup.rollup({
+      input: path.resolve(__dirname, '../src/browserlib/extract-algorithms.mjs'),
+      onwarn: _ => {}
+    });
+    const extractAlgorithmsOutput = (await extractAlgorithmsBundle.generate({
+      name: 'extractAlgorithms',
+      format: 'iife'
+    })).output;
+    extractAlgorithmsCode = extractAlgorithmsOutput[0].code;
+
+    const mapIdsToHeadingsBundle = await rollup.rollup({
+      input: path.resolve(__dirname, '../src/browserlib/map-ids-to-headings.mjs')
+    });
+    const mapIdsToHeadingsOutput = (await mapIdsToHeadingsBundle.generate({
+      name: 'mapIdsToHeadings',
+      format: 'iife'
+    })).output;
+    mapIdsToHeadingsCode = mapIdsToHeadingsOutput[0].code;
+
+    browser = await puppeteer.launch({ headless: true });
+  });
+
+  tests.forEach(t => {
+    it(t.title, async () => assertExtractedAlgorithms(t.html, t.algorithms, t.spec));
+  });
+
+
+  after(async () => {
+    await browser.close();
+  });
+});
+


### PR DESCRIPTION
This adds a browserlib module that creates extracts filled with information about algorithms defined in the spec. The extracts are rather raw: they just capture the tree structure of algorithms and copy the HTML for each step. This makes the resulting extracts less directly useful but also makes it possible to run all sorts of analyses on them (see related PR in Strudy: https://github.com/w3c/strudy/pull/645 and the [current results of running the analysis](https://github.com/tidoust/parallel-promise/issues/2)).

This would add about 50MB of additional data to a Webref crawl result. That's significant, roughly equivalent to the IDs extracts, which are the heaviest for now.

The structure of the extracts is very likely going to change substantively as we learn from experience!

There are plenty of things that could be improved. The code contains TODOs for main ones.

An algorithm extract is essentially an object with the following keys:
- `name`: The name of the algorithm, when one exists
- `href`: The URL with fragment to reach the algorithm, when one exists
- `html`: Some introductory prose for the algorithm. That prose may well contain actual algorithmic operations, e.g.: "When invoked, run the following
 steps in parallel". href/src attributes in the HTML have absolute URLs.
- `steps`: Atomic algorithm steps.

Each step is essentially an object that follows the same structure as an algorithm, except that it does not have a `name` and `href` keys, and may also have the following keys:
- `operation`: Gives the name of the main operation performed by the step, when one was identified. So far, that's only for "switch".
- `case`: Used in switch steps to identify the switch condition that triggers the step.
- `ignored`: Ordered lists found at the step level that do no look like algorithm steps. Or maybe they are? The lists should get reviewed: they usually describe inputs/outputs or conditions, but they may signal parts where the extraction logic needs to be improved. The lists are reported as text prose.
- `additional`: Each step should contain one and only one algorithm. When other algorithms are found at the same level, they get reported in that property. That usually either signals that the spec could be improved because if fails to use different list items for different steps, and/or that the extraction logic needs to be smarter.