### PR TITLE
Switch to ECMAScript modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,19 @@
-module.exports = {
-  parseIdl: require("./src/cli/parse-webidl").parse,
-  crawlSpecs: require("./src/lib/specs-crawler").crawlSpecs,
-  expandCrawlResult: require("./src/lib/util").expandCrawlResult,
-  mergeCrawlResults: require("./src/lib/util").mergeCrawlResults,
-  isLatestLevelThatPasses: require("./src/lib/util").isLatestLevelThatPasses,
-  getInterfaceTreeInfo: require("./src/lib/util").getInterfaceTreeInfo,
-  getSchemaValidationFunction: require("./src/lib/util").getSchemaValidationFunction,
-  postProcessor: require("./src/lib/post-processor")
+import { parseIdl } from "./src/cli/parse-webidl.js";
+import { crawlSpecs } from "./src/lib/specs-crawler.js";
+import { expandCrawlResult } from "./src/lib/util.js";
+import { mergeCrawlResults } from "./src/lib/util.js";
+import { isLatestLevelThatPasses } from "./src/lib/util.js";
+import { getInterfaceTreeInfo } from "./src/lib/util.js";
+import { getSchemaValidationFunction } from "./src/lib/util.js";
+import postProcessor from "./src/lib/post-processor.js";
+
+export {
+  parseIdl,
+  crawlSpecs,
+  expandCrawlResult,
+  mergeCrawlResults,
+  isLatestLevelThatPasses,
+  getInterfaceTreeInfo,
+  getSchemaValidationFunction,
+  postProcessor
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "engines": {
     "node": ">=20.12.1"
   },
+  "type": "module",
   "main": "index.js",
   "bin": "./reffy.js",
   "dependencies": {

--- a/src/cli/merge-crawl-results.js
+++ b/src/cli/merge-crawl-results.js
@@ -15,8 +15,10 @@
  * @module merger
  */
 
-const fs = require('fs');
-const requireFromWorkingDirectory = require('../lib/util').requireFromWorkingDirectory;
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+import { loadJSON } from '../lib/util.js';
 
 
 /**
@@ -81,11 +83,11 @@ function mergeCrawlResults(newCrawl, refCrawl, options) {
  * @param {Object} options Merge options. Only "matchTitle" is supported for now
  * @return {Promise} The promise to have merged the two JSON files into one
  */
-function mergeCrawlFiles(newCrawlPath, refCrawlPath, resPath, options) {
+async function mergeCrawlFiles(newCrawlPath, refCrawlPath, resPath, options) {
     options = options || {};
 
-    let newCrawl = requireFromWorkingDirectory(newCrawlPath);
-    let refCrawl = requireFromWorkingDirectory(refCrawlPath);
+    let newCrawl = await loadJSON(newCrawlPath);
+    let refCrawl = await loadJSON(refCrawlPath);
     return mergeCrawlResults(newCrawl, refCrawl, options)
         .then(filedata => new Promise((resolve, reject) =>
             fs.writeFile(resPath, JSON.stringify(filedata, null, 2),
@@ -96,14 +98,16 @@ function mergeCrawlFiles(newCrawlPath, refCrawlPath, resPath, options) {
 /**************************************************
 Export the methods for use as module
 **************************************************/
-module.exports.mergeCrawlResults = mergeCrawlResults;
-module.exports.mergeCrawlFiles = mergeCrawlFiles;
+export {
+    mergeCrawlResults,
+    mergeCrawlFiles
+};
 
 
 /**************************************************
 Code run if the code is run as a stand-alone module
 **************************************************/
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
     let newCrawlPath = process.argv[2];
     let refCrawlPath = process.argv[3];
     let resPath = process.argv[4];

--- a/src/cli/parse-webidl.js
+++ b/src/cli/parse-webidl.js
@@ -18,7 +18,9 @@
  * @module webidlParser
  */
 
-const WebIDL2 = require("webidl2");
+import * as WebIDL2 from 'webidl2';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
 
 
 /**
@@ -410,15 +412,17 @@ function addDependency(name, idlNames, externalDependencies) {
 /**************************************************
 Export the parse method for use as module
 **************************************************/
-module.exports.parse = parse;
-module.exports.hasObsoleteIdl = hasObsoleteIdl;
+export {
+    parse,
+    hasObsoleteIdl
+};
 
 
 /**************************************************
 Code run if the code is run as a stand-alone module
 **************************************************/
-if (require.main === module) {
-    const fs = require("fs");
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    const fs = await import('node:fs');
     const idlFile = process.argv[2];
     if (!idlFile) {
         console.error("No IDL file to parse");

--- a/src/lib/css-grammar-parser.js
+++ b/src/lib/css-grammar-parser.js
@@ -437,4 +437,4 @@ const parsePropDefValue = (value) => {
   return res.length === 1 ? res[0] : res;
 };
 
-module.exports.parsePropDefValue =  parsePropDefValue;
+export { parsePropDefValue };

--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -6,7 +6,6 @@
  */
 
 import os from 'node:os';
-import { cwd } from 'node:process';
 import path from 'node:path';
 import baseFetch from 'fetch-filecache-for-crawling';
 import { loadJSON } from './util.js';

--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -5,16 +5,15 @@
  * @module finder
  */
 
-const os = require('os');
-const path = require('path');
-const baseFetch = require('fetch-filecache-for-crawling');
+import os from 'node:os';
+import { cwd } from 'node:process';
+import path from 'node:path';
+import baseFetch from 'fetch-filecache-for-crawling';
+import { loadJSON } from './util.js';
 
 // Read configuration parameters from `config.json` file
-let config = null;
-try {
-    config = require(path.resolve('config.json'));
-}
-catch (err) {
+let config = await loadJSON('config.json');
+if (!config) {
     config = {};
 }
 
@@ -32,7 +31,7 @@ catch (err) {
  *   options for fetch-filecache-for-crawling)
  * @return {Promise(Response)} Promise to get an HTTP response
  */
-async function fetch(url, options) {
+export default async function fetch(url, options) {
     options = Object.assign({headers: {}}, options);
     ['cacheFolder', 'resetCache', 'cacheRefresh', 'logToConsole'].forEach(param => {
         let fetchParam = (param === 'cacheRefresh') ? 'refresh' : param;
@@ -51,6 +50,3 @@ async function fetch(url, options) {
 
     return baseFetch(url, options);
 }
-
-
-module.exports = fetch;

--- a/src/lib/mock-server.js
+++ b/src/lib/mock-server.js
@@ -5,9 +5,12 @@
  * @module mock-server
  */
 
-const { MockAgent, setGlobalDispatcher } = require('undici');
-const path = require("path");
-const { existsSync, readFileSync } = require('fs');
+import { MockAgent, setGlobalDispatcher } from 'undici';
+import path from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Determine the path to the "node_modules" folder. The path depends on whether
@@ -17,7 +20,7 @@ const { existsSync, readFileSync } = require('fs');
  * @return {String} Path to the node_modules folder.
  */
 function getModulesFolder() {
-    const rootFolder = path.resolve(__dirname, '../..');
+    const rootFolder = path.resolve(scriptPath, '../..');
     let folder = path.resolve(rootFolder, 'node_modules');
     if (existsSync(folder)) {
         return folder;
@@ -185,4 +188,4 @@ nock.emitter.on('no match', function(req, options, requestBody) {
   }
 });*/
 
-module.exports = mockAgent;
+export default mockAgent;

--- a/src/lib/throttled-queue.js
+++ b/src/lib/throttled-queue.js
@@ -43,7 +43,7 @@ function getOrigin(url) {
  * while guaranteeing that only one request will be sent to a given origin
  * server at a time.
  */
-module.exports = class ThrottledQueue {
+export default class ThrottledQueue {
   originQueue = {};
   maxParallel = 4;
   sleepInterval = 2000;

--- a/src/postprocessing/annotate-links.js
+++ b/src/postprocessing/annotate-links.js
@@ -18,7 +18,7 @@ function canonicalizeUrl(url) {
 
 const needsSaving = {};
 
-module.exports = {
+export default {
   dependsOn: ['links'],
   input: 'spec',
 
@@ -38,3 +38,4 @@ module.exports = {
     return spec;
   }
 };
+

--- a/src/postprocessing/csscomplete.js
+++ b/src/postprocessing/csscomplete.js
@@ -8,9 +8,9 @@
  * rather completes the `css` property with additional info.
  */
 
-const { getGeneratedIDLNamesByCSSProperty } = require('../lib/util');
+import { getGeneratedIDLNamesByCSSProperty } from '../lib/util.js';
 
-module.exports = {
+export default {
   dependsOn: ['css', 'dfns'],
   input: 'spec',
 

--- a/src/postprocessing/events.js
+++ b/src/postprocessing/events.js
@@ -3,9 +3,9 @@
  * per event.
  */
 
-const { isLatestLevelThatPasses, getInterfaceTreeInfo } = require('../lib/util');
+import { isLatestLevelThatPasses, getInterfaceTreeInfo } from '../lib/util.js';
 
-module.exports = {
+export default {
   dependsOn: ['events'],
   input: 'crawl',
   property: 'events',

--- a/src/postprocessing/idlnames.js
+++ b/src/postprocessing/idlnames.js
@@ -7,20 +7,20 @@
  * to worry about ordering, "idlparsed" will always run before this one).
  */
 
-const fs = require('fs');
-const path = require('path');
-const {
+import fs from 'node:fs';
+import path from 'node:path';
+import {
   matchIdlDfn,
-  getExpectedDfnFromIdlDesc } = require('../cli/check-missing-dfns');
-const {
+  getExpectedDfnFromIdlDesc } from '../cli/check-missing-dfns.js';
+import {
   isLatestLevelThatPasses,
-  createFolderIfNeeded } = require('../lib/util');
+  createFolderIfNeeded } from '../lib/util.js';
 
 
 /**
  * Definition of the post-processing module
  */
-module.exports = {
+export default {
   dependsOn: ['idlparsed', 'dfns'],
   input: 'crawl',
   run: generateIdlNames,

--- a/src/postprocessing/idlparsed.js
+++ b/src/postprocessing/idlparsed.js
@@ -5,9 +5,9 @@
  * The module runs at the spec level and generates an `idlparsed` property.
  */
 
-const webidlParser = require('../cli/parse-webidl');
+import * as webidlParser from '../cli/parse-webidl.js';
 
-module.exports = {
+export default {
   dependsOn: ['dfns', 'idl'],
   input: 'spec',
   property: 'idlparsed',

--- a/src/postprocessing/patch-dfns.js
+++ b/src/postprocessing/patch-dfns.js
@@ -10,7 +10,7 @@
  * The module runs at the spec level.
  */
 
-module.exports = {
+export default {
   dependsOn: ['dfns'],
   input: 'spec',
 

--- a/tests/create-outline.js
+++ b/tests/create-outline.js
@@ -1,7 +1,9 @@
-const assert = require('assert');
-const puppeteer = require('puppeteer');
-const path = require('path');
-const rollup = require('rollup');
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+import { rollup } from 'rollup';
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 
 // Note: Most of these tests are taken from the Sample outlines section in HTML
 // https://html.spec.whatwg.org/multipage/sections.html#sample-outlines
@@ -292,8 +294,8 @@ describe("Test outline generation", function () {
   before(async () => {
     // Convert the JS module to a JS script that can be loaded in Puppeteer
     // without having to provide a URL for it (tests run in "about:blank" pages)
-    const bundle = await rollup.rollup({
-      input: path.resolve(__dirname, '../src/browserlib/create-outline.mjs')
+    const bundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/create-outline.mjs')
     });
     const { output } = await bundle.generate({
       name: 'createOutline',

--- a/tests/css-grammar-parser/test.js
+++ b/tests/css-grammar-parser/test.js
@@ -1,11 +1,11 @@
-const css = require("../../src/lib/css-grammar-parser");
-const fs = require("fs");
-const assert = require("assert");
+import assert from "node:assert";
+import fs from "node:fs";
+import { parsePropDefValue } from "../../src/lib/css-grammar-parser.js";
 
 const propDefs = fs.readFileSync("tests/css-grammar-parser/in", "utf-8").split("\n").map(def => def.trim());
 const propDefsOut = JSON.parse(fs.readFileSync("tests/css-grammar-parser/out.json", "utf-8"));
 
-const results = propDefs.map(css.parsePropDefValue);
+const results = propDefs.map(parsePropDefValue);
 describe('Parser correctly parses grammar instances', () => {
   for(let i in results) {
     it(`parses property definition ${propDefs[i]} as expected`, () => {

--- a/tests/extract-algorithms.js
+++ b/tests/extract-algorithms.js
@@ -1,8 +1,10 @@
-const assert = require('assert');
-const puppeteer = require('puppeteer');
-const path = require('path');
-const rollup = require('rollup');
-const { getSchemaValidationFunction } = require('../src/lib/util');
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+import { rollup } from 'rollup';
+import { getSchemaValidationFunction } from '../src/lib/util.js';
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 
 const tests = [
   {
@@ -508,7 +510,7 @@ describe('The algorithms extraction module', function () {
   let browser;
   let mapIdsToHeadingsCode;
   let extractAlgorithmsCode;
-  const validateSchema = getSchemaValidationFunction('extract-algorithms');
+  let validateSchema;
 
   async function assertExtractedAlgorithms(html, algorithms, spec) {
     const page = await browser.newPage();
@@ -532,8 +534,10 @@ describe('The algorithms extraction module', function () {
   }
 
   before(async () => {
-    const extractAlgorithmsBundle = await rollup.rollup({
-      input: path.resolve(__dirname, '../src/browserlib/extract-algorithms.mjs'),
+    validateSchema = await getSchemaValidationFunction('extract-algorithms');
+
+    const extractAlgorithmsBundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/extract-algorithms.mjs'),
       onwarn: _ => {}
     });
     const extractAlgorithmsOutput = (await extractAlgorithmsBundle.generate({
@@ -542,8 +546,8 @@ describe('The algorithms extraction module', function () {
     })).output;
     extractAlgorithmsCode = extractAlgorithmsOutput[0].code;
 
-    const mapIdsToHeadingsBundle = await rollup.rollup({
-      input: path.resolve(__dirname, '../src/browserlib/map-ids-to-headings.mjs')
+    const mapIdsToHeadingsBundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/map-ids-to-headings.mjs')
     });
     const mapIdsToHeadingsOutput = (await mapIdsToHeadingsBundle.generate({
       name: 'mapIdsToHeadings',

--- a/tests/extract-css.js
+++ b/tests/extract-css.js
@@ -1,8 +1,10 @@
-const assert = require('assert');
-const puppeteer = require('puppeteer');
-const path = require('path');
-const rollup = require('rollup');
-const { getSchemaValidationFunction } = require('../src/lib/util');
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+import { rollup } from 'rollup';
+import { getSchemaValidationFunction } from '../src/lib/util.js';
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 
 const tests = [
   {title: "parses a regular propdef table",
@@ -1586,13 +1588,15 @@ describe("Test CSS properties extraction", function() {
   this.timeout(10000);
   let browser;
   let extractCSSCode;
-  const validateSchema = getSchemaValidationFunction('extract-cssdfn');
+  let validateSchema;
 
   before(async () => {
+    validateSchema = await getSchemaValidationFunction('extract-cssdfn');
+
     // Convert the JS module to a JS script that can be loaded in Puppeteer
     // without having to provide a URL for it (tests run in "about:blank" pages)
-    const bundle = await rollup.rollup({
-      input: path.resolve(__dirname, '../src/browserlib/extract-cssdfn.mjs')
+    const bundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/extract-cssdfn.mjs')
     });
     const { output } = await bundle.generate({
       name: 'extractCSS',

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -1,8 +1,10 @@
-const assert = require('assert');
-const puppeteer = require('puppeteer');
-const path = require('path');
-const rollup = require('rollup');
-const { getSchemaValidationFunction } = require('../src/lib/util');
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+import { rollup } from 'rollup';
+import { getSchemaValidationFunction } from '../src/lib/util.js';
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 
 // Associating HTML definitions with the right data relies on IDL defined in that spec
 const baseHtml = `<pre><code class=idl>
@@ -728,7 +730,7 @@ describe("Test definition extraction", function () {
   let browser;
   let mapIdsToHeadingsCode;
   let extractDefinitionsCode;
-  const validateSchema = getSchemaValidationFunction('extract-dfns');
+  let validateSchema;
 
   async function assertExtractedDefinition(html, dfns, spec) {
     const page = await browser.newPage();
@@ -762,8 +764,10 @@ describe("Test definition extraction", function () {
   }
 
   before(async () => {
-    const extractDefinitionsBundle = await rollup.rollup({
-      input: path.resolve(__dirname, '../src/browserlib/extract-dfns.mjs'),
+    validateSchema = await getSchemaValidationFunction('extract-dfns');
+
+    const extractDefinitionsBundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/extract-dfns.mjs'),
       onwarn: _ => {}
     });
     const extractDefinitionsOutput = (await extractDefinitionsBundle.generate({
@@ -772,8 +776,8 @@ describe("Test definition extraction", function () {
     })).output;
     extractDefinitionsCode = extractDefinitionsOutput[0].code;
 
-    const mapIdsToHeadingsBundle = await rollup.rollup({
-      input: path.resolve(__dirname, '../src/browserlib/map-ids-to-headings.mjs')
+    const mapIdsToHeadingsBundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/map-ids-to-headings.mjs')
     });
     const mapIdsToHeadingsOutput = (await mapIdsToHeadingsBundle.generate({
       name: 'mapIdsToHeadings',

--- a/tests/extract-elements.js
+++ b/tests/extract-elements.js
@@ -1,8 +1,10 @@
-const assert = require('assert');
-const puppeteer = require('puppeteer');
-const path = require('path');
-const rollup = require('rollup');
-const { getSchemaValidationFunction } = require('../src/lib/util');
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+import { rollup } from 'rollup';
+import { getSchemaValidationFunction } from '../src/lib/util.js';
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 
 const tests = [
   {
@@ -209,11 +211,12 @@ describe("Markup element extraction", function () {
 
   let browser;
   let extractElementsCode;
-  const validateSchema = getSchemaValidationFunction('extract-elements');
+  let validateSchema;
 
   before(async () => {
-    const bundle = await rollup.rollup({
-      input: path.resolve(__dirname, '../src/browserlib/extract-elements.mjs'),
+    validateSchema = await getSchemaValidationFunction('extract-elements');
+    const bundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/extract-elements.mjs'),
       onwarn: _ => {}
     });
     const output = (await bundle.generate({

--- a/tests/extract-events.js
+++ b/tests/extract-events.js
@@ -1,8 +1,10 @@
-const assert = require('assert');
-const puppeteer = require('puppeteer');
-const path = require('path');
-const rollup = require('rollup');
-const { getSchemaValidationFunction } = require('../src/lib/util');
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+import { rollup } from 'rollup';
+import { getSchemaValidationFunction } from '../src/lib/util.js';
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 
 const defaultResults = (format, {successIface} = {successIface: "SuccessEvent"}) =>  [
   {
@@ -178,11 +180,12 @@ describe("Events extraction", function () {
   this.slow(5000);
   let browser;
   let extractEventsCode;
-  const validateSchema = getSchemaValidationFunction('extract-events');
+  let validateSchema;
 
   before(async () => {
-    const bundle = await rollup.rollup({
-      input: path.resolve(__dirname, '../src/browserlib/extract-events.mjs'),
+    validateSchema = await getSchemaValidationFunction('extract-events');
+    const bundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/extract-events.mjs'),
       onwarn: _ => {}
     });
     const output = (await bundle.generate({

--- a/tests/extract-headings.js
+++ b/tests/extract-headings.js
@@ -1,8 +1,10 @@
-const assert = require('assert');
-const puppeteer = require('puppeteer');
-const path = require('path');
-const rollup = require('rollup');
-const { getSchemaValidationFunction } = require('../src/lib/util');
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+import { rollup } from 'rollup';
+import { getSchemaValidationFunction } from '../src/lib/util.js';
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 
 const testHeadings = [
   {
@@ -61,13 +63,14 @@ describe("Test headings extraction", function () {
   this.slow(5000);
 
   let browser;
-  let extractDefinitionsCode;
+  let extractHeadingsCode;
   let mapIdsToHeadingsCode;
-  const validateSchema = getSchemaValidationFunction('extract-headings');
+  let validateSchema;
 
   before(async () => {
-    const extractHeadingsBundle = await rollup.rollup({
-      input: path.resolve(__dirname, '../src/browserlib/extract-headings.mjs')
+    validateSchema = await getSchemaValidationFunction('extract-headings');
+    const extractHeadingsBundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/extract-headings.mjs')
     });
     const extractHeadingsOutput = (await extractHeadingsBundle.generate({
       name: 'extractHeadings',
@@ -75,8 +78,8 @@ describe("Test headings extraction", function () {
     })).output;
     extractHeadingsCode = extractHeadingsOutput[0].code;
 
-    const mapIdsToHeadingsBundle = await rollup.rollup({
-      input: path.resolve(__dirname, '../src/browserlib/map-ids-to-headings.mjs')
+    const mapIdsToHeadingsBundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/map-ids-to-headings.mjs')
     });
     const mapIdsToHeadingsOutput = (await mapIdsToHeadingsBundle.generate({
       name: 'mapIdsToHeadings',

--- a/tests/extract-ids.js
+++ b/tests/extract-ids.js
@@ -1,8 +1,10 @@
-const assert = require('assert');
-const puppeteer = require('puppeteer');
-const path = require('path');
-const rollup = require('rollup');
-const { getSchemaValidationFunction } = require('../src/lib/util');
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+import { rollup } from 'rollup';
+import { getSchemaValidationFunction } from '../src/lib/util.js';
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 
 const testIds = [
   {
@@ -63,11 +65,12 @@ describe("IDs extraction", function () {
 
   let browser;
   let extractIdsCode;
-  const validateSchema = getSchemaValidationFunction('extract-ids');
+  let validateSchema;
 
   before(async () => {
-    const extractIdsBundle = await rollup.rollup({
-      input: path.resolve(__dirname, '../src/browserlib/extract-ids.mjs')
+    validateSchema = await getSchemaValidationFunction('extract-ids');
+    const extractIdsBundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/extract-ids.mjs')
     });
     const extractIdsOutput = (await extractIdsBundle.generate({
       name: 'extractIds',

--- a/tests/extract-links.js
+++ b/tests/extract-links.js
@@ -1,8 +1,10 @@
-const assert = require('assert');
-const puppeteer = require('puppeteer');
-const path = require('path');
-const rollup = require('rollup');
-const { getSchemaValidationFunction } = require('../src/lib/util');
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+import { rollup } from 'rollup';
+import { getSchemaValidationFunction } from '../src/lib/util.js';
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 
 const testLinks = [
   {
@@ -68,11 +70,12 @@ describe("Links extraction", function () {
 
   let browser;
   let extractLinksCode;
-  const validateSchema = getSchemaValidationFunction('extract-links');
+  let validateSchema;
 
   before(async () => {
-    const extractLinksBundle = await rollup.rollup({
-      input: path.resolve(__dirname, '../src/browserlib/extract-links.mjs')
+    validateSchema = await getSchemaValidationFunction('extract-links');
+    const extractLinksBundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/extract-links.mjs')
     });
     const extractLinksOutput = (await extractLinksBundle.generate({
       name: 'extractLinks',

--- a/tests/extract-references.js
+++ b/tests/extract-references.js
@@ -1,8 +1,10 @@
-const assert = require('assert');
-const puppeteer = require('puppeteer');
-const path = require('path');
-const rollup = require('rollup');
-const { getSchemaValidationFunction } = require('../src/lib/util');
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+import { rollup } from 'rollup';
+import { getSchemaValidationFunction } from '../src/lib/util.js';
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 
 const testRefs = [
   {
@@ -239,11 +241,12 @@ describe("References extraction", function () {
 
   let browser;
   let extractRefsCode;
-  const validateSchema = getSchemaValidationFunction('extract-refs');
+  let validateSchema;
 
   before(async () => {
-    const extractRefsBundle = await rollup.rollup({
-      input: path.resolve(__dirname, '../src/browserlib/extract-references.mjs')
+    validateSchema = await getSchemaValidationFunction('extract-refs');
+    const extractRefsBundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/extract-references.mjs')
     });
     const extractRefsOutput = (await extractRefsBundle.generate({
       name: 'extractRefs',

--- a/tests/extract-webidl.js
+++ b/tests/extract-webidl.js
@@ -1,7 +1,9 @@
-const assert = require('assert');
-const puppeteer = require('puppeteer');
-const path = require('path');
-const rollup = require('rollup');
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+import { rollup } from 'rollup';
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 
 const testIds = [
   {
@@ -152,8 +154,8 @@ describe("Web IDL extraction", function () {
   let extractCode;
 
   before(async () => {
-    const extractBundle = await rollup.rollup({
-      input: path.resolve(__dirname, '../src/browserlib/extract-webidl.mjs')
+    const extractBundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/extract-webidl.mjs')
     });
     const extractOutput = (await extractBundle.generate({
       name: 'extractIdl',

--- a/tests/generate-idlparsed.js
+++ b/tests/generate-idlparsed.js
@@ -1,17 +1,17 @@
-const assert = require('assert');
-const { run } = require('../src/postprocessing/idlparsed');
+import assert from 'node:assert';
+import idlparsed from '../src/postprocessing/idlparsed.js';
 
 describe('The parsed IDL generator', function () {
   it('leaves a spec without IDL intact', async () => {
     const spec = {};
-    const result = await run(spec);
+    const result = await idlparsed.run(spec);
     assert.deepEqual(result, {});
   });
 
   it('parses raw IDL defined in the `idl` property', async () => {
     const idl = 'interface foo {};';
     const spec = { idl };
-    const result = await run(spec);
+    const result = await idlparsed.run(spec);
     assert.deepEqual(result?.idlparsed?.idlNames, {
       foo: {
         extAttrs: [],
@@ -28,7 +28,7 @@ describe('The parsed IDL generator', function () {
   it('reports IDL parsing errors', async () => {
     const idl = 'intraface foo {};';
     const spec = { idl };
-    const result = await run(spec);
+    const result = await idlparsed.run(spec);
     assert.equal(result.idlparsed, `WebIDLParseError: Syntax error at line 1:
 intraface foo {};
 ^ Unrecognised tokens`);
@@ -58,7 +58,7 @@ intraface foo {};
   ]) {
     it(`links back to the definition in the spec when available (${type})`, async () => {
       const spec = getIdlSpecWithDfn(type);
-      const result = await run(spec);
+      const result = await idlparsed.run(spec);
       assert.deepEqual(result?.idlparsed?.idlNames, {
         foo: {
           extAttrs: [],

--- a/tests/util.js
+++ b/tests/util.js
@@ -1,10 +1,10 @@
-const assert = require('assert');
-
-const specs = require('web-specs');
-const {
+import assert from 'node:assert';
+import {
   getGeneratedIDLNamesByCSSProperty,
   isLatestLevelThatPasses
-} = require('../src/lib/util');
+} from '../src/lib/util.js';
+import specs from 'web-specs' with { type: 'json' };
+
 
 describe('isLatestLevelThatPasses', () => {
   function getSpecAtLevel(level, flags) {

--- a/tests/webidl-parser/exported-names.js
+++ b/tests/webidl-parser/exported-names.js
@@ -1,8 +1,7 @@
-const assert = require('assert');
+import assert from 'node:assert';
+import { parse } from '../../src/cli/parse-webidl.js';
 
 describe('The WebIDL parser exports all IDL names', () => {
-  var parse = require('../../src/cli/parse-webidl').parse;
-
   it('exports named definitions', async () => {
     const data = await parse(`
       interface testInterface {};

--- a/tests/webidl-parser/global.js
+++ b/tests/webidl-parser/global.js
@@ -1,8 +1,7 @@
-const assert = require('assert');
+import assert from 'node:assert';
+import { parse } from '../../src/cli/parse-webidl.js';
 
 describe('For Global/Exposed attributes, the WebIDL parser', () => {
-  var parse = require('../../src/cli/parse-webidl').parse;
-
   it('does not expose an interface on Window by default', async () => {
     const data = await parse(`
       interface notExposedOnWindow {};

--- a/tests/webidl-parser/includes.js
+++ b/tests/webidl-parser/includes.js
@@ -1,8 +1,7 @@
-const assert = require('assert');
+import assert from 'node:assert';
+import { parse } from '../../src/cli/parse-webidl.js';
 
 describe('The WebIDL parser understands includes statements', () => {
-  var parse = require('../../src/cli/parse-webidl').parse;
-
   it('does not choke on includes statements', async () => {
     const data = await parse(`
 interface Base {};

--- a/tests/webidl-parser/well-known.js
+++ b/tests/webidl-parser/well-known.js
@@ -1,8 +1,7 @@
-const assert = require('assert');
+import assert from 'node:assert';
+import { parse } from '../../src/cli/parse-webidl.js';
 
 describe('When it parses well-known types, the WebIDL parser', () => {
-  const parse = require('../../src/cli/parse-webidl').parse;
-
   const someWellKnownTypes = ['undefined', 'boolean', 'DOMString', 'long long'];
 
   someWellKnownTypes.forEach(type => {


### PR DESCRIPTION
Shaving yaks... I naively thought a couple of updates would be all that was required to switch to ECMAScript modules. The number of updates grew a bit out of control, but nothing fantastic in there, just turning calls to `require` into calls to `import` and adjusting the logic here and there (e.g., no more `__dirname`). We may still end up with a couple of bad surprises on things that are not fully covered by tests but they should be easy to fix.

I refreshed a bit the post-processor logic to load the modules once at the begining of the crawl so as to avoid making other functions asynchronous.

Scripts retain a `.js` file extension for now, mainly because it was easier to update the code without also changing the extensions. The switch to ECMAScript modules is done in `package.json` instead.

Note the check `process.argv[1] === fileURLToPath(import.meta.url)` is not a perfect replacement for `require.main === module` as it does not account for cases where the script is run without specifying the file extension, but that should still be good enough for the few modules where we still need that.

One **breaking change**: the `getSchemaValidationFunction`, exported by Reffy and used in Webref, becomes asynchronous.