### PR TITLE
Add anchors for web developers to dfns extracts

### DIFF
--- a/schemas/browserlib/extract-dfns.json
+++ b/schemas/browserlib/extract-dfns.json
@@ -24,20 +24,27 @@
         "enum": [
           "property", "descriptor", "value", "type",
           "at-rule", "function", "selector",
-
           "namespace", "interface", "constructor", "method", "argument",
           "attribute", "callback", "dictionary", "dict-member", "enum",
           "enum-value", "exception", "const", "typedef", "stringifier",
           "serializer", "iterator", "maplike", "setlike", "extended-attribute",
           "event", "permission",
-
           "element", "element-state", "element-attr", "attr-value",
-
           "cddl-module", "cddl-type", "cddl-parameter", "cddl-key", "cddl-value",
-
           "scheme", "http-header",
+          "grammar", "abstract-op", "dfn",
 
-          "grammar", "abstract-op", "dfn"
+          "dev-property", "dev-descriptor", "dev-value", "dev-type",
+          "dev-at-rule", "dev-function", "dev-selector",
+          "dev-namespace", "dev-interface", "dev-constructor", "dev-method", "dev-argument",
+          "dev-attribute", "dev-callback", "dev-dictionary", "dev-dict-member", "dev-enum",
+          "dev-enum-value", "dev-exception", "dev-const", "dev-typedef", "dev-stringifier",
+          "dev-serializer", "dev-iterator", "dev-maplike", "dev-setlike", "dev-extended-attribute",
+          "dev-event", "dev-permission",
+          "dev-element", "dev-element-state", "dev-element-attr", "dev-attr-value",
+          "dev-cddl-module", "dev-cddl-type", "dev-cddl-parameter", "dev-cddl-key", "dev-cddl-value",
+          "dev-scheme", "dev-http-header",
+          "dev-grammar", "dev-abstract-op", "dev-dfn"
         ],
         "$comment": "Types taken from src/browserlib/extract-dfns.mjs"
       },

--- a/schemas/browserlib/extract-dfns.json
+++ b/schemas/browserlib/extract-dfns.json
@@ -2,6 +2,21 @@
   "$schema": "http://json-schema.org/schema#",
   "$id": "https://github.com/w3c/reffy/blob/main/schemas/browserlib/extract-dfns.json",
 
+  "$defs": {
+    "heading": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["href", "title"],
+      "properties": {
+        "id": { "$ref": "../common.json#/$defs/id" },
+        "href": { "$ref": "../common.json#/$defs/url" },
+        "title": { "type": "string" },
+        "number": { "$ref": "../common.json#/$defs/headingNumber" },
+        "alternateIds": { "type": "array", "items": { "$ref": "../common.json#/$defs/id"} }
+      }
+    }
+  },
+
   "type": "array",
   "items": {
     "type": "object",
@@ -32,19 +47,7 @@
           "element", "element-state", "element-attr", "attr-value",
           "cddl-module", "cddl-type", "cddl-parameter", "cddl-key", "cddl-value",
           "scheme", "http-header",
-          "grammar", "abstract-op", "dfn",
-
-          "dev-property", "dev-descriptor", "dev-value", "dev-type",
-          "dev-at-rule", "dev-function", "dev-selector",
-          "dev-namespace", "dev-interface", "dev-constructor", "dev-method", "dev-argument",
-          "dev-attribute", "dev-callback", "dev-dictionary", "dev-dict-member", "dev-enum",
-          "dev-enum-value", "dev-exception", "dev-const", "dev-typedef", "dev-stringifier",
-          "dev-serializer", "dev-iterator", "dev-maplike", "dev-setlike", "dev-extended-attribute",
-          "dev-event", "dev-permission",
-          "dev-element", "dev-element-state", "dev-element-attr", "dev-attr-value",
-          "dev-cddl-module", "dev-cddl-type", "dev-cddl-parameter", "dev-cddl-key", "dev-cddl-value",
-          "dev-scheme", "dev-http-header",
-          "dev-grammar", "dev-abstract-op", "dev-dfn"
+          "grammar", "abstract-op", "dfn"
         ],
         "$comment": "Types taken from src/browserlib/extract-dfns.mjs"
       },
@@ -59,20 +62,24 @@
       "informative": {
         "type": "boolean"
       },
