### PR TITLE
[CSS consolidation] Drop auto-expansion of at-rules syntaxes

### DIFF
--- a/test/merge-css.js
+++ b/test/merge-css.js
@@ -469,42 +469,6 @@ describe('CSS extracts consolidation', function () {
   });
 
 
-  it('expands at-rules syntaxes when possible', async () => {
-    const results = structuredClone([
-      {
-        shortname: 'css-stuff-1',
-        series: { shortname: 'css-stuff' },
-        seriesVersion: '1',
-        css: Object.assign({}, emptyExtract, {
-          atrules: [
-            Object.assign({}, atrule2, {
-              value: '@media { <declaration-list> }',
-              descriptors: [descriptor1]
-            })
-          ]
-        })
-      },
-      {
-        shortname: 'css-otherstuff-1',
-        series: { shortname: 'css-otherstuff' },
-        seriesVersion: '1',
-        css: Object.assign({}, emptyExtract, {
-          atrules: [
-            Object.assign({}, atrule2, {
-              descriptors: [descriptor2]
-            })
-          ]
-        })
-      }
-    ]);
-    const result = await cssmerge.run({ results });
-    assert.deepEqual(result.atrules[0].syntax, `@media {
-  [ descriptor1: [ <number> ]; ] ||
-  [ descriptor2: [ <mq-boolean> ]; ]
-}`);
-  });
-
-
   it('sets the syntax of legacy aliases', async () => {
     const results = structuredClone([
       {


### PR DESCRIPTION
Via discussion in Webref, notably:
https://github.com/w3c/webref/issues/1519#issuecomment-3106822229 https://github.com/w3c/webref/issues/1519#issuecomment-3108852719

The syntax of at-rules was expanded to better align with `mdn/data`, but:

1. The syntax was wrong (the same descriptor may appear more than once)
2. CSS does not define any syntax to describe the grammar of a block of content. Using the Value Definition Syntax to describe a block of content was at best approximative.
3. The list of descriptors known to be associated with an at-rule is usually not exhaustive. Specs often reference families of descriptors in prose, e.g.: https://drafts.csswg.org/css-anchor-position-1/#at-ruledef-position-try
4. Main consumers do not need the expanded syntax in any case!

This update drops the expansion.