### PR TITLE
CSS merge: flatten nested at-rules (breaking change)

### DIFF
--- a/schemas/postprocessing/css.json
+++ b/schemas/postprocessing/css.json
@@ -32,6 +32,7 @@
         "properties": {
           "name": { "type": "string", "pattern": "^@" },
           "href": { "$ref": "../common.json#/$defs/url" },
+          "for": { "$ref": "#/$defs/scopes" },
           "extended": { "$ref": "#/$defs/extended" },
           "syntax": { "$ref": "../common.json#/$defs/cssValue" },
           "prose": { "type": "string" },

--- a/src/postprocessing/cssmerge.js
+++ b/src/postprocessing/cssmerge.js
@@ -105,6 +105,13 @@ export default {
             categorized.types.push(
               ...values.filter(v => v.type === 'type'));
           }
+          if (feature.descriptors) {
+            // Note: at-rule descriptors already have a "for" attribute
+            categorized.atrules.push(
+              ...feature.descriptors.filter(v => v.type === 'at-rule'));
+            feature.descriptors = feature.descriptors
+              .filter(d => d.type !== 'at-rule');
+          }
         }
       }
     }

--- a/test/merge-css.js
+++ b/test/merge-css.js
@@ -698,4 +698,35 @@ describe('CSS extracts consolidation', function () {
     const result = await cssmerge.run({ results });
     assert.deepEqual(result, conv(emptyMerged));
   });
+
+  it('flattens at-rules when they are nested', async () => {
+    const nestedAtrule = Object.assign({
+      for: atrule2.name,
+      type: 'at-rule'
+    }, atrule1);
+    const results = structuredClone([
+      {
+        shortname: 'css-stuff-1',
+        series: { shortname: 'css-stuff' },
+        seriesVersion: '1',
+        css: Object.assign({}, emptyExtract, {
+          atrules: [
+            Object.assign({}, atrule2, {
+              descriptors: [
+                descriptor1,
+                nestedAtrule
+              ]
+            })
+          ],
+        })
+      }
+    ]);
+    const result = await cssmerge.run({ results });
+    assert.deepEqual(result, conv(Object.assign({}, emptyMerged, {
+      atrules: [
+        Object.assign({}, { for: [atrule2.name] }, atrule1),
+        Object.assign({}, atrule2, { descriptors: [descriptor1] })
+      ]
+    })));
+  });
 });


### PR DESCRIPTION
The `@font-feature-values` at-rule defined in `css-fonts-4` defines nested at-rules. These were captured as descriptors and did not appear at the root level as scoped at-rules. This wasn't consistent with the way scoped functions and types are handled in the `@webref/css` package.

This update flattens the at-rules, scoping them to the at-rule that they are defined for.

Note: for extra-consistency with scoped functions and types, the `for` property is defined as an array.

There are 7 scoped at-rules, all scoped to `@font-feature-values`:
- `@annotation`
- `@character-variant`
- `@historical-forms`
- `@ornaments`
- `@styleset`
- `@stylistic`
- `@swash`

This is a breaking change in that there wasn't any scoped at-rule until now and the `for` property was not allowed for at-rules. I suspect most consumers will be able to adopt the new major version without having to do anything in practice.

This is intended to address:
https://github.com/w3c/webref/issues/1697