-      "heading": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["href", "title"],
-        "properties": {
-          "id": { "$ref": "../common.json#/$defs/id" },
-          "href": { "$ref": "../common.json#/$defs/url" },
-          "title": { "type": "string" },
-          "number": { "$ref": "../common.json#/$defs/headingNumber" },
-          "alternateIds": { "type": "array", "items": { "$ref": "../common.json#/$defs/id"} }
-        }
-      },
+      "heading": { "$ref": "#/$defs/heading" },
       "definedIn": {
         "type": "string"
+      },
+      "links": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "id", "href", "name"],
+          "properties": {
+            "type": { "type": "string", "enum": ["dev"] },
+            "id": { "$ref": "../common.json#/$defs/id" },
+            "name": { "type": "string" },
+            "href": { "$ref": "../common.json#/$defs/url" },
+            "heading": { "$ref": "#/$defs/heading" }
+          }
+        }
       },
       "htmlProse": {
         "type": "string",

--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -279,7 +279,7 @@ function definitionMapper(el, idToHeading, usesDfnDataModel) {
     // indicates that definition appears in the main body of the specification)
     definedIn,
 
-    // Important anchors that reference the definition
+    // Important links that complement the definition
     // (typically: anchors in "for web developers" sections)
     links: []
   };

--- a/src/browserlib/get-absolute-url.mjs
+++ b/src/browserlib/get-absolute-url.mjs
@@ -18,7 +18,12 @@ export default function (node, { singlePage, attribute } =
   const url = new URL(page ?? window.location.href);
   const hashid = node.getAttribute(attribute);
   if (hashid) {
-    url.hash = '#' + encodeURIComponent(hashid);
+    let fragment = hashid;
+    if (hashid.match(/^#/) && attribute === 'href') {
+      // Function is called to turn a fragment ref into an absolute URL
+      fragment = hashid.substring(1);
+    }
+    url.hash = '#' + encodeURIComponent(fragment);
   }
   return url.toString();
 }

--- a/test/crawl-test.json
+++ b/test/crawl-test.json
@@ -47,7 +47,8 @@
           "href": "https://w3c.github.io/woff/woff2/",
           "title": "WOFF2"
         },
-        "definedIn": "prose"
+        "definedIn": "prose",
+        "links": []
       }
     ],
     "events": [],
@@ -124,7 +125,8 @@
           "href": "https://w3c.github.io/mediacapture-output/#title",
           "title": "No Title"
         },
-        "definedIn": "pre"
+        "definedIn": "pre",
+        "links": []
       },
       {
         "id": "dom-foo-bar",
@@ -146,7 +148,8 @@
           "href": "https://w3c.github.io/mediacapture-output/#title",
           "title": "No Title"
         },
-        "definedIn": "pre"
+        "definedIn": "pre",
+        "links": []
       }
     ],
     "events": [],

