### PR TITLE
Use `export default` for main exported classes

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,20 @@ import { mergeCrawlResults } from "./src/cli/merge-crawl-results.js";
 import { isLatestLevelThatPasses } from "./src/lib/util.js";
 import { getInterfaceTreeInfo } from "./src/lib/util.js";
 import { getSchemaValidationFunction } from "./src/lib/util.js";
-import * as postProcessor from "./src/lib/post-processor.js";
+import postProcessor from "./src/lib/post-processor.js";
 
 export {
+  parseIdl,
+  crawlSpecs,
+  expandCrawlResult,
+  mergeCrawlResults,
+  isLatestLevelThatPasses,
+  getInterfaceTreeInfo,
+  getSchemaValidationFunction,
+  postProcessor
+};
+
+export default {
   parseIdl,
   crawlSpecs,
   expandCrawlResult,

--- a/src/cli/parse-webidl.js
+++ b/src/cli/parse-webidl.js
@@ -410,9 +410,14 @@ function addDependency(name, idlNames, externalDependencies) {
 
 
 /**************************************************
-Export the parse method for use as module
+Export the Web IDL parser
 **************************************************/
+const webidlParser = {
+    parse,
+    hasObsoleteIdl
+};
 export {
+    webidlParser as default,
     parse,
     hasObsoleteIdl
 };

--- a/src/lib/post-processor.js
+++ b/src/lib/post-processor.js
@@ -308,13 +308,14 @@ function appliesAtLevel(mod, level) {
 /**************************************************
 Export post-processing functions
 **************************************************/
-const moduleNames = Object.keys(modules);
-export {
-  moduleNames as modules,
+const postProcessor = {
+  modules: Object.keys(modules),
   loadModules,
   run, save,
   extractsPerSeries,
   dependsOn,
   getProperty,
   appliesAtLevel
-};
+}
+
+export default postProcessor;

--- a/src/lib/specs-crawler.js
+++ b/src/lib/specs-crawler.js
@@ -14,7 +14,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { inspect } from 'node:util';
 import specs from 'web-specs' with { type: 'json' };
-import * as postProcessor from './post-processor.js';
+import postProcessor from './post-processor.js';
 import ThrottledQueue from './throttled-queue.js';
 import {
     completeWithAlternativeUrls,

--- a/src/postprocessing/idlparsed.js
+++ b/src/postprocessing/idlparsed.js
@@ -5,7 +5,7 @@
  * The module runs at the spec level and generates an `idlparsed` property.
  */
 
-import * as webidlParser from '../cli/parse-webidl.js';
+import webidlParser from '../cli/parse-webidl.js';
 
 export default {
   dependsOn: ['dfns', 'idl'],


### PR DESCRIPTION
With the switch to ECMAScript modules, main Reffy functions were exported as **named** exports but there was no **default** export, meaning Reffy could be imported through:

```js
import * as reffy from 'reffy';
import { crawlSpecs } from 'reffy';
```

... but there was no way to write:

```js
import reffy from 'reffy';
```

This update makes it possible to do either:

```js
import reffy from 'reffy';
import { crawlSpecs } from 'reffy';
```

Now, the dark side of this feature requires lines some might consider to be unnatural... In particular, that requires writing similar things 3 times in `index.js`:

1. First, to import named exports from the different modules
2. Second, to create named exports
3. Third, to create a default Reffy export, a sort of static class that exposes the functions.

There's no way to reduce that (if there is a way, I don't know how :)). That makes me wonder whether this approach is good practice?

For example, there is a specific syntax in JavaScript for re-exporting values from other modules:

```js
export { crawlSpecs } from "./src/lib/specs-crawler.js";
```

That is tempting! But that syntax does not import `crawlSpecs` and so cannot be used to also create a default export with `crawlSpecs` as a property.

Also, while they are written the same way, the values of the `export` and `export default` syntaxes cannot be combined because they are conceptually different beasts: the former is a list of names, the latter an object with properties.

The update does similar magic for the `parse-webidl.js` module. The post-processor module only exports the processor as a sort of static class and does not create named exports, because that's how the module is used in practice.