### PR TITLE
Add missing `descriptors` property to nested at-rules

### DIFF
--- a/src/postprocessing/cssmerge.js
+++ b/src/postprocessing/cssmerge.js
@@ -106,9 +106,13 @@ export default {
               ...values.filter(v => v.type === 'type'));
           }
           if (feature.descriptors) {
-            // Note: at-rule descriptors already have a "for" attribute
-            categorized.atrules.push(
-              ...feature.descriptors.filter(v => v.type === 'at-rule'));
+            // Note: at-rule descriptors already have a "for" attribute but
+            // nested at-rules typically don't have "descriptors" themselves
+            // while schema requires the property for consistency
+            const atrules = feature.descriptors
+              .filter(v => v.type === 'at-rule')
+              .map(v => Object.assign({ descriptors: [] }, v));
+            categorized.atrules.push(...atrules);
             feature.descriptors = feature.descriptors
               .filter(d => d.type !== 'at-rule');
           }

--- a/test/merge-css.js
+++ b/test/merge-css.js
@@ -700,10 +700,12 @@ describe('CSS extracts consolidation', function () {
   });
 
   it('flattens at-rules when they are nested', async () => {
-    const nestedAtrule = Object.assign({
+    const nestedAtrule = {
+      name: '@nested',
       for: atrule2.name,
-      type: 'at-rule'
-    }, atrule1);
+      type: 'at-rule',
+      href: 'https://example.org/nestedatrule'
+    };
     const results = structuredClone([
       {
         shortname: 'css-stuff-1',
@@ -724,8 +726,13 @@ describe('CSS extracts consolidation', function () {
     const result = await cssmerge.run({ results });
     assert.deepEqual(result, conv(Object.assign({}, emptyMerged, {
       atrules: [
-        Object.assign({}, { for: [atrule2.name] }, atrule1),
-        Object.assign({}, atrule2, { descriptors: [descriptor1] })
+        Object.assign({}, atrule2, { descriptors: [descriptor1] }),
+        {
+          name: nestedAtrule.name,
+          for: [atrule2.name],
+          href: nestedAtrule.href,
+          descriptors: []
+        }
       ]
     })));
   });


### PR DESCRIPTION
The nested at-rules get extracted as descriptors and do not go through the usual logic that handles at-rules. That's fine because they don't (currently at least) define descriptors themselves. But that means they don't have a `descriptors` property themselves. That property needs to be added when the nested at-rules get moved to the root.

... and one day, I'll add schema testing in post-processing tests as well to catch this sort of problems right away!