### PR TITLE
Extract headings from www.rfc-editor.org RFCs

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -24,6 +24,8 @@ import {parse} from "../../node_modules/webidl2/index.js";
  *     can be one of "dt", "pre", "table", "heading", "note", "example", or
  *     "prose" (last one indicates that definition appears in the main body of
  *     the spec)
+ * - links: A list of interesting links with IDs that complete the definitions,
+ *     notably non-normative descriptions that target web developers.
  *
  * The extraction ignores definitions with an unknown type. A warning is issued
  * to the console when that happens.

--- a/src/browserlib/extract-headings.mjs
+++ b/src/browserlib/extract-headings.mjs
@@ -20,12 +20,29 @@ export default function (spec, idToHeading) {
     };
   });
 
+  // Headings using spans in www.rfc-editor.org RFCs
+  const rfcSelector = 'pre > span:is(.h2,.h3,.h4,.h5,.h6) > a.selflink[id]';
+  const rfcHeadings = [...document.querySelectorAll(rfcSelector)].map(n => {
+    const headingNumber = n.textContent;
+    const headingLevel = headingNumber ? headingNumber.split(".").length : undefined;
+    return {
+      id: n.id,
+      href: getAbsoluteUrl(n, { singlePage }),
+      title: n.parentNode.textContent
+        .replace(headingNumber, '')
+        .replace(/^\s*\./, '')
+        .trim(),
+      level: headingLevel,
+      number: headingNumber
+    };
+  });
+
   const headingsSelector = [
     ':is(h1,h2,h3,h4,h5,h6)[id]',                 // Regular headings
     ':is(h1,h2,h3,h4,h5,h6):not([id]) > a[name]'  // CSS 2.1 headings
   ].join(',');
 
-  return esHeadings.concat([...document.querySelectorAll(headingsSelector)].map(n => {
+  return esHeadings.concat(rfcHeadings).concat([...document.querySelectorAll(headingsSelector)].map(n => {
     // Note: In theory, all <hX> heading elements that have an ID are associated
     // with a heading in idToHeading. One exception to the rule: when the
     // heading element appears in a <hgroup> element, the mapping is not

--- a/test/extract-headings.js
+++ b/test/extract-headings.js
@@ -63,6 +63,26 @@ const testHeadings = [
     html: "<section id=title-0><h1 id=title>Heading in a section with its own id</h1>",
     res: [{id: "title-0", "href": "about:blank#title-0", title: "Heading in a section with its own id", level: 1, alternateIds: ["title"]}]
   },
+  {
+    title: "deals with headings in www.rfc-editor.org RFCs",
+    html: `<pre>
+      <span class="h2">
+        <a class="selflink" id="title" href="#title">2</a>.
+        Title
+      </span>
+    </pre>`,
+    res: [{id: "title", href: "about:blank#title", title: "Title", number: "2", level: 1}]
+  },
+  {
+    title: "deals with sub-headings in www.rfc-editor.org RFCs",
+    html: `<pre>
+      <span class="h3">
+        <a class="selflink" id="title" href="#title">3.1</a>.
+        Title
+      </span>
+    </pre>`,
+    res: [{id: "title", href: "about:blank#title", title: "Title", number: "3.1", level: 2}]
+  },
 ];
 
 describe("Test headings extraction", function () {


### PR DESCRIPTION
Via https://github.com/mdn/browser-compat-data/pull/23958#pullrequestreview-3010230133.

RFCs published at www.rfc-editor.org use spans to define headings. This update creates custom logic to deal with these, while attempting to restrict the pattern as much as practical, in case another spec suddenly introduces class names such as `h2` attached to spans.