### PR TITLE
Move explicit test timeout from suite to test level

### DIFF
--- a/test/extract-css.js
+++ b/test/extract-css.js
@@ -1647,7 +1647,7 @@ that spans multiple lines */
   }
 ];
 
-describe("Test CSS properties extraction", {timeout: 10000}, function() {
+describe("Test CSS properties extraction", function() {
   let browser;
   let extractCSSCode;
   let validateSchema;
@@ -1669,7 +1669,7 @@ describe("Test CSS properties extraction", {timeout: 10000}, function() {
   });
 
   tests.forEach(t => {
-    it(t.title, async () => {
+    it(t.title, {timeout: 10000}, async () => {
       const page = await browser.newPage();
       const pageContent = t.html;
       page.setContent(pageContent);


### PR DESCRIPTION
There seems to be an important nuance between Mocha and Node.js with regards to timeouts: a call to `this.timeout()` in Mocha at the suite level says "Apply the timeout to individual tests", whereas specifying the timeout at the suite level in Node.js seems to say "Apply the timeout to individual tests **and** to the entire suite".

I'm getting timeouts when I run tests locally as a result (although that does not seem to affect tests execution in GitHub actions for now). This update moves the timeout to the test level where it matters. There are other places where the timeout is set at the suite level, but these typically contain only one test, so no need to move.