### PR TITLE
[CSS extracts] Do not skip dfns that have sub-component links

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -730,12 +730,14 @@ const extractTypedDfns = dfn => {
   // definition. They would create an artificial scoped type/function
   // otherwise. Ideally, these scoped definitions would rather be defined with
   // a "value" type (or not be defined at all).
+  const wrappedLink = dfn.querySelector('a[data-link-type]');
   if (dfnFor && ['function', 'type'].includes(dfnType) &&
-      dfn.querySelector('a[data-link-type]')) {
+      wrappedLink &&
+      dfn.textContent.trim() === wrappedLink.textContent.trim()) {
     // Bikeshed sometimes produces links to self. We should only skip
     // definitions that target *another* construct.
     const url = new URL(`#${dfn.id}`, window.location);
-    if (dfn.querySelector('a[data-link-type]').href !== url.toString()) {
+    if (wrappedLink.href !== url.toString()) {
       return dfns;
     }
   }

--- a/test/extract-css.js
+++ b/test/extract-css.js
@@ -1832,6 +1832,38 @@ that spans multiple lines */
       }]
     }]
   },
+
+  {
+    title: 'considers scoped types definitions that contain links for a sub-component',
+    html: `<table class="propdef">
+    <tbody>
+     <tr>
+      <th>Name:
+      </th><td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-font-palette">font-palette</dfn>
+     </td></tr><tr>
+      <th><a href="#values">Value</a>:
+      </th><td>&lt;color&gt;</td>
+     </tr></tbody></table>
+    <p>
+      <dfn class="css" data-dfn-for="font-palette" data-dfn-type="function" data-export="" data-lt="func()" id="funcdef-font-palette-func">
+        func(
+          <a data-link-type="type" href="https://www.w3.org/TR/css-values-4/#typedef-length-percentage">&lt;length-percentage&gt;</a>
+        )
+      </dfn> is a great function.
+    </p>`,
+    propertyName: 'properties',
+    css: [{
+      href: 'about:blank#propdef-font-palette',
+      name: 'font-palette',
+      value: '<color>',
+      values: [{
+        href: 'about:blank#funcdef-font-palette-func',
+        name: 'func()',
+        type: 'function',
+        value: 'func( <length-percentage> )'
+      }]
+    }]
+  },
 ];
 
 describe("Test CSS properties extraction", function() {


### PR DESCRIPTION
Previous changes (#2000 and #2001) assumed that links that appear in definitions would always be for the entire definition. But function definitions may describe their function parameters with a link to the definition of the underlying type, e.g., `<length-percentage>` will link to its definition in `fade( [ <length-percentage> ] )`.

This update makes the crawler compare the text of the definition and of the first link it contains to determine whether that definition is really just a link to another definition.