### PR TITLE
Set user-agent to "Reffy/x.y.z" when sending HTTP requests

### DIFF
--- a/src/lib/specs-crawler.js
+++ b/src/lib/specs-crawler.js
@@ -120,6 +120,7 @@ async function crawlSpec(spec, crawlOptions) {
               [spec, crawlOptions.modules],
                 { quiet: crawlOptions.quiet,
                   forceLocalFetch: crawlOptions.forceLocalFetch,
+                  userAgent: `Reffy/${reffyVersion}`,
                   ...cacheInfo}
             );
             if (result.status === "notmodified" && fallback) {

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -318,6 +318,7 @@ async function processSpecification(spec, processFunction, args, options) {
     if (!browser) {
         throw new Error('Browser instance not initialized, setupBrowser() must be called before processSpecification().');
     }
+    options.userAgent = options.userAgent ?? await browser.userAgent();
 
     // Create an abort controller for network requests directly handled by the
     // Node.js code (and not by Puppeteer)
@@ -462,7 +463,11 @@ async function processSpecification(spec, processFunction, args, options) {
           // We set a conditional request header
           // Use If-Modified-Since in preference as it is in practice
           // more reliable for conditional requests
-          let headers = {'Accept-Encoding': 'gzip, deflate, br', 'Upgrade-Insecure-Requests': 1, 'User-Agent': browser.userAgent()};
+          let headers = {
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Upgrade-Insecure-Requests': 1,
+            'User-Agent': options.userAgent
+          };
           if (options.lastModified) {
             headers["If-Modified-Since"] = options.lastModified;
           } else if (options.etag) {
@@ -482,6 +487,7 @@ async function processSpecification(spec, processFunction, args, options) {
           }
         }
         const page = await browser.newPage();
+        await page.setUserAgent(options.userAgent);
 
         // Disable cache if caller wants to handle all network requests
         await page.setCacheEnabled(!options.forceLocalFetch);
@@ -553,6 +559,7 @@ async function processSpecification(spec, processFunction, args, options) {
             for (const url of pageUrls) {
                 const subAbort = new AbortController();
                 const subPage = await browser.newPage();
+                await subPage.setUserAgent(options.userAgent);
                 await subPage.setCacheEnabled(!options.forceLocalFetch);
                 const subCdp = await subPage.target().createCDPSession();
                 await subCdp.send('Fetch.enable');


### PR DESCRIPTION
Reffy sends a number of HTTP requests, some directly through `fetch`, others indirectly through Puppeteer. Puppeteer uses a usual User-Agent string, with a `HeadlessChrome/x.y.z.xxx` token. Requests sent with `fetch` were supposedly using the same string but failed because `browser.userAgent()` is async in practice.

The drafts CSS specs server seems to have started to review User-Agents strings more thoroughly a few days ago and now rejects the `fetch` requests with a 403 response.

It is good practice to be explicit about what is making the requests in any case. This update makes Reffy use a `Reffy/x.y.z` User-Agent string, which seems to work fine with the drafts CSS specs server. We may need to complete the string with more usual tokens over time. Let's keep things simple for now!