### PR TITLE
[CSS] Avoid accidently looking at the entire body

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -718,8 +718,11 @@ const extractTypedDfns = dfn => {
   const dfnType = dfn.getAttribute('data-dfn-type');
   const dfnFor = dfn.getAttribute('data-dfn-for');
   // Note there's no point going beyond a heading, especially since parent is
-  // likely going to be an entire section or even the whole document body.
-  const parent = (dfn.tagName.startsWith('H') ? dfn : dfn.parentNode)
+  // likely going to be an entire section or even the whole document body
+  // (and avoid looking at the entire body in any case).
+  const parent = (dfn.tagName.startsWith('H') ||
+      ['BODY', 'MAIN'].includes(dfn.parentNode.tagName) ?
+        dfn : dfn.parentNode)
     .cloneNode(true);
   const fnRegExp = /^([:a-zA-Z_][:a-zA-Z0-9_\-]+)\([^\)]*\)$/;
 

--- a/test/extract-css.js
+++ b/test/extract-css.js
@@ -1765,6 +1765,19 @@ that spans multiple lines */
       }
     ]
   },
+
+  {
+    title: 'does not extract the whole document <main> tag as prose',
+    html: `<main>
+      This <dfn class="css" data-dfn-type="type">&lt;definition&gt;</dfn> is a direct
+      child of the main tag and contains an = sign.
+      </main>`,
+    propertyName: 'values',
+    css: [{
+      name: '<definition>',
+      type: 'type'
+    }]
+  },
 ];
 
 describe("Test CSS properties extraction", function() {


### PR DESCRIPTION
Code looks at the surrounding context next to a definition to find nearby production rules. When a definition is the direct child of the `<body>` or `<main>` tag, it does not make sense to look for a production rule (we're no longer "nearby").

This update catches the case to avoid accidental hiccups as recently found in css-forms.