### PR TITLE
Events extraction: support "given" for functional events

### DIFF
--- a/src/browserlib/extract-events.mjs
+++ b/src/browserlib/extract-events.mjs
@@ -150,7 +150,7 @@ export default function (spec) {
         const bubblesCell = table.querySelector(`tr:nth-child(${bubblingInfoRow + 1}) td:nth-child(2)`);
         const bubbles = bubblesCell ? bubblesCell.textContent.trim() === "Yes" : null;
         const cancelableCell = table.querySelector(`tr:nth-child(${cancelableInfoRow + 1}) td:nth-child(2)`);
-	const cancelable = cancelableCell ? cancelableCell.textContent.trim() === "Yes" : null;
+        const cancelable = cancelableCell ? cancelableCell.textContent.trim() === "Yes" : null;
         const iface = table.querySelector(`tr:nth-child(${interfaceRow + 1}) td:nth-child(2)`)?.textContent?.trim();
         if (eventName) {
           events.push({
@@ -216,7 +216,7 @@ export default function (spec) {
           phrasing = "fire a pointer event";
         }
       } else {
-        m = parsedText.match(/fir(e|ing)\sa?\s*functional\s+event\s+(named\s+)?"?(?<eventName>[a-z]+)/i);
+        m = parsedText.match(/fir(e|ing)\sa?\s*functional\s+event\s+((named|given)\s+)?"?(?<eventName>[a-z]+)/i);
         if (m) {
           phrasing = "fire functional event";
         }
@@ -277,7 +277,7 @@ export default function (spec) {
             }
           }
         }
-	if (event.bubbles === undefined && event.cancelable === undefined) {
+        if (event.bubbles === undefined && event.cancelable === undefined) {
           if (parsedText.match(/bubbles and cancelable attributes/)) {
             if (parsedText.match(/true/)) {
               event.bubbles = true;
@@ -286,8 +286,8 @@ export default function (spec) {
               event.bubbles = false;
               event.cancelable = false;
             }
-	  }
-	}
+          }
+        }
         if (event.bubbles === undefined) {
           if (parsedText.match(/bubbles attribute/)) {
             if (parsedText.match(/true/)) {

--- a/tests/extract-events.js
+++ b/tests/extract-events.js
@@ -173,6 +173,31 @@ ${defaultIdl}`,
       <p id=error><a href='https://dom.spec.whatwg.org/#concept-event-fire'>Fire an event</a> named <code>error</code> using <a href=''>ErrorEvent</a> with the <code>bubbles</code> attribute initialized to <code>false</code> and must not be cancelable</p>
       ${defaultIdl}`,
     res: defaultResults("fire an event phrasing")
+  },
+  {
+    title: "supports 'given' on top of 'named' to specify the event type and interface",
+    html: `<p id=success><a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">Fire Functional Event</a>
+      given <code>success</code>, <code>NotificationEvent</code>.
+    </p>`,
+    res: [
+      {
+        "href": "about:blank#success",
+        "interface": "NotificationEvent",
+        "src": {
+          "format": "fire an event phrasing",
+          "href": "about:blank#success"
+        },
+        "type": "success"
+      }
+    ]
+  },
+  {
+    title: "does not extract variable names as event types",
+    html: `<p>To fire a service worker notification event named <var>name</var>:
+      run <a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">Fire Functional Event</a>
+      given <var>name</var>.
+    </p>`,
+    res: []
   }
 ];
 


### PR DESCRIPTION
The Notifications API now uses "given" to fire a functional event: https://notifications.spec.whatwg.org/#fire-a-service-worker-notification-event

That terminology is aligned with Infra, so we should support it as well.

The code was extracting an event type `"given"`. This update makes it skip "given", as it also skips "named".

The end result for the above example is that the code no longer extracts anything. That is what we want: this is a generic algorithm, the event type `"name"` is correctly being rejected as being a variable name, and not an actual event type name.

(Detected because "given" triggered a data curation error in Webref)

PS: Also fixed tabs and spaces mixup!!!