### PR TITLE
[CSS post-processing] Unwrap type names (breaking)

### DIFF
--- a/schemas/postprocessing/css.json
+++ b/schemas/postprocessing/css.json
@@ -51,7 +51,7 @@
         "required": ["name", "type"],
         "additionalProperties": false,
         "properties": {
-          "name": { "type": "string", "pattern": "^<[^>]+>$|^.*()$" },
+          "name": { "type": "string", "pattern": "^.*()$" },
           "for": { "$ref": "#/$defs/scopes" },
           "href": { "$ref": "../common.json#/$defs/url" },
           "type": { "type": "string", "enum": ["function"] },
@@ -100,7 +100,7 @@
         "required": ["name", "type"],
         "additionalProperties": false,
         "properties": {
-          "name": { "type": "string", "pattern": "^<[^>]+>$|^.*()$" },
+          "name": { "type": "string", "pattern": "^[a-zA-Z0-9-\\(\\)\\[\\]\\{\\}]+$" },
           "for": { "$ref": "#/$defs/scopes" },
           "href": { "$ref": "../common.json#/$defs/url" },
           "type": { "type": "string", "enum": ["type"] },

--- a/src/postprocessing/cssmerge.js
+++ b/src/postprocessing/cssmerge.js
@@ -55,7 +55,6 @@
  * `functions` and `types` lists. MDN data stores them in a separate `syntaxes`
  * category. The `syntaxes` view can be built by merging the `functions` and
  * `types` lists.
- * - This code keeps the surrounding `<>` for type names, MDN data does not.
  *
  * Module runs at the crawl level to create a `css.json` file.
  */
@@ -158,7 +157,9 @@ export default {
         // of inner value definitions, which we no longer need
         // (interesting ones were already copied to the root level)
         // Let's also turn `value` keys into `syntax` keys because that's
-        // a better name and that matches what MDN data uses.
+        // a better name and that matches what MDN data uses, and drop
+        // enclosing `<` and `>` for type names (type names that look like
+        // functions should be .
         if (feature.values) {
           delete feature.values;
         }
@@ -175,6 +176,7 @@ export default {
             delete descriptor.value;
           }
         }
+        feature.name = unwrapName(feature.name);
 
         const featureId = getFeatureId(feature);
         if (!featureDfns[featureId]) {
@@ -373,4 +375,19 @@ function decorateFeaturesWithSpec(data, spec) {
       }
     }
   }
+}
+
+
+/**
+ * Unwrap (type) name
+ *
+ * Note: names that appear in other categories are never enclosed in `<`
+ * and `>`
+ */
+function unwrapName(name) {
+  const typeMatch = name.match(/^<([^>]+)>$/);
+  if (typeMatch) {
+    return typeMatch[1];
+  }
+  return name;
 }

--- a/test/merge-css.js
+++ b/test/merge-css.js
@@ -105,15 +105,18 @@ function conv(entry) {
   if (typeof entry !== 'object') {
     return entry;
   }
-  for (const key of Object.keys(entry)) {
-    if (Array.isArray(entry[key])) {
-      res[key] = entry[key].map(conv);
+  for (const [key, value] of Object.entries(entry)) {
+    if (Array.isArray(value)) {
+      res[key] = value.map(conv);
     }
     else if (key === 'value') {
-      res.syntax = entry[key];
+      res.syntax = value;
+    }
+    else if (typeof value === 'string' && value.match(/^<([^>]+)>$/)) {
+      res[key] = value.slice(1, -1);
     }
     else {
-      res[key] = entry[key];
+      res[key] = value;
     }
   }
   return res;
@@ -591,17 +594,17 @@ describe('CSS extracts consolidation', function () {
       ],
       types: [
         {
-          name: '<another-repeat>',
+          name: 'another-repeat',
           href: 'https://drafts.csswg.org/css-grid-2/#typedef-another-repeat',
           type: 'type'
         },
         {
-          name: '<repeat-ad-libitum>',
+          name: 'repeat-ad-libitum',
           href: 'https://drafts.csswg.org/css-grid-2/#typedef-repeat-ad-libitum',
           type: 'type'
         },
         {
-          name: '<track-repeat>',
+          name: 'track-repeat',
           href: 'https://drafts.csswg.org/css-grid-2/#typedef-track-repeat',
           type: 'type'
         }


### PR DESCRIPTION
Type name are defined enclosed in `<` and `>` in CSS specs. MDN data drops the enclosing characters while Reffy preserves them. This update drops the enclosing characters for type names in the consolidated file.

Note: When a feature is scoped to a type, the enclosing characters must be kept in the `for` key because nothing prevents a type name (without enclosing characters) to match a property name in theory. That seems to be exceptional but typical examples are `top`, `right`, `bottom`, `left`, which are both property names and type names. That makes things perhaps a bit clunky, but then any tool looking into syntaxes and scopes would de facto need to parse references enclosed in `<` and `>` to determine whether they are references to a property, a function or a type.