### PR TITLE
Dfns extraction: expand logic that skips imported definitions

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -341,7 +341,9 @@ export default function (spec, idToHeading = {}) {
     // (pending a proper dfns curation process, see:
     // https://github.com/w3c/webref/issues/789)
     .filter(node => {
-      const link = node.querySelector('a[href^="http"]');
+      const link =
+        node.querySelector('a[href^="http"]') ??
+        node.closest('a[href^="http"]');
       return !link ||
         (node.textContent.trim() !== link.textContent.trim()) ||
         (link.href === 'https://www.w3.org/TR/CSS2/syndata.html#vendor-keywords');

--- a/tests/extract-dfns.js
+++ b/tests/extract-dfns.js
@@ -326,6 +326,12 @@ const tests = [
     spec: "html"
   },
   {
+    title: "ignores definitions imported in the Source map format spec",
+    html: '<li>The <a href="https://infra.spec.whatwg.org/#byte-sequence"><dfn id="external-whatwg-infra-byte-sequence">byte sequence</dfn></a>',
+    changesToBaseDfn: [],
+    spec: "sourcemap"
+  },
+  {
     "title": "extracts attribute definition from the SVG2 spec",
     html: `<table class="attrdef def"><tr>
         <td><dfn id="RequiredExtensionsAttribute">requiredExtensions</dfn></td>


### PR DESCRIPTION
The crawler expected "imported definitions" to use `<dfn>` as the wrapping element with an inner `<a>` element. The Source map format spec now uses the opposite pattern. This update expands the logic accordingly.

Close #1788.