### PR TITLE
Extract CDDL definitions

### DIFF
--- a/src/browserlib/extract-cddl.mjs
+++ b/src/browserlib/extract-cddl.mjs
@@ -24,18 +24,18 @@ import trimSpaces from './trim-spaces.mjs';
  *
  * @function
  * @public 
- * @return {Promise} The promise to get a dump of the CDDL definitions per
- *   CDDL module, or an empty array if the spec does not contain any CDDL.
+ * @return {Array} A dump of the CDDL definitions per CDDL module, or an empty
+ * array if the spec does not contain any CDDL.
  */
 export default function () {
     // Specs with CDDL are either recent enough that they all use the same
     // `<pre class="cddl">` convention, or they don't flag CDDL blocks in any
     // way, making it impossible to extract them.
-    const cddlSelector = 'pre.cddl:not(.exclude):not(.extract)';
-    const indexSelector = '#cddl-index';
+    const cddlSelectors = ['pre.cddl:not(.exclude):not(.extract)'];
+    const excludeSelectors = ['#cddl-index'];
 
     // Retrieve all elements that contains CDDL content
-    const cddlEls = getCodeElements([cddlSelector], [indexSelector]);
+    const cddlEls = getCodeElements(cddlSelectors, { excludeSelectors });
 
     // Start by assembling the list of modules
     const modules = {};

--- a/src/browserlib/extract-cddl.mjs
+++ b/src/browserlib/extract-cddl.mjs
@@ -1,0 +1,115 @@
+import getCodeElements from './get-code-elements.mjs';
+import trimSpaces from './trim-spaces.mjs';
+
+/**
+ * Extract the list of CDDL definitions in the current spec.
+ *
+ * A spec may define more that one CDDL module. For example, the WebDriver BiDi
+ * spec has CDDL definitions that apply to either of both the local end and the
+ * remote end. The functions returns an array that lists all CDDL modules.
+ * 
+ * Each CDDL module is represented as an object with the following keys whose
+ * values are strings:
+ * - shortname: the CDDL module shortname. Shortname is "" if there are no
+ * - label: A full name for the CDDL module.
+ * - cddl: A dump of the CDDL definitions.
+ *
+ * If the spec defines more than one module, the first item in the array is the
+ * "all" module that contains a dump of all CDDL definitions, regardless of the
+ * module they are actually defined for (the assumption is that looking at the
+ * union of all CDDL modules defined in a spec will always make sense, and that
+ * a spec will never reuse the same rule name with a different definition for
+ * different CDDL modules).
+ *
+ * @function
+ * @public 
+ * @return {Promise} The promise to get a dump of the CDDL definitions per
+ *   CDDL module, or an empty array if the spec does not contain any CDDL.
+ */
+export default function () {
+    // Specs with CDDL are either recent enough that they all use the same
+    // `<pre class="cddl">` convention, or they don't flag CDDL blocks in any
+    // way, making it impossible to extract them.
+    const cddlSelector = 'pre.cddl:not(.exclude):not(.extract)';
+    const indexSelector = '#cddl-index';
+
+    // Retrieve all elements that contains CDDL content
+    const cddlEls = getCodeElements([cddlSelector], [indexSelector]);
+
+    // By convention, CDDL defined without specifying a module is defined
+    // for all modules (that CDDL would essentially be lost otherwise, there's
+    // no reason for a spec to define CDDL for no module if it uses modules).
+    // Start by assembled the list of modules
+    const modules = {};
+    for (const el of cddlEls) {
+        const elModules = getModules(el);
+        for (const name of elModules) {
+            modules[name] = [];
+        }
+    }
+
+    // Assemble the CDDL per module
+    const mergedCddl = [];
+    for (const el of cddlEls) {
+        const cddl = trimSpaces(el.textContent);
+        if (!cddl) {
+            continue;
+        }
+        mergedCddl.push(cddl);
+        let elModules = getModules(el);
+        if (elModules.length === 0) {
+            // No module means the CDDL is defined for all modules
+            elModules = Object.keys(modules);
+        }
+        for (const name of elModules) {
+            if (!modules[name]) {
+                modules[name] = [];
+            }
+            modules[name].push(cddl);
+        }
+    }
+
+    if (mergedCddl.length === 0) {
+        return [];
+    }
+    const res = [ { name: "", cddl: mergedCddl.join('\n\n') } ];
+    for (const [name, cddl] of Object.entries(modules)) {
+        res.push({ name, cddl: cddl.join('\n\n') });
+    }
+    // Remove trailing spaces and use spaces throughout
+    for (const cddlModule of res) {
+        cddlModule.cddl = cddlModule.cddl
+            .replace(/\s+$/gm, '\n')
+            .replace(/\t/g, '  ')
+            .trim();
+    }
+    return res;
+}
+
+
+/**
+ * Retrieve the list of CDDL module shortnames that the element references.
+ *
+ * This list of modules is either specified in a `data-cddl-module` attribute
+ * or directly within the class attribute prefixed by `cddl-` or suffixed by
+ * `-cddl`.
+ */
+function getModules(el) {
+    const moduleAttr = el.getAttribute('data-cddl-module');
+    if (moduleAttr) {
+        return moduleAttr.split(',').map(str => str.trim());
+    }
+
+    const list = [];
+    const classes = el.classList.values()
+    for (const name of classes) {
+        const match = name.match(/^(.*)-cddl$|^cddl-(.*)$/);
+        if (match) {
+            const shortname = match[1] ?? match[2];
+            if (!list.includes(shortname)) {
+                list.push(shortname);
+            }
+        }
+    }
+    return list;
+}

--- a/src/browserlib/extract-webidl.mjs
+++ b/src/browserlib/extract-webidl.mjs
@@ -1,6 +1,6 @@
 import getGenerator from './get-generator.mjs';
-import informativeSelector from './informative-selector.mjs';
-import cloneAndClean from './clone-and-clean.mjs';
+import getCodeElements from './get-code-elements.mjs';
+import trimSpaces from './trim-spaces.mjs';
 
 /**
  * Extract the list of WebIDL definitions in the current spec
@@ -70,56 +70,21 @@ function extractBikeshedIdl() {
  * sure that it only extracts elements once.
  */
 function extractRespecIdl() {
-    // Helper function that trims individual lines in an IDL block,
-    // removing as much space as possible from the beginning of the page
-    // while preserving indentation. Rules followed:
-    // - Always trim the first line
-    // - Remove whitespaces from the end of each line
-    // - Replace lines that contain spaces with empty lines
-    // - Drop same number of leading whitespaces from all other lines
-    const trimIdlSpaces = idl => {
-        const lines = idl.trim().split('\n');
-        const toRemove = lines
-            .slice(1)
-            .filter(line => line.search(/\S/) > -1)
-            .reduce(
-                (min, line) => Math.min(min, line.search(/\S/)),
-                Number.MAX_VALUE);
-        return lines
-            .map(line => {
-                let firstRealChat = line.search(/\S/);
-                if (firstRealChat === -1) {
-                    return '';
-                }
-                else if (firstRealChat === 0) {
-                    return line.replace(/\s+$/, '');
-                }
-                else {
-                    return line.substring(toRemove).replace(/\s+$/, '');
-                }
-            })
-            .join('\n');
-    };
-
-    // Detect the IDL index appendix if there's one (to exclude it)
-    const idlEl = document.querySelector('#idl-index pre') ||
-        document.querySelector('.chapter-idl pre'); // SVG 2 draft
-
-    let idl = [
+    const idlSelectors = [
         'pre.idl:not(.exclude):not(.extract):not(#actual-idl-index)',
         'pre:not(.exclude):not(.extract) > code.idl-code:not(.exclude):not(.extract)',
         'pre:not(.exclude):not(.extract) > code.idl:not(.exclude):not(.extract)',
         'div.idl-code:not(.exclude):not(.extract) > pre:not(.exclude):not(.extract)',
         'pre.widl:not(.exclude):not(.extract)'
-    ]
-        .map(sel => [...document.querySelectorAll(sel)])
-        .reduce((res, elements) => res.concat(elements), [])
-        .filter(el => el !== idlEl)
-        .filter((el, idx, self) => self.indexOf(el) === idx)
-        .filter(el => !el.closest(informativeSelector))
-        .map(cloneAndClean)
-        .map(el => trimIdlSpaces(el.textContent))
-        .join('\n\n');
+    ];
 
-    return idl;
+    const indexSelectors = [
+        '#idl-index',
+        '.chapter-idl'
+    ];
+
+    const idlElements = getCodeElements(idlSelectors, indexSelectors);
+    return idlElements
+        .map(el => trimSpaces(el.textContent))
+        .join('\n\n');
 }

--- a/src/browserlib/extract-webidl.mjs
+++ b/src/browserlib/extract-webidl.mjs
@@ -7,8 +7,8 @@ import trimSpaces from './trim-spaces.mjs';
  *
  * @function
  * @public 
- * @return {Promise} The promise to get a dump of the IDL definitions, or
- *   an empty string if the spec does not contain any IDL.
+ * @return {String} A dump of the IDL definitions, or an empty string if the
+ * spec does not contain any IDL.
  */
 export default function () {
     const generator = getGenerator();
@@ -78,12 +78,12 @@ function extractRespecIdl() {
         'pre.widl:not(.exclude):not(.extract)'
     ];
 
-    const indexSelectors = [
+    const excludeSelectors = [
         '#idl-index',
         '.chapter-idl'
     ];
 
-    const idlElements = getCodeElements(idlSelectors, indexSelectors);
+    const idlElements = getCodeElements(idlSelectors, { excludeSelectors });
     return idlElements
         .map(el => trimSpaces(el.textContent))
         .join('\n\n');

--- a/src/browserlib/get-code-elements.mjs
+++ b/src/browserlib/get-code-elements.mjs
@@ -1,0 +1,22 @@
+import informativeSelector from './informative-selector.mjs';
+import cloneAndClean from './clone-and-clean.mjs';
+
+/**
+ * Helper function that returns a set of code elements in document order based
+ * on a given set of selectors, excluding elements that are within an index.
+ *
+ * The function excludes elements defined in informative sections.
+ *
+ * The code elements are cloned and cleaned before they are returned to strip
+ * annotations and other asides.
+ */
+export default function getCodeElements(codeSelectors, excludeSelectors) {
+    return [...document.querySelectorAll(codeSelectors.join(', '))]
+        // Only keep the elements that are not within the index at the end of
+        // the specification and that are defined in a normative section.
+        .filter(el => !el.closest((excludeSelectors ?? []).join(', ')))
+        .filter(el => !el.closest(informativeSelector))
+
+        // Clone and clean the elements
+        .map(cloneAndClean);
+}

--- a/src/browserlib/get-code-elements.mjs
+++ b/src/browserlib/get-code-elements.mjs
@@ -10,11 +10,10 @@ import cloneAndClean from './clone-and-clean.mjs';
  * The code elements are cloned and cleaned before they are returned to strip
  * annotations and other asides.
  */
-export default function getCodeElements(codeSelectors, excludeSelectors) {
+export default function getCodeElements(codeSelectors, { excludeSelectors = [] }) {
     return [...document.querySelectorAll(codeSelectors.join(', '))]
-        // Only keep the elements that are not within the index at the end of
-        // the specification and that are defined in a normative section.
-        .filter(el => !el.closest((excludeSelectors ?? []).join(', ')))
+        // Skip excluded and elements and those in informative content
+        .filter(el => !el.closest(excludeSelectors.join(', ')))
         .filter(el => !el.closest(informativeSelector))
 
         // Clone and clean the elements

--- a/src/browserlib/reffy.json
+++ b/src/browserlib/reffy.json
@@ -62,5 +62,9 @@
     "href": "./extract-ids.mjs",
     "property": "ids",
     "needsIdToHeadingMap": true
+  },
+  {
+    "href": "./extract-cddl.mjs",
+    "property": "cddl"
   }
 ]

--- a/src/browserlib/trim-spaces.mjs
+++ b/src/browserlib/trim-spaces.mjs
@@ -21,11 +21,11 @@ export default function trimSpaces(code) {
             Number.MAX_VALUE);
     return lines
         .map(line => {
-            let firstRealChat = line.search(/\S/);
-            if (firstRealChat === -1) {
+            let firstRealChar = line.search(/\S/);
+            if (firstRealChar === -1) {
                 return '';
             }
-            else if (firstRealChat === 0) {
+            else if (firstRealChar === 0) {
                 return line.replace(/\s+$/, '');
             }
             else {

--- a/src/browserlib/trim-spaces.mjs
+++ b/src/browserlib/trim-spaces.mjs
@@ -1,0 +1,36 @@
+/**
+ * Helper function that trims individual lines in a code block, removing as
+ * much space as possible from the beginning of the page while preserving
+ * indentation.
+ *
+ * Typically useful for CDDL and IDL extracts
+ *
+ * Rules followed:
+ * - Always trim the first line
+ * - Remove whitespaces from the end of each line
+ * - Replace lines that contain spaces with empty lines
+ * - Drop same number of leading whitespaces from all other lines
+ */
+export default function trimSpaces(code) {
+    const lines = code.trim().split('\n');
+    const toRemove = lines
+        .slice(1)
+        .filter(line => line.search(/\S/) > -1)
+        .reduce(
+            (min, line) => Math.min(min, line.search(/\S/)),
+            Number.MAX_VALUE);
+    return lines
+        .map(line => {
+            let firstRealChat = line.search(/\S/);
+            if (firstRealChat === -1) {
+                return '';
+            }
+            else if (firstRealChat === 0) {
+                return line.replace(/\s+$/, '');
+            }
+            else {
+                return line.substring(toRemove).replace(/\s+$/, '');
+            }
+        })
+        .join('\n');
+}

--- a/tests/crawl-test.json
+++ b/tests/crawl-test.json
@@ -24,6 +24,7 @@
     },
     "title": "WOFF2",
     "algorithms": [],
+    "cddl": [],
     "css": {
       "atrules": [],
       "properties": [],
@@ -99,6 +100,7 @@
     "title": "No Title",
     "generator": "respec",
     "algorithms": [],
+    "cddl": [],
     "css": {
       "atrules": [],
       "properties": [],
@@ -224,6 +226,7 @@
     },
     "title": "[No title found for https://w3c.github.io/accelerometer/]",
     "algorithms": [],
+    "cddl": [],
     "css": {
       "atrules": [],
       "properties": [],

--- a/tests/extract-cddl.js
+++ b/tests/extract-cddl.js
@@ -1,0 +1,183 @@
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+import { rollup } from 'rollup';
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
+
+const tests = [
+  {
+    title: 'extracts CDDL from pre.cddl',
+    html: `<pre class="cddl">cddl = tstr</pre>`,
+    res: 'cddl = tstr'
+  },
+
+  {
+    title: 'produces no CDDL when there is no CDDL',
+    html: `<p>Me no define CDDL</p>`,
+    res: []
+  },
+
+  {
+    title: 'merges multiples blocks of CDDL',
+    html: `<pre class="cddl">cddl = * rule</pre>
+           <pre class="cddl">rule = tstr</pre>`,
+    res: `cddl = * rule
+
+rule = tstr`
+  },
+
+  {
+    title: 'strips trailing spaces',
+    html: `<pre class="cddl">
+            cddl = * rule    </pre>`,
+    res: `cddl = * rule`
+  },
+
+  {
+    title: 'preserves internal indentation',
+    html: `<pre class="cddl">
+            rule = (
+              typedef /
+              groupdef
+            )
+            typedef = tstr
+              groupdef = tstr
+          </pre>`,
+    res: `rule = (
+  typedef /
+  groupdef
+)
+typedef = tstr
+  groupdef = tstr`
+  },
+
+  {
+    title: 'extracts CDDL module names from data-cddl-module',
+    html: `<pre class="cddl" data-cddl-module="mod">cddl = tstr</pre>`,
+    res: [
+      { name: '',    cddl: 'cddl = tstr' },
+      { name: 'mod', cddl: 'cddl = tstr' }
+    ]
+  },
+
+  {
+    title: 'extracts CDDL module name defined as class',
+    html: `<pre class="cddl mod1-cddl cddl-mod2">cddl = tstr</pre>`,
+    res: [
+      { name: '',     cddl: 'cddl = tstr' },
+      { name: 'mod1', cddl: 'cddl = tstr' },
+      { name: 'mod2', cddl: 'cddl = tstr' }
+    ]
+  },
+
+  {
+    title: 'assembles CDDL in modules',
+    html: `
+      <pre class="cddl">
+        cddl = * rule
+      </pre>
+      <pre class="cddl" data-cddl-module="mod1, mod2">
+        rule = (typedef / groupdef)
+      </pre>
+      <pre class="cddl" data-cddl-module="mod1">
+        cddl1 = tstr
+      </pre>
+      <pre class="cddl" data-cddl-module="mod2">
+        cddl2 = tstr
+      </pre>
+      <pre class="cddl">
+        typedef = tstr
+        groupdef = tstr
+      </pre>
+    `,
+    res: [
+      {
+        name: '',
+        cddl:
+`cddl = * rule
+
+rule = (typedef / groupdef)
+
+cddl1 = tstr
+
+cddl2 = tstr
+
+typedef = tstr
+groupdef = tstr`
+      },
+      {
+        name: 'mod1',
+        cddl:
+`cddl = * rule
+
+rule = (typedef / groupdef)
+
+cddl1 = tstr
+
+typedef = tstr
+groupdef = tstr`
+      },
+      {
+        name: 'mod2',
+        cddl:
+`cddl = * rule
+
+rule = (typedef / groupdef)
+
+cddl2 = tstr
+
+typedef = tstr
+groupdef = tstr`
+      }
+    ]
+  }
+];
+
+function isString(x) {
+  return Object.prototype.toString.call(x) === "[object String]";
+}
+
+describe("CDDL extraction", function () {
+  this.slow(5000);
+
+  let browser;
+  let extractCode;
+
+  before(async () => {
+    const extractBundle = await rollup({
+      input: path.resolve(scriptPath, '../src/browserlib/extract-cddl.mjs')
+    });
+    const extractOutput = (await extractBundle.generate({
+      name: 'extractCddl',
+      format: 'iife'
+    })).output;
+    extractCode = extractOutput[0].code;
+
+    browser = await puppeteer.launch({ headless: true });
+  });
+
+  for (const test of tests) {
+    it(test.title, async () => {
+      const page = await browser.newPage();
+      page.setContent(test.html);
+      await page.addScriptTag({ content: extractCode });
+
+      const extracted = await page.evaluate(async () => extractCddl());
+      await page.close();
+
+      if (isString(test.res)) {
+        assert.deepEqual(extracted.length, 1,
+          `Expected extraction to return 1 CDDL module, got ${extracted.length}`);
+        assert.deepEqual(extracted[0].cddl, test.res);
+      }
+      else {
+        assert.deepEqual(extracted, test.res);
+      }
+    });
+  }
+
+  after(async () => {
+    await browser.close();
+  });
+});

--- a/tests/extract-cddl.js
+++ b/tests/extract-cddl.js
@@ -56,7 +56,7 @@ typedef = tstr
     title: 'extracts CDDL module names from data-cddl-module',
     html: `<pre class="cddl" data-cddl-module="mod">cddl = tstr</pre>`,
     res: [
-      { name: '',    cddl: 'cddl = tstr' },
+      { name: 'all',    cddl: 'cddl = tstr' },
       { name: 'mod', cddl: 'cddl = tstr' }
     ]
   },
@@ -65,7 +65,7 @@ typedef = tstr
     title: 'extracts CDDL module name defined as class',
     html: `<pre class="cddl mod1-cddl cddl-mod2">cddl = tstr</pre>`,
     res: [
-      { name: '',     cddl: 'cddl = tstr' },
+      { name: 'all',  cddl: 'cddl = tstr' },
       { name: 'mod1', cddl: 'cddl = tstr' },
       { name: 'mod2', cddl: 'cddl = tstr' }
     ]
@@ -74,11 +74,8 @@ typedef = tstr
   {
     title: 'assembles CDDL in modules',
     html: `
-      <pre class="cddl">
-        cddl = * rule
-      </pre>
-      <pre class="cddl" data-cddl-module="mod1, mod2">
-        rule = (typedef / groupdef)
+      <pre class="cddl" data-cddl-module="all">
+        rule = (cddl1 / cddl2)
       </pre>
       <pre class="cddl" data-cddl-module="mod1">
         cddl1 = tstr
@@ -93,11 +90,9 @@ typedef = tstr
     `,
     res: [
       {
-        name: '',
+        name: 'all',
         cddl:
-`cddl = * rule
-
-rule = (typedef / groupdef)
+`rule = (cddl1 / cddl2)
 
 cddl1 = tstr
 
@@ -109,11 +104,7 @@ groupdef = tstr`
       {
         name: 'mod1',
         cddl:
-`cddl = * rule
-
-rule = (typedef / groupdef)
-
-cddl1 = tstr
+`cddl1 = tstr
 
 typedef = tstr
 groupdef = tstr`
@@ -121,11 +112,7 @@ groupdef = tstr`
       {
         name: 'mod2',
         cddl:
-`cddl = * rule
-
-rule = (typedef / groupdef)
-
-cddl2 = tstr
+`cddl2 = tstr
 
 typedef = tstr
 groupdef = tstr`


### PR DESCRIPTION
Needed for https://github.com/w3c/webref/issues/1353. Created as draft pull request as I'm not yet fully convinced by the combined extract, and as the `data-cddl-module` convention hasn't been integrated in Bikeshed yet (see https://github.com/speced/bikeshed/pull/2977).

With this update, Reffy looks for and extracts CDDL content defined in `<pre class="cddl">` block. The logic is vastly similar to the logic used for IDL. Shared code was factored out accordingly.

Something specific about CDDL: on top of generating text extracts, the goal is also to create one extract per CDDL module that the spec defines. To associate a `<pre>` block with one or more CDDL module, the code looks for a possible `data-cddl-module` module, or for module names in the `class` attribute (prefixed by `cddl-` or suffixed by `-cddl`). The former isn't used by any spec but is the envisioned mechanism in Bikeshed to define the association, the latter is the convention currently used in the WebDriver BiDi specification.

When a spec defines modules, CDDL defined in a `<pre>` block with no explicit module annotation is considered to be defined for all modules (not doing so would essentially mean the CDDL would not be defined for any module, which seems weird).

When there is CDDL, the extraction produces:
1. an extract that contains all CDDL definitions: `cddl/[shortname].cddl`
2. one extract per CDDL module: `cddl/[shortname]-[modulename].cddl` (I'm going to assume that no one is ever going to define a module name that would make `[shortname]-[modulename]` collide with the shortname of another spec).

Note: some specs that define CDDL do not flag the `<pre>` blocks in any way (Open Screen Protocol, WebAuthn). Extraction won't work for them for now. Also, there are a couple of places in the WebDriver BiDi spec that use a `<pre class="cddl">` block to *reference* a CDDL construct defined elsewhere. Extraction will happily include these references as well, leading to CDDL extracts that contain invalid CDDL. These need fixing in the specs.