### PR TITLE
Expand JSON schema of idlparsed extracts

### DIFF
--- a/schemas/common.json
+++ b/schemas/common.json
@@ -800,9 +800,9 @@
               "const": "number"
             },
             "value": {
-              "anyOf": [
-                {"type": "number"},
-                {"type": "string"}
+              "type": [
+                "number",
+                "string"
               ]
             }
           },

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -249,7 +249,7 @@
           }
         },
         "generic": {
-          "description": "The generic type, if any.",
+          "description": "The type of a parameterized type, if any.",
           "type": "string"
         },
         "nullable": {

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -522,7 +522,14 @@
         },
         "special": {
           "description": "The special property of the operation (e.g., 'static').",
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "",
+            "deleter",
+            "getter",
+            "setter",
+            "static"
+          ]
         },
         "readonly": {
           "description": "Whether the operation is read-only.",

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -474,7 +474,13 @@
         },
         "special": {
           "description": "The special property of the attribute (e.g., 'static').",
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "",
+            "inherit",
+            "static",
+            "stringifier"
+          ]
         },
         "readonly": {
           "description": "Whether the attribute is read-only.",

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -330,10 +330,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": "string",
-          "enum": [
-            "argument"
-          ]
+          "const": "argument"
         },
         "name": {
           "description": "The name of the argument.",

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -371,27 +371,6 @@
     },
     "idlMember": {
       "description": "Represents a member of a WebIDL interface, dictionary, etc.",
-      "type": "object",
-      "properties": {
-        "type": {
-          "description": "The type of the member.",
-          "type": "string",
-          "enum": [
-            "constructor",
-            "attribute",
-            "operation",
-            "const",
-            "field",
-            "iterable",
-            "setlike",
-            "maplike",
-            "async_iterable"
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
       "oneOf": [
         {
           "$ref": "#/$defs/constructorMember"
@@ -821,10 +800,10 @@
               "const": "number"
             },
             "value": {
-        "anyOf": [
-    {"type": "number"},
-    {"type": "string"}
-        ]
+              "anyOf": [
+                {"type": "number"},
+                {"type": "string"}
+              ]
             }
           },
           "required": [

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -514,7 +514,8 @@
             "deleter",
             "getter",
             "setter",
-            "static"
+            "static",
+            "stringifier"
           ]
         },
         "readonly": {

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -105,6 +105,80 @@
       "additionalProperties": { "$ref": "#/$defs/interfaces" }
     },
 
+    "idlFragment": {
+      "description": "Represents a Web IDL fragment definition.",
+      "type": "object",
+      "properties": {
+        "fragment": {
+          "description": "The raw IDL fragment.",
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "description": "The type of the IDL definition.",
+          "$ref": "#/$defs/extensiontype"
+        },
+        "name": {
+          "description": "The name of the IDL definition.",
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "description": "The target of an includes statement.",
+          "type": "string",
+          "minLength": 1
+        },
+        "includes": {
+          "description": "The module that is included.",
+          "type": "string",
+          "minLength": 1
+        },
+        "inheritance": {
+          "description": "The name of the inherited interface, if any.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "members": {
+          "description": "A list of members of the IDL definition.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/idlMember"
+          }
+        },
+        "idlType": {
+          "$ref": "#/$defs/idlType"
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/argument"
+          }
+        },
+        "extAttrs": {
+          "description": "A list of extended attributes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/extendedAttribute"
+          }
+        },
+        "partial": {
+          "description": "Whether the definition is partial.",
+          "type": "boolean"
+        },
+        "href": {
+          "description": "The URL to the definition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fragment",
+        "type",
+        "extAttrs"
+      ]
+    },
+
     "idlFragmentInSpec": {
       "type": "object",
       "additionalProperties": false,
@@ -144,6 +218,661 @@
           "specShortname": { "$ref": "#/$defs/shortname" }
         }
       }
