### PR TITLE
[CSS consolidation] Fix URL set in `extended` property

### DIFF
--- a/src/postprocessing/cssmerge.js
+++ b/src/postprocessing/cssmerge.js
@@ -250,7 +250,7 @@ export default {
               continue;
             }
             baseDfn.syntax += ' | ' + dfn.newValues;
-            baseDfn.extended.push(dfn.href);
+            baseDfn.extended.push(dfn.href ?? dfn.spec.crawled ?? dfn.spec.url);
           }
           else if (dfn.syntax) {
             // Extensions of functions and types are *re-definitions* in


### PR DESCRIPTION
The consolidation code assumed that properties extended with "new values" always had a `<dfn>`. They don't in practice as they rather link to the base definition.

The code now sets the extended URL to the URL of the spec that extends the definition.