--- a/test/extract-dfns.js
+++ b/test/extract-dfns.js
@@ -787,6 +787,74 @@ When initialize(<var>newItem</var>) is called, the following steps are run:</p>`
         'There is one web'
       ],
     }]
+  },
+
+  {
+    title: "extracts definitions for web developers",
+    html: `<p><dfn id='foo' data-dfn-type='dfn'>Foo</dfn></p>
+      <div class="domintro">
+        <dl>
+          <dt><a id="foo-dev" href="#foo">Foo</a></dt>
+          <dd>Blah</dd>
+        </dl>
+      </div>`,
+    changesToBaseDfn: [
+      {},
+      {
+        id: 'foo-dev',
+        href: 'about:blank#foo-dev',
+        type: 'dev-dfn',
+        informative: true,
+        definedIn: 'dt'
+      }
+    ]
+  },
+
+  {
+    title: "extracts base info for definitions for web developers",
+    html: `<p><dfn id='foo' data-dfn-type='interface' data-dfn-for="Cest" data-lt="Fou">Foo</dfn></p>
+      <dl class="domintro">
+        <dt><a id="foo-dev" href="#foo">Foo</a></dt>
+        <dd>Blah</dd>
+      </dl>`,
+    changesToBaseDfn: [
+      {
+        type: 'interface',
+        access: 'public',
+        for: ['Cest'],
+        linkingText: ['Fou']
+      },
+      {
+        id: 'foo-dev',
+        href: 'about:blank#foo-dev',
+        type: 'dev-interface',
+        informative: true,
+        access: 'public',
+        definedIn: 'dt',
+        for: ['Cest'],
+        linkingText: ['Fou'],
+      }
+    ]
+  },
+
+  {
+    title: "ignores sections for web developers that contain dfns",
+    html: `<p><dfn id='foo' data-dfn-type='dfn'>Foo</dfn></p>
+      <dl class="domintro">
+        <dt>
+          <dfn id="bar" data-dfn-type='dfn'>Bar</dfn>
+          <a id="foo-dev" href="#foo">Foo</a></dt>
+        <dd>Blah</dd>
+      </dl>`,
+    changesToBaseDfn: [
+      {},
+      {
+        id: 'bar',
+        href: 'about:blank#bar',
+        linkingText: ['Bar'],
+        definedIn: 'dt'
+      }
+    ]
   }
 ];
 

--- a/test/extract-dfns.js
+++ b/test/extract-dfns.js
@@ -95,7 +95,8 @@ const baseDfn = {
     heading: {
       href: 'about:blank',
       title: ''
-    }
+    },
+    links: []
 };
 const tests = [
   {title: "parses a simple <dfn>",
@@ -790,7 +791,7 @@ When initialize(<var>newItem</var>) is called, the following steps are run:</p>`
   },
 
   {
-    title: "extracts definitions for web developers",
+    title: "extracts links for web developers",
     html: `<p><dfn id='foo' data-dfn-type='dfn'>Foo</dfn></p>
       <div class="domintro">
         <dl>
@@ -799,40 +800,52 @@ When initialize(<var>newItem</var>) is called, the following steps are run:</p>`
         </dl>
       </div>`,
     changesToBaseDfn: [
-      {},
       {
-        id: 'foo-dev',
-        href: 'about:blank#foo-dev',
-        type: 'dev-dfn',
-        informative: true,
-        definedIn: 'dt'
+        links: [
+          {
+            type: 'dev',
+            id: 'foo-dev',
+            name: 'Foo',
+            href: 'about:blank#foo-dev',
+            heading: {
+              href: 'about:blank',
+              title: ''
+            }
+          }
+        ]
       }
     ]
   },
 
   {
-    title: "extracts base info for definitions for web developers",
+    title: "extracts heading info for links for web developers",
     html: `<p><dfn id='foo' data-dfn-type='interface' data-dfn-for="Cest" data-lt="Fou">Foo</dfn></p>
-      <dl class="domintro">
-        <dt><a id="foo-dev" href="#foo">Foo</a></dt>
-        <dd>Blah</dd>
-      </dl>`,
+      <section id="foo-sec">
+        <h3>Foo section</h3>
+        <dl class="domintro">
+          <dt>Fou . C . <a id="foo-dev" href="#foo">Foo</a></dt>
+          <dd>Blah</dd>
+        </dl>
+      </section>`,
     changesToBaseDfn: [
       {
         type: 'interface',
         access: 'public',
         for: ['Cest'],
-        linkingText: ['Fou']
-      },
-      {
-        id: 'foo-dev',
-        href: 'about:blank#foo-dev',
-        type: 'dev-interface',
-        informative: true,
-        access: 'public',
-        definedIn: 'dt',
-        for: ['Cest'],
         linkingText: ['Fou'],
+        links: [
+          {
+            type: 'dev',
+            id: 'foo-dev',
+            name: 'Fou . C . Foo',
+            href: 'about:blank#foo-dev',
+            heading: {
+              href: 'about:blank#foo-sec',
+              id: 'foo-sec',
+              title: 'Foo section'
+            }
+          }
+        ]
       }
     ]
   },

--- a/test/generate-idlparsed.js
+++ b/test/generate-idlparsed.js
@@ -45,7 +45,8 @@ intraface foo {};
         type: type.split(' ')[0],
         for: [],
         access: 'public',
-        informative: false
+        informative: false,
+        links: []
       }],
       idl: `${type} foo {};`
     };


### PR DESCRIPTION
For context, see discussion starting at:
https://github.com/mdn/browser-compat-data/pull/23958#issuecomment-3035921128

Some specs such as DOM, Encoding, HTML contain sections targeted at web developers. These sections re-define terms normatively defined elsewhere in a more developer-friendly way. Terms re-defined in these sections are good targets for documentation but did not appear in definitions extracts.

This update makes Reffy parse "for web developers" sections and extract the definitions they contain. This is a prerequisite to publishing a package with definitions that could be used to validate URLs in BCD and web-features, as envisioned in:
https://github.com/w3c/webref/issues/1198#issuecomment-3032925937

Worth noting:
- Ideally, spec authoring tools would provide better support for this pattern, giving definitions more stable IDs than `ref-for-[foo][number]` and creating proper dfns themselves. If they do that, the custom processing introduced here would become moot. Going through tools and specs will take time though. The custom processing done here allows to add the definitions right away. It does not solve the "unstable" IDs issue, but at least provides a theoretical way to identify situations where the ID of a dev dfn changes.
- To keep the cross-references database useful, newly extracted definitions need to be in a separate dfn namespace, i.e., have their own dfn type. Problem is that they also have a "natural" dfn type such as `interface`, `method` or `attribute`. The solution implemented here is to prefix their type with `dev-`. That duplicates dfn types. A cleaner solution would record the "dev" namespace in another property. But that would surprise spec authoring tools. An alternative approach would be to give all of these dfns a `dev` dfn type, but we'd then lose information that could turn out to be useful.
- The key marker for sections targeted at web developers is the use of a `domintro` class. Now, a few specs do use `domintro` in normative definition lists (shape-detection-api, image-capture, mediastream-recording). That's probably unintentional. I'll look into fixing the specs. The code skips `domintro` sections that look suspicious.
- This would add **2815 definitions** to the dfns extracts (which currently contain ~50000 definitions)