### PR TITLE
[CSS post-processing] Merge scopes when possible (breaking)

### DIFF
--- a/schemas/postprocessing/css.json
+++ b/schemas/postprocessing/css.json
@@ -2,6 +2,16 @@
   "$schema": "http://json-schema.org/schema#",
   "$id": "https://github.com/w3c/reffy/blob/main/schemas/postprocessing/css.json",
 
+  "$defs": {
+    "scopes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  },
+
   "type": "object",
   "additionalProperties": false,
   "required": ["atrules", "functions", "properties", "selectors", "types"],
@@ -42,7 +52,7 @@
         "additionalProperties": false,
         "properties": {
           "name": { "type": "string", "pattern": "^<[^>]+>$|^.*()$" },
-          "for": { "type": "string" },
+          "for": { "$ref": "#/$defs/scopes" },
           "href": { "$ref": "../common.json#/$defs/url" },
           "type": { "type": "string", "enum": ["function"] },
           "prose": { "type": "string" },
@@ -91,7 +101,7 @@
         "additionalProperties": false,
         "properties": {
           "name": { "type": "string", "pattern": "^<[^>]+>$|^.*()$" },
-          "for": { "type": "string" },
+          "for": { "$ref": "#/$defs/scopes" },
           "href": { "$ref": "../common.json#/$defs/url" },
           "type": { "type": "string", "enum": ["type"] },
           "prose": { "type": "string" },


### PR DESCRIPTION
A CSS feature may be defined within a single dfn for multiple scopes. These features appeared in separate entries in the consolidated file. To ease indexing and lookup by feature name, this update further merges scopes.

This does not fully turn feature names into identifiers, but only 8 features remain that use the same name but have different definitions for different scopes. Some (but not all) of them, we should be able to get rid of through spec fixes and possible improvements to the curation logic in Webref.

See list and details at:
https://github.com/w3c/webref/issues/1519#issuecomment-2962111268

This is a breaking change since it turns `for` keys into arrays in the consolidated file.

Side note: the update also fixes an unrelated comment in the code.