### PR TITLE
[CSS consolidation] Add `extended` to store list of extension URLs

### DIFF
--- a/schemas/postprocessing/css.json
+++ b/schemas/postprocessing/css.json
@@ -9,6 +9,13 @@
         "type": "string"
       },
       "minItems": 1
+    },
+
+    "extended": {
+      "type": "array",
+      "items": {
+        "$ref": "../common.json#/$defs/url"
+      }
     }
   },
 
@@ -25,6 +32,7 @@
         "properties": {
           "name": { "type": "string", "pattern": "^@" },
           "href": { "$ref": "../common.json#/$defs/url" },
+          "extended": { "$ref": "#/$defs/extended" },
           "syntax": { "$ref": "../common.json#/$defs/cssValue" },
           "prose": { "type": "string" },
           "descriptors": {
@@ -54,6 +62,7 @@
           "name": { "type": "string", "pattern": "^.*()$" },
           "for": { "$ref": "#/$defs/scopes" },
           "href": { "$ref": "../common.json#/$defs/url" },
+          "extended": { "$ref": "#/$defs/extended" },
           "prose": { "type": "string" },
           "syntax": { "$ref": "../common.json#/$defs/cssValue" }
         }
@@ -68,6 +77,7 @@
         "properties": {
           "name": { "$ref": "../common.json#/$defs/cssPropertyName" },
           "href": { "$ref": "../common.json#/$defs/url" },
+          "extended": { "$ref": "#/$defs/extended" },
           "syntax": { "$ref": "../common.json#/$defs/cssValue" },
           "legacyAliasOf": { "$ref": "../common.json#/$defs/cssPropertyName" },
           "styleDeclaration": {
@@ -87,6 +97,7 @@
         "properties": {
           "name": { "$ref": "../common.json#/$defs/cssPropertyName" },
           "href": { "$ref": "../common.json#/$defs/url" },
+          "extended": { "$ref": "#/$defs/extended" },
           "prose": { "type": "string" },
           "syntax": { "$ref": "../common.json#/$defs/cssValue" }
         }
@@ -102,6 +113,7 @@
           "name": { "type": "string", "pattern": "^[a-zA-Z0-9-\\+\\(\\)\\[\\]\\{\\}]+$" },
           "for": { "$ref": "#/$defs/scopes" },
           "href": { "$ref": "../common.json#/$defs/url" },
+          "extended": { "$ref": "#/$defs/extended" },
           "prose": { "type": "string" },
           "syntax": { "$ref": "../common.json#/$defs/cssValue" }
         }


### PR DESCRIPTION
This adds a new `extended` key to entries in the consolidated CSS that lists URLs of specs that extend the base definition. For properties, the URLs target the actual extended definition. For functions and types, the URLs merely target the spec without any specific fragment, because there is no actual definition and we don't know where the extension appears at the consolidation phase.

One question I wondered about is whether to use a separate `extended` key or to turn the `href` key into an array of references, with the first reference targeting the base definition. I stuck to a separate key on the grounds that most consumers that need a URL probably want a single URL to start with. Also, some of the constructs don't have any extension for now (at-rules, selectors, descriptors)... but then they might in the future. Having a single array might be a better approach?

Note this also prepares the consolidation to deal with extended functions and types (same update as that made in #1903). As opposed to extensions of properties where new values are added to the syntax, function/type extensions re-define the entire syntax. Reffy does not support extraction of function/type extensions in itself yet, so that part of the update is not going to be used for now.