### PR TITLE
Adjust minimal version of Node.js required

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=20.12.1"
+    "node": ">=20.18.1"
   },
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
I thought the latest version of the Undici library merely required Node.js >=20 but it actually requires >=20.18.1, whereas we were as >=20.12.1 in Reffy. Adjusting package.json file accordingly.