### PR TITLE
Make algorithm extraction more resilient to invalid switch markup

### DIFF
--- a/src/browserlib/extract-algorithms.mjs
+++ b/src/browserlib/extract-algorithms.mjs
@@ -546,15 +546,12 @@ function serializeSteps(root) {
           while (dd && dd.nodeName !== 'DD') {
             dd = dd.nextElementSibling;
           }
-          if (!dd) {
-            throw new Error('Switch option without <dd> found: ' + option.textContent);
-          }
           return Object.assign(
             { 'case': getTextContent(option) },
-            serializeStep(dd));
+            dd ? serializeStep(dd) : {});
         })
       }
-    ]
+    ];
   }
   else if (root.nodeName === 'OL') {
     return [...root.querySelectorAll('& > li')].map(li => serializeStep(li));

--- a/test/extract-algorithms.js
+++ b/test/extract-algorithms.js
@@ -111,6 +111,37 @@ const tests = [
   },
 
   {
+    title: 'does not choke on a badly written switch',
+    html: `
+      <p>To <dfn id="be">be or not to be</dfn>, given <var>will</var>:</p>
+      <dl class="switch">
+        <dt>to be</dt>
+        <dt>not to be</dt>
+      </dl>`,
+    algorithms: [
+      {
+        name: 'be or not to be',
+        href: 'about:blank#be',
+        html: 'To <dfn id=\"be\">be or not to be</dfn>, given <var>will</var>:',
+        rationale: '.switch',
+        steps: [
+          {
+            operation: 'switch',
+            steps: [
+              {
+                case: 'to be'
+              },
+              {
+                case: 'not to be'
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+
+  {
     title: 'extracts an algorithm when an operation is found (return)',
     html: `
       <ol><li>Return foo.</li></ol>`,


### PR DESCRIPTION
Specs from the FIDO Alliance have algorithm-like steps that use of the `<dl class="switch">` form, but one of these only has `<dt>` without any `<dd>` which resulted in an error being thrown by Reffy.

The extraction logic can now handle that case, reporting the option without further details.