### PR TITLE
Skip section numbers in heading definitions

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -199,6 +199,23 @@ function definitionMapper(el, idToHeading, usesDfnDataModel) {
       break;
   }
 
+  // Linking text is given by the data-lt attribute if present, or it is the
+  // textual content... but we'll skip section numbers that might have been
+  // captured when definition is defined in a heading, as in:
+  // https://www.w3.org/TR/ethical-web-principles/#oneweb
+  let linkingText = '';
+  if (el.hasAttribute('data-lt')) {
+    linkingText = el.getAttribute('data-lt').split('|').map(normalize);
+  }
+  else {
+    const copy = el.cloneNode(true);
+    let secno = null;
+    while (secno = copy.querySelector('.secno')) {
+      secno.remove();
+    }
+    linkingText = [normalize(copy.textContent)];
+  }
+
   // Compute the absolute URL with fragment
   // (Note the crawler merges pages of a multi-page spec in the first page
   // to ease parsing logic, and we want to get back to the URL of the page)
@@ -215,11 +232,8 @@ function definitionMapper(el, idToHeading, usesDfnDataModel) {
     // Absolute URL with fragment
     href,
 
-    // Linking text is given by the data-lt attribute if present, or it is the
-    // textual content
-    linkingText: el.hasAttribute('data-lt') ?
-      el.getAttribute('data-lt').split('|').map(normalize) :
-      [normalize(el.textContent)],
+    // Linking text
+    linkingText,
 
     // Additional linking text can be defined for local references
     localLinkingText: el.getAttribute('data-local-lt') ?

--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -207,13 +207,14 @@ function definitionMapper(el, idToHeading, usesDfnDataModel) {
   if (el.hasAttribute('data-lt')) {
     linkingText = el.getAttribute('data-lt').split('|').map(normalize);
   }
-  else {
+  else if (el.querySelector('.secno')) {
     const copy = el.cloneNode(true);
-    let secno = null;
-    while (secno = copy.querySelector('.secno')) {
-      secno.remove();
-    }
+    const secno = copy.querySelector('.secno');
+    secno.remove();
     linkingText = [normalize(copy.textContent)];
+  }
+  else {
+    linkingText = [normalize(el.textContent)];
   }
 
   // Compute the absolute URL with fragment

--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -203,7 +203,7 @@ function definitionMapper(el, idToHeading, usesDfnDataModel) {
   // textual content... but we'll skip section numbers that might have been
   // captured when definition is defined in a heading, as in:
   // https://www.w3.org/TR/ethical-web-principles/#oneweb
-  let linkingText = '';
+  let linkingText = [];
   if (el.hasAttribute('data-lt')) {
     linkingText = el.getAttribute('data-lt').split('|').map(normalize);
   }

--- a/test/extract-dfns.js
+++ b/test/extract-dfns.js
@@ -761,6 +761,33 @@ When initialize(<var>newItem</var>) is called, the following steps are run:</p>`
       }
     }]
   },
+
+  {
+    title: "skips section numbers in headings that are also definitions",
+    html: `<section>
+  <div class="header-wrapper">
+    <h3 id="oneweb" data-dfn-type="dfn">
+      <bdi class="secno">2.1 </bdi>
+      There is one web
+    </h3>
+  </div>
+  <p>... with too many conventions to define terms.</p>
+</section>`,
+    changesToBaseDfn: [{
+      definedIn: 'heading',
+      heading: {
+        href: 'about:blank#oneweb',
+        id: 'oneweb',
+        number: '2.1',
+        title: 'There is one web'
+      },
+      href: 'about:blank#oneweb',
+      id: 'oneweb',
+      linkingText: [
+        'There is one web'
+      ],
+    }]
+  }
 ];
 
 describe("Test definition extraction", function () {


### PR DESCRIPTION
Via https://github.com/w3c/browser-specs/issues/1889#issuecomment-2911452998

When a heading is also a definition, the section number ended up being part of the definition, which is not ideal. This update makes the code skip the section number (defined in an element with a `.secno` class in practice).