### PR TITLE
Normalize newlines when slicing IDL extracts text

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -828,19 +828,11 @@ async function expandSpecResult(spec, baseFolder, properties) {
             // Also drop header that may have been added when extract was
             // serialized.
             if (contents.startsWith('// GENERATED CONTENT - DO NOT EDIT')) {
-                const hasWindowsEndings = contents.includes('\r\n\r\n');
-                if (hasWindowsEndings) {
-                    const endOfHeader = contents.indexOf('\r\n\r\n');
-                    contents = contents.substring(endOfHeader + 4)
-                    // remove trailing newline added in saveIdl
-                      .slice(0, -2);
-                }
-                else {
-                    const endOfHeader = contents.indexOf('\n\n');
-                    contents = contents.substring(endOfHeader + 2)
-                    // remove trailing newline added in saveIdl
-                      .slice(0, -1);
-                }
+                // Normalize newlines to avoid off-by-one slices when we remove
+                // the trailing newline that was added by saveIdl
+                contents = contents.replace(/\r/g, '');
+                const endOfHeader = contents.indexOf('\n\n');
+                contents = contents.substring(endOfHeader + 2).slice(0, -1);
             }
             spec.idl = contents;
         }


### PR DESCRIPTION
IDL extracts are generated using `\n` as newline delimiter. However, platform-specific newlines may be introduced during curation when patches are applied, meaning that, on Windows, curated extracts may end up with a mix of `\n` and `\r\n` characters. This confused the code that read the extracts and dropped the header.

The code now normalizes all newlines to `\n` before it slices the content.