### PR TITLE
Repair and extend refs extraction for ECMA specs

### DIFF
--- a/src/browserlib/extract-references.mjs
+++ b/src/browserlib/extract-references.mjs
@@ -165,6 +165,38 @@ function extractReferencesWithoutRules() {
   const anchors = [...document.querySelectorAll("h1, h2, h3")];
   console.log('[reffy]', 'extract refs without rules');
 
+  // Custom logic for Source map format specification (ECMA-426)
+  // Looks for <emu-clause id="sec-references"> and its child clauses
+  for (const refType of ['normative', 'informative']) {
+    const clause = document.querySelector([
+      `emu-clause#sec-references-${refType}`,
+      `emu-clause#sec-${refType}-references`
+    ].join(','));
+    if (clause) {
+      const refs = [];
+      clause.querySelectorAll('p').forEach(p => {
+        const ref = {};
+        const match = p.innerText.match(/(.+?), /m);
+        if (match) {
+          ref.name = match[1].trim();
+        }
+        if (!match) {
+          ref.name = p.querySelector('i')?.innerText.trim();
+        }
+        if (!ref.name) {
+          return;
+        }
+
+        const anchor = p.querySelector('a[href]');
+        if (anchor) {
+          ref.url = anchor.getAttribute('href');
+        }
+        refs.push(ref);
+      });
+      references[refType] = refs;
+    }
+  }
+
   // Look for a "Normative references" heading
   const normative = anchors.findLast(
     textMatch(/^\s*((\w|\d+)(\.\d+)*\.?)?\s*normative\s+references\s*$/i));

--- a/test/extract-references.js
+++ b/test/extract-references.js
@@ -233,6 +233,66 @@ const testRefs = [
       normative: [],
       informative: [{ name: "CSS-MULTICOL-1", url: "https://drafts.csswg.org/css-multicol/" }]
     }
+  },
+
+  {
+    title: "extracts normative and informative references from ECMA specs",
+    html: `
+<emu-clause id="sec-references">
+  <h1><span class="secnum">3</span> References</h1>
+  <emu-clause id="sec-normative-references">
+    <h1><span class="secnum">3.1</span> Normative References</h1>
+    <p>
+      <a href="https://tc39.es/ecma262/">ECMA-262</a>, <i>ECMAScript® Language Specification</i>.
+    </p>
+    <p>
+      ECMA-404, <i>The JSON Data Interchange Format</i>.<br>
+      <a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-404/">https://www.ecma-international.org/publications-and-standards/standards/ecma-404/</a>
+    </p>
+  </emu-clause>
+  <emu-clause id="sec-references-informative">
+    <h1><span class="secnum">3.2</span> Informative References</h1>
+    <p>
+      IETF RFC 4648, <i>The Base16, Base32, and Base64 Data Encodings</i>.<br>
+      <a href="https://datatracker.ietf.org/doc/html/rfc4648">https://datatracker.ietf.org/doc/html/rfc4648</a>
+    </p>
+    <p>
+      <i>WebAssembly Core Specification</i>.<br>
+      <a href="https://www.w3.org/TR/wasm-core-2/">https://www.w3.org/TR/wasm-core-2/</a>
+    </p>
+    <p>
+      WHATWG <i>Encoding</i>.<br>
+      <a href="https://encoding.spec.whatwg.org/">https://encoding.spec.whatwg.org/</a>
+    </p>
+    <p>
+      WHATWG <emu-not-ref><i>Fetch</i></emu-not-ref>.<br>
+      <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+    </p>
+    <p>
+      WHATWG <i>Infra</i>.<br>
+      <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+    </p>
+    <p>
+      WHATWG <emu-not-ref><i>URL</i></emu-not-ref>.<br>
+      <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
+    </p>
+  </emu-clause>
+</emu-clause>
+`,
+    res: {
+      normative: [
+        { name: "ECMA-262", url: "https://tc39.es/ecma262/" },
+        { name: "ECMA-404", url: "https://www.ecma-international.org/publications-and-standards/standards/ecma-404/" }
+      ],
+      informative: [
+        { name: "IETF RFC 4648", url: "https://datatracker.ietf.org/doc/html/rfc4648" },
+        { name: "WebAssembly Core Specification", url: "https://www.w3.org/TR/wasm-core-2/" },
+        { name: "Encoding", url: "https://encoding.spec.whatwg.org/" },
+        { name: "Fetch", url: "https://fetch.spec.whatwg.org/" },
+        { name: "Infra", url: "https://infra.spec.whatwg.org/" },
+        { name: "URL", url: "https://url.spec.whatwg.org/" }
+      ]
+    }
   }
 
 ];


### PR DESCRIPTION
Normative references listed in the ECMAScript spec were no longer being extracted because the spec now lists them using `<p>` tags.

This update also adds support for the very similar format used in the Source map format specification (closes #1792). That spec notes in an HTML comment that the informative references should be normative references. We extract these references as informative, which seems good as we shouldn't have to rely on an HTML comment hidden in the source...