### PR TITLE
Fix invalid imports and schema validation code

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-import { parseIdl } from "./src/cli/parse-webidl.js";
+import { parse as parseIdl } from "./src/cli/parse-webidl.js";
 import { crawlSpecs } from "./src/lib/specs-crawler.js";
 import { expandCrawlResult } from "./src/lib/util.js";
-import { mergeCrawlResults } from "./src/lib/util.js";
+import { mergeCrawlResults } from "./src/cli/merge-crawl-results.js";
 import { isLatestLevelThatPasses } from "./src/lib/util.js";
 import { getInterfaceTreeInfo } from "./src/lib/util.js";
 import { getSchemaValidationFunction } from "./src/lib/util.js";
-import postProcessor from "./src/lib/post-processor.js";
+import * as postProcessor from "./src/lib/post-processor.js";
 
 export {
   parseIdl,

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1059,11 +1059,8 @@ async function getSchemaValidationFunction(schemaName) {
 
     const schemasFolder = path.resolve(scriptPath, '..', '..', 'schemas');
     const schemaFile = getSchemaFileFromSchemaName(schemaName);
-    let schema;
-    try {
-        schema = await loadJSON(path.join(schemasFolder, schemaFile));
-    }
-    catch (err) {
+    const schema = await loadJSON(path.join(schemasFolder, schemaFile));
+    if (!schema) {
         return null;
     }
 


### PR DESCRIPTION
Tests needed for `index.js`, the typos went through the cracks...

Also, the new `loadJSON` function does not throw an error when file cannot be loaded, but rather returns null. The function failed as a result when asked to provide a validation function for a schema that did not exist (Webref tests happilly request a validation function for IDL extracts and only after checks that the extracts are JSON files).