### PR TITLE
Properly skip function-like selectors when setting syntax

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -316,11 +316,15 @@ export default function () {
     if (selector.value) {
       return;
     }
-    if (selector.name.match(/^[:a-z][^\(]+/i)) {
+    if (selector.name.match(/\(/)) {
+      // Function-like selector
+      return;
+    }
+    if (selector.name.match(/^[:a-z]/i)) {
       // Keyword-like selector that is not a combinator
       selector.value = selector.name;
     }
-    else if (!selector.name.match(/^[:a-z]/i)) {
+    else {
       // Combinator, let's enclose tokens in single-quotes
       const tokens = selector.name.split('');
       if (tokens.length === 1) {

--- a/test/extract-css.js
+++ b/test/extract-css.js
@@ -680,7 +680,7 @@ that spans multiple lines */
   },
 
   {
-    title: "parses combinators definitions without setting a value",
+    title: "parses combinators definitions and sets an appropriate value",
     html: `
     <p>
       The <dfn data-dfn-type="selector" data-export>+</dfn> combinator is great.
@@ -700,6 +700,22 @@ that spans multiple lines */
         name: "||",
         prose: "The || combinator is cool too.",
         value: "'|' '|'"
+      }
+    ]
+  },
+
+  {
+    title: "parses function-like selectors and does not set a value",
+    html: `
+    <p>
+      The <dfn data-dfn-type="selector" data-export>:func()</dfn> selector is a function.
+    </p>
+    `,
+    propertyName: "selectors",
+    css: [
+      {
+        name: ":func()",
+        prose: "The :func() selector is a function."
       }
     ]
   },


### PR DESCRIPTION
Lost myself in regular expressions in previous update and forgot to add a test for function-like selectors. Code fixed (and simplified), and test now added!