### PR TITLE
Drop "Appendix" prefix from heading number

### DIFF
--- a/src/browserlib/extract-headings.mjs
+++ b/src/browserlib/extract-headings.mjs
@@ -33,7 +33,7 @@ export default function (spec, idToHeading) {
         .replace(/^\s*\./, '')
         .trim(),
       level: headingLevel,
-      number: headingNumber
+      number: headingNumber.replace(/\s*appendix\s+/i, '')
     };
   });
 

--- a/test/extract-headings.js
+++ b/test/extract-headings.js
@@ -83,6 +83,16 @@ const testHeadings = [
     </pre>`,
     res: [{id: "title", href: "about:blank#title", title: "Title", number: "3.1", level: 2}]
   },
+  {
+    title: "deals with appendices in www.rfc-editor.org RFCs",
+    html: `<pre>
+      <span class="h3">
+        <a class="selflink" id="title" href="#title">Appendix A</a>.
+        Title
+      </span>
+    </pre>`,
+    res: [{id: "title", href: "about:blank#title", title: "Title", number: "A", level: 1}]
+  },
 ];
 
 describe("Test headings extraction", function () {


### PR DESCRIPTION
We expect heading "numbers" to be actual numbers or letters but appendix sections in RFCs typically start with "Appendix", e.g.: https://www.rfc-editor.org/rfc/rfc8610#appendix-A

Headings extraction produced "Appendix A" as heading number, which fails schema validation. This update drops the "Appendix" prefix to get back to "A".