### PR TITLE
[CSS extracts] Skip scoped type dfns that target another dfn

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -726,6 +726,15 @@ const extractTypedDfns = dfn => {
     .cloneNode(true);
   const fnRegExp = /^([:a-zA-Z_][:a-zA-Z0-9_\-]+)\([^\)]*\)$/;
 
+  // Skip scoped definitions of types/functions that link back to another
+  // definition. They would create an artificial scoped type/function
+  // otherwise. Ideally, these scoped definitions would rather be defined with
+  // a "value" type (or not be defined at all).
+  if (dfnFor && ['function', 'type'].includes(dfnType) &&
+      dfn.querySelector('a[data-link-type]')) {
+    return dfns;
+  }
+
   // Remove note references as in:
   // https://drafts.csswg.org/css-syntax-3/#the-anb-type
   // and remove MDN annotations as well

--- a/test/extract-css.js
+++ b/test/extract-css.js
@@ -1778,6 +1778,30 @@ that spans multiple lines */
       type: 'type'
     }]
   },
+
+  {
+    title: 'skips scoped types definitions that wrap a link to a dfn',
+    html: `<table class="propdef">
+    <tbody>
+     <tr>
+      <th>Name:
+      </th><td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-font-palette">font-palette</dfn>
+     </td></tr><tr>
+      <th><a href="#values">Value</a>:
+      </th><td>&lt;color&gt;</td>
+     </tr></tbody></table>
+    <p>
+      <dfn class="css" data-dfn-for="font-palette" data-dfn-type="type" data-export="" id="typedef-font-palette-palette-mix">
+        <a class="css" data-link-type="function" href="#funcdef-palette-mix" id="ref-for-funcdef-palette-mix⑤">&lt;palette-mix()&gt;</a>
+      </dfn> is a great type.
+    </p>`,
+    propertyName: 'properties',
+    css: [{
+      href: 'about:blank#propdef-font-palette',
+      name: 'font-palette',
+      value: '<color>'
+    }]
+  },
 ];
 
 describe("Test CSS properties extraction", function() {


### PR DESCRIPTION
CSS specs often describe the list of possible values that a property may take. Items in that list typically uses `value` as definition data type. From time to time, these values define actual (scoped) types or functions, and thus use `type` or `function` as definition data type. That's fine when the type or function is not meant to be a global one.

However, once in a little while, specs also use `type` or `function` as definition data type for a value that actually references an actual generic type or function. A scoped type/function shouldn't be created in such cases, the generic type/function is all that is needed.

This update skips these value definitions so as not hide the underlying generic type/function.

Fixes #1995.