### PR TITLE
Set selector syntax to selector name when possible

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -306,6 +306,21 @@ export default function () {
     delete value.pureSyntax;
   }
 
+  // Specs typically do not make the syntax of selectors such as `:visited`
+  // explicit because it essentially goes without saying: the syntax is the
+  // selector's name itself. Note that the syntax of selectors that are
+  // function-like such as `:nth-child()` cannot be inferred in the same way.
+  for (const selector of res.selectors) {
+    if (!selector.value && !selector.name.match(/\(/)) {
+      selector.value = selector.name;
+    }
+    for (const subSelector of selector.values ?? []) {
+      if (!subSelector.value && !subSelector.name.match(/\(/)) {
+        subSelector.value = subSelector.name;
+      }
+    }
+  }
+
   // Report warnings
   if (warnings.length > 0) {
     res.warnings = warnings;

--- a/test/extract-css.js
+++ b/test/extract-css.js
@@ -668,11 +668,13 @@ that spans multiple lines */
     css: [
       {
         name: ":open",
-        prose: "The :open pseudo-class represents an element that has both “open” and “closed” states, and which is currently in the “open” state."
+        prose: "The :open pseudo-class represents an element that has both “open” and “closed” states, and which is currently in the “open” state.",
+        value: ":open"
       },
       {
         name: ":closed",
-        prose: "The :closed pseudo-class represents an element that has both “open” and “closed” states, and which is currently in the “closed” state."
+        prose: "The :closed pseudo-class represents an element that has both “open” and “closed” states, and which is currently in the “closed” state.",
+        value: ":closed"
       }
     ]
   },
@@ -1234,10 +1236,12 @@ that spans multiple lines */
     css: [{
       name: '::first-letter',
       prose: 'The ::first-letter pseudo-element represents the first letter.',
+      value: '::first-letter',
       values: [{
         name: '::prefix',
         type: 'selector',
-        prose: 'The ::prefix represents the preceding punctuation of the ::first-letter element.'
+        prose: 'The ::prefix represents the preceding punctuation of the ::first-letter element.',
+        value: '::prefix'
       }]
     }]
   },


### PR DESCRIPTION
The syntax of selectors is often not formally defined in specs. For selectors that are function-like such as `:nth-child()`, we'll have to see how specs can be updated. For selectors are are keyword-like such as `:visited`, updating the specs seems more confusing than anything else though: the syntax of the selector goes without saying, it is simply the selector's name.

This update makes Reffy set the selector's syntax to be the selector's name when the selector is keyword-like.