### PR TITLE
[CSS extracts] Handle non-breaking spaces in property key names

### DIFF
--- a/src/browserlib/extract-cssdfn.mjs
+++ b/src/browserlib/extract-cssdfn.mjs
@@ -374,7 +374,7 @@ const normalize = value => value.trim().replace(/\s+/g, ' ').replace(/−/g, '-'
  */
 const dfnLabel2Property = label => label.trim()
   .replace(/:/, '')
-  .split(' ')
+  .split(/\s/)
   .map((str, idx) => (idx === 0) ?
     str.toLowerCase() :
     str.charAt(0).toUpperCase() + str.slice(1))

--- a/test/extract-css.js
+++ b/test/extract-css.js
@@ -1864,6 +1864,31 @@ that spans multiple lines */
       }]
     }]
   },
+
+  {
+    title: "handles non-breaking spaces in key names",
+    html: `<table class="propdef">
+    <tbody>
+     <tr>
+      <th>Name:</th>
+      <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-background-color">background-color</dfn></td>
+     </tr>
+     <tr>
+      <th><a href="#values">Value</a>:</th>
+      <td>&lt;color&gt;</td>
+     </tr>
+     <tr>
+      <th>Computed\u00A0value:</th>
+      <td>computed color</td>
+     </tr>
+    </tbody></table>`,
+   css: [{
+      "name": "background-color",
+      "href": "about:blank#propdef-background-color",
+      "value": "<color>",
+      "computedValue": "computed color"
+   }]
+  },
 ];
 
 describe("Test CSS properties extraction", function() {


### PR DESCRIPTION
Via https://github.com/w3c/webref/pull/1908#discussion_r3161010641

The SVG spec uses non-breaking spaces in property definition tables for "Computed value". Reffy failed to convert that to `computedValue` as a result. This update uses the more generic `\s` regular expression to split on spaces.