### PR TITLE
Fix dfns extraction for RFC8610 (CDDL types)

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -977,18 +977,21 @@ function preProcessSVG2() {
  */
 function preProcessRFC8610() {
   // The RFC is defined as a set of pages (yuck!)
-  // The standard prelude is an appendix, let's look for it
+  // The standard prelude is an appendix, let's look for it.
+  // Note: we match on text because RFC editor gets innovative once in a while
+  // and adds HTML comments that are hard to capture with a regexp approach.
+  // We also look for anchors with IDs to avoid matching the table of contents.
   const prePages = [...document.querySelectorAll('pre.newpage')];
-  const preludeStart = /<a [^>]*id=[^>]*>Appendix .<\/a>\.\s+Standard Prelude/;
+  const preludeStart = /Appendix .\.\s+Standard Prelude/;
   const preludeEnd = /Figure \d+: CDDL Prelude/;
   const preStart = prePages
-    .findIndex(pre => pre.innerHTML.match(preludeStart));
+    .findIndex(pre => pre.textContent.match(preludeStart) && pre.querySelector('a[id]'));
   if (preStart === -1) {
     // Can't find the expected prelude start text, not a good start!
     return;
   }
   const preEnd = prePages
-    .findIndex((pre, idx) => idx >= preStart && pre.innerHTML.match(preludeEnd));
+    .findIndex((pre, idx) => idx >= preStart && pre.textContent.match(preludeEnd));
   if (preEnd === -1) {
     // Can't find the expected prelude ending text, not a good start!
     return;


### PR DESCRIPTION
Reffy creates a dfn for CDDL types defined in RFC8610.

A new rendition of RFC specs seems to have been put in place for `www.rfc-editor.org` URLs. On top of redirecting URLs, the new rendition adds a few unexpected HTML comments around section titles for some reason, and the anchose we used to detect the "Standard Prelude" appendix needed to be adjusted accordingly.

Detection is now done on actual text to avoid further problems. That remains imperfect, but will hopefully prove more stable over time.