### PR TITLE
[CSS extracts] Do not skip dfns that link back to themselves

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -732,7 +732,12 @@ const extractTypedDfns = dfn => {
   // a "value" type (or not be defined at all).
   if (dfnFor && ['function', 'type'].includes(dfnType) &&
       dfn.querySelector('a[data-link-type]')) {
-    return dfns;
+    // Bikeshed sometimes produces links to self. We should only skip
+    // definitions that target *another* construct.
+    const url = new URL(`#${dfn.id}`, window.location);
+    if (dfn.querySelector('a[data-link-type]').href !== url.toString()) {
+      return dfns;
+    }
   }
 
   // Remove note references as in:

--- a/test/extract-css.js
+++ b/test/extract-css.js
@@ -1802,6 +1802,36 @@ that spans multiple lines */
       value: '<color>'
     }]
   },
+
+  {
+    title: 'considers scoped types definitions that wrap a link to themselves',
+    html: `<table class="propdef">
+    <tbody>
+     <tr>
+      <th>Name:
+      </th><td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-font-palette">font-palette</dfn>
+     </td></tr><tr>
+      <th><a href="#values">Value</a>:
+      </th><td>&lt;color&gt;</td>
+     </tr></tbody></table>
+    <p>
+      <dfn class="css" data-dfn-for="font-palette" data-dfn-type="type" data-export="" id="typedef-font-palette-palette-identifier">
+        <a class="css production" data-link-type="type" href="#typedef-font-palette-palette-identifier" id="ref-for-typedef-font-palette-palette-identifier②">&lt;palette-identifier&gt;</a>
+        </dfn> is a great type.
+    </p>`,
+    propertyName: 'properties',
+    css: [{
+      href: 'about:blank#propdef-font-palette',
+      name: 'font-palette',
+      value: '<color>',
+      values: [{
+        href: 'about:blank#typedef-font-palette-palette-identifier',
+        name: '<palette-identifier>',
+        prose: '<palette-identifier> is a great type.',
+        type: 'type'
+      }]
+    }]
+  },
 ];
 
 describe("Test CSS properties extraction", function() {


### PR DESCRIPTION
Previous change (see #2000) made Reffy skip dfns that wrap a link to another definition, but the code didn't expect that there would be definitions that link back to themselves. Bikeshed does generate a link to self when the dfn appears in a definition list, and these dfns should not be ignored.

This update compares the link with the initial ID (comparing absolute URLs in case someone decides to use them in the links for some reason).