### PR TITLE
Rationalize exported crawlSpecs function behavior

### DIFF
--- a/schemas/files/index.json
+++ b/schemas/files/index.json
@@ -35,6 +35,25 @@
       "items": {
         "type": "object"
       }
+    },
+
+    "post": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "mod": {
+            "type": "string"
+          },
+          "result": {
+            "oneOf": [
+              { "type": "object" },
+              { "type": "array" }
+            ]
+          },
+          "additionalProperties": false
+        }
+      }
     }
   }
 }

--- a/src/lib/post-processor.js
+++ b/src/lib/post-processor.js
@@ -50,7 +50,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { createFolderIfNeeded } from './util.js';
+import { createFolderIfNeeded, shouldSaveToFile } from './util.js';
 import csscomplete from '../postprocessing/csscomplete.js';
 import events from '../postprocessing/events.js';
 import idlnames from '../postprocessing/idlnames.js';
@@ -220,7 +220,7 @@ async function save(mod, processResult, options) {
     }
   }
 
-  if (!options.output) {
+  if (!shouldSaveToFile(options)) {
     // Nothing to do if no output folder was given
     return;
   }

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1137,6 +1137,21 @@ async function getSchemaValidationFunction(schemaName) {
     };
 }
 
+
+/**
+ * Return true if the crawler should save results to files given the crawl
+ * options.
+ *
+ * @function
+ * @param {Object} crawlOptions Crawl options (optional)
+ * @return {Boolean} true when the crawler should save the results to files,
+ *   false otherwise.
+ */
+function shouldSaveToFile(crawlOptions) {
+    return crawlOptions?.output && crawlOptions.output !== '{return}';
+}
+
+
 export {
     fetch,
     expandBrowserModules,
@@ -1151,5 +1166,6 @@ export {
     createFolderIfNeeded,
     getInterfaceTreeInfo,
     getSchemaValidationFunction,
-    loadJSON
+    loadJSON,
+    shouldSaveToFile
 };

--- a/src/postprocessing/idlnames.js
+++ b/src/postprocessing/idlnames.js
@@ -14,7 +14,8 @@ import {
   getExpectedDfnFromIdlDesc } from '../cli/check-missing-dfns.js';
 import {
   isLatestLevelThatPasses,
-  createFolderIfNeeded } from '../lib/util.js';
+  createFolderIfNeeded,
+  shouldSaveToFile } from '../lib/util.js';
 
 
 /**
@@ -379,7 +380,7 @@ async function generateIdlNames(crawl, options) {
  * @param {Object} options Crawl options ("output" will be used)
  */
 async function saveIdlNames(names, options) {
-  if (!options?.output) {
+  if (!shouldSaveToFile(options)) {
     return;
   }
 


### PR DESCRIPTION
The exported `crawlSpecs` function has always behaved differently depending on whether the first parameter it receives is an array of specs, or an object that sets crawl options. Some of these differences are more historical artefacts than anything else, did not make any sense, and could bite ;) (for example, in browser-specs, I cannot access the markdown summaries that were added by the previous release of Reffy, because they are only reported to the console...)

This makes a minimal amount of updates to rationalize the behavior of the function (which maps internally to `crawlList` and `crawlSpecs`). In particular:
- `crawlList` now accepts getting specs shortnames, series shortnames or URLs as input, same format as `crawlSpecs` in short.
- `crawlList` now also processes the `summary` option to add markdown crawl summaries to each spec, as done by `crawlSpecs`.
- `crawlSpecs` now accepts a specific `{return}` value for the `output` option that makes it return the index of crawl results to the caller and not output anything to console and files (the function could only report to the console or to files, and there was no way for a caller to access crawl results). If post-processing modules need to run at the `crawl` level, their results are now reported in a `post` property.

Differences that remain are:
1. Given an array as first parameter, the function returns an array of results (and not an index of crawl results). That seems somewhat logical. Array in, array out. Object in, object out.
2. Given an array as first parameter, the function does not run post-processing modules that run at the `crawl` level. That's also somewhat logical as there would be no way to report the results in the returned array.
3. Given an array as first parameter, the function does not output anything to the console and files. That remains imperfect, but I can live with it for now. The `{return}` value (remains clunky but) goes in the other direction and forces the function to return an index of crawl results so that a caller may process further things.

Changes should be non-breaking.