### PR TITLE
Authorize alternateIds property in dfns schema as well

### DIFF
--- a/schemas/browserlib/extract-dfns.json
+++ b/schemas/browserlib/extract-dfns.json
@@ -60,7 +60,8 @@
           "id": { "$ref": "../common.json#/$defs/id" },
           "href": { "$ref": "../common.json#/$defs/url" },
           "title": { "type": "string" },
-          "number": { "$ref": "../common.json#/$defs/headingNumber" }
+          "number": { "$ref": "../common.json#/$defs/headingNumber" },
+          "alternateIds": { "type": "array", "items": { "$ref": "../common.json#/$defs/id"} }
         }
       },
       "definedIn": {

--- a/test/extract-dfns.js
+++ b/test/extract-dfns.js
@@ -741,6 +741,26 @@ When initialize(<var>newItem</var>) is called, the following steps are run:</p>`
     </p>`,
     changesToBaseDfn: [{type: 'cddl-type'}]
   },
+
+  {
+    title: "extracts alternate heading IDs when they exist",
+    html: `<section id=title>
+      <h1 id=title-h>Heading in a section with its own id</h1>
+      <p>
+        <dfn id='foo' data-dfn-type='dfn'>Foo</dfn>
+      </p>
+    </section>`,
+    changesToBaseDfn: [{
+      heading: {
+        alternateIds: [
+          'title-h'
+        ],
+        href: 'about:blank#title',
+        id: 'title',
+        title: 'Heading in a section with its own id'
+      }
+    }]
+  },
 ];
 
 describe("Test definition extraction", function () {


### PR DESCRIPTION
Close #1842.

Note: the update does not attempt to move the definition of a heading to be common between dfns extracts and headings extracts because dfns extraction can produce headings that slightly deviate from the structure used in headings extracts:
1. headings in dfns extracts may only consist of an `href` and `title`, to indicate that the dfn was found outside of any heading (not that this happens much outside of the context of tests).
2. headings in dfns extracts do not have information about `level` for now.