+    },
+
+    "idlType": {
+      "description": "Represents a WebIDL type.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of the IDL type.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "argument-type",
+            "attribute-type",
+            "return-type",
+            "const-type",
+            "dictionary-type",
+            "field-type",
+            "typedef-type",
+            null
+          ]
+        },
+        "extAttrs": {
+          "description": "A list of extended attributes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/extendedAttribute"
+          }
+        },
+        "generic": {
+          "description": "The generic type, if any.",
+          "type": "string"
+        },
+        "nullable": {
+          "description": "Whether the type is nullable.",
+          "type": "boolean"
+        },
+        "union": {
+          "description": "Whether the type is a union type.",
+          "type": "boolean"
+        },
+        "idlType": {
+          "description": "The inner IDL type. Can be a string or an array of idlType objects for union or generic types.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/idlType"
+              }
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "extAttrs",
+        "generic",
+        "nullable",
+        "union",
+        "idlType"
+      ]
+    },
+    "extendedAttribute": {
+      "description": "Represents a WebIDL extended attribute.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "extended-attribute"
+          ]
+        },
+        "name": {
+          "description": "The name of the extended attribute.",
+          "type": "string"
+        },
+        "rhs": {
+          "description": "The right-hand side of the extended attribute.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "arguments": {
+          "description": "A list of arguments for the extended attribute.",
+          "type": "array"
+        }
+      },
+      "required": [
+        "type",
+        "name",
+        "rhs",
+        "arguments"
+      ]
+    },
+    "argument": {
+      "description": "Represents an argument to a WebIDL operation or constructor.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "argument"
+          ]
+        },
+        "name": {
+          "description": "The name of the argument.",
+          "type": "string"
+        },
+        "extAttrs": {
+          "description": "A list of extended attributes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/extendedAttribute"
+          }
+        },
+        "idlType": {
+          "$ref": "#/$defs/idlType"
+        },
+        "default": {
+          "$ref": "#/$defs/defaultValue"
+        },
+        "optional": {
+          "description": "Whether the argument is optional.",
+          "type": "boolean"
+        },
+        "variadic": {
+          "description": "Whether the argument is variadic.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "type",
+        "name",
+        "extAttrs",
+        "idlType",
+        "default",
+        "optional",
+        "variadic"
+      ]
+    },
+    "idlMember": {
+      "description": "Represents a member of a WebIDL interface, dictionary, etc.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of the member.",
+          "type": "string",
+          "enum": [
+            "constructor",
+            "attribute",
+            "operation",
+            "const",
+            "field",
+            "iterable",
+            "setlike",
+            "maplike",
+            "async_iterable"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "oneOf": [
+        {
+          "$ref": "#/$defs/constructorMember"
+        },
+        {
+          "$ref": "#/$defs/attributeMember"
+        },
+        {
+          "$ref": "#/$defs/operationMember"
+        },
+        {
+          "$ref": "#/$defs/constMember"
+        },
+        {
+          "$ref": "#/$defs/fieldMember"
+        },
+        {
+          "$ref": "#/$defs/iterableMember"
+        },
+        {
+          "$ref": "#/$defs/setlikeMember"
+        },
+        {
+          "$ref": "#/$defs/maplikeMember"
+        },
+        {
+          "$ref": "#/$defs/asyncIterableMember"
+        }
+      ]
+    },
+    "constructorMember": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "constructor"
+        },
+        "arguments": {
+          "description": "A list of arguments for the constructor.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/argument"
+          }
+        },
+        "extAttrs": {
+          "description": "A list of extended attributes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/extendedAttribute"
+          }
+        },
+        "href": {
+          "description": "The URL to the definition of the constructor.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "arguments",
+        "extAttrs"
+      ]
+    },
+    "attributeMember": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "attribute"
+        },
+        "name": {
+          "description": "The name of the attribute.",
+          "type": "string"
+        },
+        "idlType": {
+          "$ref": "#/$defs/idlType"
+        },
+        "extAttrs": {
+          "description": "A list of extended attributes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/extendedAttribute"
+          }
+        },
+        "special": {
+          "description": "The special property of the attribute (e.g., 'static').",
+          "type": "string"
+        },
+        "readonly": {
+          "description": "Whether the attribute is read-only.",
+          "type": "boolean"
+        },
+        "href": {
+          "description": "The URL to the definition of the attribute.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "name",
+        "idlType",
+        "extAttrs",
+        "special"
+      ]
+    },
+    "operationMember": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "operation"
+        },
+        "name": {
+          "description": "The name of the operation.",
+          "type": "string"
+        },
+        "idlType": {
+          "$ref": "#/$defs/idlType"
+        },
+        "arguments": {
+          "description": "A list of arguments for the operation.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/argument"
+          }
+        },
+        "extAttrs": {
+          "description": "A list of extended attributes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/extendedAttribute"
+          }
+        },
+        "special": {
+          "description": "The special property of the operation (e.g., 'static').",
+          "type": "string"
+        },
+        "readonly": {
+          "description": "Whether the operation is read-only.",
+          "type": "boolean"
+        },
+        "href": {
+          "description": "The URL to the definition of the operation.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "name",
+        "arguments",
+        "extAttrs",
+        "special"
+      ]
+    },
+    "constMember": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "const"
+        },
+        "name": {
+          "description": "The name of the constant.",
+          "type": "string"
+        },
+        "idlType": {
+          "$ref": "#/$defs/idlType"
+        },
+        "extAttrs": {
+          "description": "A list of extended attributes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/extendedAttribute"
+          }
+        },
+        "value": {
+          "description": "The value of the constant.",
+          "type": "object"
+        },
+        "href": {
+          "description": "The URL to the definition of the constant.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "name",
+        "idlType",
+        "extAttrs",
+        "value"
+      ]
+    },
+    "fieldMember": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field"
+        },
+        "name": {
+          "description": "The name of the field.",
+          "type": "string"
+        },
+        "extAttrs": {
+          "description": "A list of extended attributes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/extendedAttribute"
+          }
+        },
+        "idlType": {
+          "$ref": "#/$defs/idlType"
+        },
+        "default": {
+          "$ref": "#/$defs/defaultValue"
+        },
+        "required": {
+          "description": "Whether the field is required.",
+          "type": "boolean"
+        },
+        "href": {
+          "description": "The URL to the definition of the field.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "name",
+        "extAttrs",
+        "idlType",
+        "default",
+        "required"
+      ]
+    },
+    "iterableMember": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "iterable"
+        },
+        "idlType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/idlType"
+          }
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/argument"
+          }
+        },
+        "extAttrs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/extendedAttribute"
+          }
+        },
+        "readonly": {
+          "type": "boolean"
+        },
+        "async": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "type",
+        "idlType",
+        "arguments",
+        "extAttrs",
+        "readonly",
+        "async"
+      ]
+    },
+    "setlikeMember": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "setlike"
+        },
+        "idlType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/idlType"
+          }
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/argument"
+          }
+        },
+        "extAttrs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/extendedAttribute"
+          }
+        },
+        "readonly": {
+          "type": "boolean"
+        },
+        "async": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "type",
+        "idlType",
+        "arguments",
+        "extAttrs",
+        "readonly",
+        "async"
+      ]
+    },
+    "maplikeMember": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "maplike"
+        },
+        "idlType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/idlType"
+          }
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/argument"
+          }
+        },
+        "extAttrs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/extendedAttribute"
+          }
+        },
+        "readonly": {
+          "type": "boolean"
+        },
+        "async": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "type",
+        "idlType",
+        "arguments",
+        "extAttrs",
+        "readonly",
+        "async"
+      ]
+    },
+    "asyncIterableMember": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "async_iterable"
+        },
+        "idlType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/idlType"
+          }
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/argument"
+          }
+        },
+        "extAttrs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/extendedAttribute"
+          }
+        },
+        "readonly": {
+          "type": "boolean"
+        },
+        "async": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "type",
+        "idlType",
+        "arguments",
+        "extAttrs",
+        "readonly",
+        "async"
+      ]
+    },
+    "defaultValue": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "number"
+            },
+            "value": {
+        "anyOf": [
+    {"type": "number"},
+    {"type": "string"}
+        ]
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "boolean"
+            },
+            "value": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "dictionary"
+            },
+            "value": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "sequence"
+            },
+            "value": {
+              "type": "array"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "null"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        }
+      ]
     }
   }
 }

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -250,7 +250,15 @@
         },
         "generic": {
           "description": "The type of a parameterized type, if any.",
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "",
+            "FrozenArray",
+            "ObservableArray",
+            "Promise",
+            "record",
+            "sequence"
+          ]
         },
         "nullable": {
           "description": "Whether the type is nullable.",

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -257,7 +257,8 @@
             "ObservableArray",
             "Promise",
             "record",
-            "sequence"
+            "sequence",
+            "async_sequence"
           ]
         },
         "nullable": {

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -269,7 +269,7 @@
           "type": "boolean"
         },
         "idlType": {
-          "description": "The inner IDL type. Can be a string or an array of idlType objects for union or generic types.",
+          "description": "The inner IDL type. Can be a string or an array of idlType objects for union or parameterized types.",
           "oneOf": [
             {
               "type": "string"

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -307,7 +307,7 @@
           "type": "string"
         },
         "rhs": {
-          "description": "The right-hand side of the extended attribute.",
+          "description": "The right-hand side of the extended attribute, if applicable.",
           "type": [
             "object",
             "null"

--- a/schemas/postprocessing/idlparsed.json
+++ b/schemas/postprocessing/idlparsed.json
@@ -9,12 +9,14 @@
     "spec": { "$ref": "../common.json#/$defs/specInExtract" },
 
     "idlparsed": {
+      "description": "Structured information about Web IDL definitions in the spec including, for each definition, an abstract syntax tree (AST) created by parsing the raw definition.",
       "type": "object",
       "additionalProperties": false,
       "required": ["jsNames", "idlNames", "idlExtendedNames", "globals",
         "exposed", "dependencies", "externalDependencies", "hasObsoleteIdl"],
       "properties": {
         "jsNames": {
+          "description": "List of names available to global interfaces, either as objects that can be constructed or as objects that can be returned from functions",
           "type": "object",
           "additionalProperties": false,
           "required": ["constructors", "functions"],
@@ -24,45 +26,41 @@
           }
         },
         "idlNames": {
+          "description": "List of base IDL definitions, indexed by name",
           "type": "object",
           "propertyNames": { "$ref": "../common.json#/$defs/interface" },
-          "additionalProperties": {
-            "type": "object",
-            "additionalProperties": true,
-            "required": ["fragment", "type"],
-            "properties": {
-              "fragment": { "type": "string" },
-              "type": { "$ref": "../common.json#/$defs/interfacetype" },
-              "href": { "$ref": "../common.json#/$defs/url" }
-            }
-          }
+          "additionalProperties": { "$ref": "../common.json#/$defs/idlFragment" }
         },
         "idlExtendedNames": {
+          "description": "List of partial IDL definitions, indexed by name",
           "type": "object",
           "propertyNames": { "$ref": "../common.json#/$defs/interface" },
           "additionalProperties": {
             "type": "array",
-            "items": {
-              "type": "object",
-              "additionalProperties": true,
-              "required": ["fragment", "type"],
-              "properties": {
-                "fragment": { "type": "string" },
-                "type": { "$ref": "../common.json#/$defs/extensiontype" },
-                "href": { "$ref": "../common.json#/$defs/url" }
-              }
-            }
+            "items": { "$ref": "../common.json#/$defs/idlFragment" }
           }
         },
-        "globals": { "$ref": "../common.json#/$defs/interfacesByGlobal" },
-        "exposed": { "$ref": "../common.json#/$defs/interfacesByGlobal" },
+        "globals": {
+          "description": "List of globals defined by the IDL content indexed by global name, along with the list of underlying interface names",
+          "$ref": "../common.json#/$defs/interfacesByGlobal" },
+        "exposed": {
+          "description": "List of globals on which interfaces are defined indexed by global name, along with the names of the interfaces exposed on it. If present, the specific \"*\" entry lists interfaces exposed on all globals.",
+          "$ref": "../common.json#/$defs/interfacesByGlobal"
+        },
         "dependencies": {
+          "description": "List of dependencies (both internal to the specification and defined in other specifications) for each interface, indexed by interface name",
           "type": "object",
           "propertyNames": { "$ref": "../common.json#/$defs/interface" },
           "additionalProperties": { "$ref": "../common.json#/$defs/interfaces" }
         },
-        "externalDependencies": { "$ref": "../common.json#/$defs/interfaces" },
-        "hasObsoleteIdl": { "type": "boolean" }
+        "externalDependencies": {
+          "description": "List of IDL names used by the specification but defined in other specifications",
+          "$ref": "../common.json#/$defs/interfaces"
+        },
+        "hasObsoleteIdl": {
+          "description": "Whether the definitions contain obsolete Web IDL constructs",
+          "type": "boolean"
+        }
       }
     }
   }


### PR DESCRIPTION
Expansion is the result of a mix of:
- copying descriptions from the parsing code;
- completing missing object members leveraging the schema built with AI tools as part of Geek week exploration;
- re-reading the schema.

I validated the new schema against actual data in Webref.