### PR TITLE
Add a backrefs post-processing module

### DIFF
--- a/schemas/browserlib/extract-dfns.json
+++ b/schemas/browserlib/extract-dfns.json
@@ -30,10 +30,7 @@
       "localLinkingText": { "$ref": "../common.json#/$defs/strings" },
       "type": { "$ref": "../common.json#/$defs/dfnType" },
       "for": { "$ref": "../common.json#/$defs/strings" },
-      "access": {
-        "type": "string",
-        "enum": ["private", "public"]
-      },
+      "access": { "$ref": "../common.json#/$defs/access" },
       "informative": {
         "type": "boolean"
       },

--- a/schemas/browserlib/extract-dfns.json
+++ b/schemas/browserlib/extract-dfns.json
@@ -26,14 +26,8 @@
     "properties": {
       "id": { "$ref": "../common.json#/$defs/id" },
       "href": { "$ref": "../common.json#/$defs/url" },
-      "linkingText": {
-        "type": "array",
-        "items": { "type": "string" }
-      },
-      "localLinkingText": {
-        "type": "array",
-        "items": { "type": "string" }
-      },
+      "linkingText": { "$ref": "../common.json#/$defs/strings" },
+      "localLinkingText": { "$ref": "../common.json#/$defs/strings" },
       "type": {
         "type": "string",
         "enum": [
@@ -51,10 +45,7 @@
         ],
         "$comment": "Types taken from src/browserlib/extract-dfns.mjs"
       },
-      "for": {
-        "type": "array",
-        "items": { "type": "string" }
-      },
+      "for": { "$ref": "../common.json#/$defs/strings" },
       "access": {
         "type": "string",
         "enum": ["private", "public"]

--- a/schemas/browserlib/extract-dfns.json
+++ b/schemas/browserlib/extract-dfns.json
@@ -28,23 +28,7 @@
       "href": { "$ref": "../common.json#/$defs/url" },
       "linkingText": { "$ref": "../common.json#/$defs/strings" },
       "localLinkingText": { "$ref": "../common.json#/$defs/strings" },
-      "type": {
-        "type": "string",
-        "enum": [
-          "property", "descriptor", "value", "type",
-          "at-rule", "function", "selector",
-          "namespace", "interface", "constructor", "method", "argument",
-          "attribute", "callback", "dictionary", "dict-member", "enum",
-          "enum-value", "exception", "const", "typedef", "stringifier",
-          "serializer", "iterator", "maplike", "setlike", "extended-attribute",
-          "event", "permission",
-          "element", "element-state", "element-attr", "attr-value",
-          "cddl-module", "cddl-type", "cddl-parameter", "cddl-key", "cddl-value",
-          "scheme", "http-header",
-          "grammar", "abstract-op", "dfn"
-        ],
-        "$comment": "Types taken from src/browserlib/extract-dfns.mjs"
-      },
+      "type": { "$ref": "../common.json#/$defs/dfnType" },
       "for": { "$ref": "../common.json#/$defs/strings" },
       "access": {
         "type": "string",

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -93,6 +93,24 @@
       "items": { "type": "string" }
     },
 
+    "dfnType": {
+      "type": "string",
+      "enum": [
+        "property", "descriptor", "value", "type",
+        "at-rule", "function", "selector",
+        "namespace", "interface", "constructor", "method", "argument",
+        "attribute", "callback", "dictionary", "dict-member", "enum",
+        "enum-value", "exception", "const", "typedef", "stringifier",
+        "serializer", "iterator", "maplike", "setlike", "extended-attribute",
+        "event", "permission",
+        "element", "element-state", "element-attr", "attr-value",
+        "cddl-module", "cddl-type", "cddl-parameter", "cddl-key", "cddl-value",
+        "scheme", "http-header",
+        "grammar", "abstract-op", "dfn"
+      ],
+      "$comment": "Types taken from src/browserlib/extract-dfns.mjs"
+    },
+
     "headingNumber": {
       "type": "string",
       "pattern": "^(\\d+|[A-Z])(\\.\\d+)*$",

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -111,6 +111,11 @@
       "$comment": "Types taken from src/browserlib/extract-dfns.mjs"
     },
 
+    "access": {
+      "type": "string",
+      "enum": ["private", "public"]
+    },
+
     "headingNumber": {
       "type": "string",
       "pattern": "^(\\d+|[A-Z])(\\.\\d+)*$",

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -88,6 +88,11 @@
       "minLength": 1
     },
 
+    "strings": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+
     "headingNumber": {
       "type": "string",
       "pattern": "^(\\d+|[A-Z])(\\.\\d+)*$",

--- a/schemas/postprocessing/backrefs.json
+++ b/schemas/postprocessing/backrefs.json
@@ -21,10 +21,7 @@
           "linkingText": { "$ref": "../common.json#/$defs/strings" },
           "type": { "$ref": "../common.json#/$defs/dfnType" },
           "for": { "$ref": "../common.json#/$defs/strings" },
-          "access": {
-            "type": "string",
-            "enum": ["private", "public"]
-          },
+          "access": { "$ref": "../common.json#/$defs/access" },
           "referencedBy": {
             "type": "array",
             "minItems": 1,

--- a/schemas/postprocessing/backrefs.json
+++ b/schemas/postprocessing/backrefs.json
@@ -19,23 +19,7 @@
           "id": { "$ref": "../common.json#/$defs/id" },
           "href": { "$ref": "../common.json#/$defs/url" },
           "linkingText": { "$ref": "../common.json#/$defs/strings" },
-          "type": {
-            "type": "string",
-            "enum": [
-              "property", "descriptor", "value", "type",
-              "at-rule", "function", "selector",
-              "namespace", "interface", "constructor", "method", "argument",
-              "attribute", "callback", "dictionary", "dict-member", "enum",
-              "enum-value", "exception", "const", "typedef", "stringifier",
-              "serializer", "iterator", "maplike", "setlike", "extended-attribute",
-              "event", "permission",
-              "element", "element-state", "element-attr", "attr-value",
-              "cddl-module", "cddl-type", "cddl-parameter", "cddl-key", "cddl-value",
-              "scheme", "http-header",
-              "grammar", "abstract-op", "dfn"
-            ],
-            "$comment": "Types taken from src/browserlib/extract-dfns.mjs"
-          },
+          "type": { "$ref": "../common.json#/$defs/dfnType" },
           "for": { "$ref": "../common.json#/$defs/strings" },
           "access": {
             "type": "string",

--- a/schemas/postprocessing/backrefs.json
+++ b/schemas/postprocessing/backrefs.json
@@ -18,10 +18,7 @@
         "properties": {
           "id": { "$ref": "../common.json#/$defs/id" },
           "href": { "$ref": "../common.json#/$defs/url" },
-          "linkingText": {
-            "type": "array",
-            "items": { "type": "string" }
-          },
+          "linkingText": { "$ref": "../common.json#/$defs/strings" },
           "type": {
             "type": "string",
             "enum": [
@@ -39,10 +36,7 @@
             ],
             "$comment": "Types taken from src/browserlib/extract-dfns.mjs"
           },
-          "for": {
-            "type": "array",
-            "items": { "type": "string" }
-          },
+          "for": { "$ref": "../common.json#/$defs/strings" },
           "access": {
             "type": "string",
             "enum": ["private", "public"]

--- a/schemas/postprocessing/backrefs.json
+++ b/schemas/postprocessing/backrefs.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/w3c/reffy/blob/main/schemas/postprocessing/backrefs.json",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["spec", "backrefs"],
+  "properties": {
+    "spec": { "$ref": "../common.json#/$defs/specInExtract" },
+
+    "backrefs": {
+      "description": "List of definitions that the spec owns and that are referenced by other specs, along with the specs that reference them.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "href", "linkingText", "type", "for", "access", "referencedBy"],
+        "properties": {
+          "id": { "$ref": "../common.json#/$defs/id" },
+          "href": { "$ref": "../common.json#/$defs/url" },
+          "linkingText": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "property", "descriptor", "value", "type",
+              "at-rule", "function", "selector",
+              "namespace", "interface", "constructor", "method", "argument",
+              "attribute", "callback", "dictionary", "dict-member", "enum",
+              "enum-value", "exception", "const", "typedef", "stringifier",
+              "serializer", "iterator", "maplike", "setlike", "extended-attribute",
+              "event", "permission",
+              "element", "element-state", "element-attr", "attr-value",
+              "cddl-module", "cddl-type", "cddl-parameter", "cddl-key", "cddl-value",
+              "scheme", "http-header",
+              "grammar", "abstract-op", "dfn"
+            ],
+            "$comment": "Types taken from src/browserlib/extract-dfns.mjs"
+          },
+          "for": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "access": {
+            "type": "string",
+            "enum": ["private", "public"]
+          },
+          "referencedBy": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["shortname", "title", "url"],
+              "properties": {
+                "shortname": { "$ref": "../common.json#/$defs/shortname" },
+                "title": { "$ref": "../common.json#/$defs/title" },
+                "url": { "$ref": "../common.json#/$defs/url" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/lib/post-processor.js
+++ b/src/lib/post-processor.js
@@ -51,6 +51,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { createFolderIfNeeded, shouldSaveToFile } from './util.js';
+import backrefs from '../postprocessing/backrefs.js';
 import csscomplete from '../postprocessing/csscomplete.js';
 import cssmerge from '../postprocessing/cssmerge.js';
 import events from '../postprocessing/events.js';
@@ -64,6 +65,7 @@ import patchdfns from '../postprocessing/patch-dfns.js';
  * Core post-processing modules
  */
 const modules = {
+  backrefs,
   csscomplete,
   cssmerge,
   events,

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1069,6 +1069,8 @@ async function getSchemaValidationFunction(schemaName) {
         switch (name) {
             case 'index.json':
                 return path.join('files', name);
+            case 'backrefs':
+                return path.join('postprocessing', 'backrefs.json');
             case 'idlnamesparsed':
                 return path.join('postprocessing', 'idlnames-parsed.json');
             case 'idlparsed':

--- a/src/postprocessing/backrefs.js
+++ b/src/postprocessing/backrefs.js
@@ -1,0 +1,212 @@
+/**
+ * Post-processing module that creates back references extracts per spec. A
+ * back references extract contains all terms defined in a spec that are
+ * referenced by other specs, along with the list of specs that reference the
+ * term.
+ *
+ * The module runs at the crawl level.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { createFolderIfNeeded, shouldSaveToFile } from '../lib/util.js';
+
+
+/**
+ * Definition of the post-processing module
+ */
+export default {
+  dependsOn: ['dfns', 'links'],
+  input: 'crawl',
+
+  run: async function (crawl, options) {
+    // href → { definingShortname, dfn }
+    const linksIndex = new Map();
+    // definingShortname → Map(dfnHref → { dfn fields, referencedBy: Map })
+    const byDefiningSpec = new Map();
+
+    for (const spec of crawl.results) {
+      for (const dfn of (spec.dfns || [])) {
+        const entry = {
+          definingShortname: spec.shortname,
+          dfn
+        };
+        indexDfnHref(linksIndex, dfn.href, entry);
+
+        if (!byDefiningSpec.has(spec.shortname)) {
+          byDefiningSpec.set(spec.shortname, {
+            spec,
+            terms: new Map()
+          });
+        }
+        const terms = byDefiningSpec.get(spec.shortname).terms;
+        if (!terms.has(dfn.href)) {
+          terms.set(dfn.href, {
+            id: dfn.id,
+            href: dfn.href,
+            linkingText: dfn.linkingText,
+            type: dfn.type,
+            for: dfn.for,
+            access: dfn.access,
+            referencedBy: new Map()
+          });
+        }
+      }
+    }
+
+    for (const spec of crawl.results) {
+      const referrer = {
+        shortname: spec.shortname,
+        title: spec.title,
+        url: spec.nightly?.url || spec.crawled || spec.url
+      };
+      for (const link of expandFragmentLinks(spec)) {
+        let match = null;
+        for (const form of alternateLinkForms(link)) {
+          match = linksIndex.get(form);
+          if (match) {
+            break;
+          }
+        }
+        if (!match) {
+          continue;
+        }
+        // Exclude self-references
+        if (match.definingShortname === spec.shortname) {
+          continue;
+        }
+        const bucket = byDefiningSpec.get(match.definingShortname);
+        const term = bucket?.terms.get(match.dfn.href);
+        if (!term) {
+          continue;
+        }
+        if (!term.referencedBy.has(referrer.shortname)) {
+          term.referencedBy.set(referrer.shortname, referrer);
+        }
+      }
+    }
+
+    for (const spec of crawl.results) {
+      const terms = byDefiningSpec.get(spec.shortname)?.terms;
+      if (!terms) {
+        delete spec.backrefs;
+        continue;
+      }
+
+      // Note: need to convert Maps to regular arrays for serialization
+      const backrefs = [...terms.values()]
+        .filter(term => term.referencedBy.size > 0);
+      if (backrefs.length === 0) {
+        delete spec.backrefs;
+        continue;
+      }
+
+      for (const backref of backrefs) {
+        backref.referencedBy = [...backref.referencedBy.values()];
+      }
+      spec.backrefs = backrefs;
+    }
+
+    return crawl;
+  },
+
+  save: async function (crawl, options) {
+    if (!shouldSaveToFile(options)) {
+      return;
+    }
+
+    function getBaseJSON(spec) {
+      return {
+        spec: {
+          title: spec.title,
+          url: spec.crawled
+        }
+      };
+    }
+
+    const folder = path.join(options.output, 'backrefs');
+    await createFolderIfNeeded(folder);
+
+    // Create backrefs extracts
+    for (const spec of crawl.results) {
+      if (!spec.backrefs) {
+        continue;
+      }
+
+      const contents = getBaseJSON(spec);
+      contents.backrefs = spec.backrefs;
+      const json = JSON.stringify(contents, null, 2);
+      const filename = path.join(folder, spec.shortname + '.json');
+      await fs.promises.writeFile(filename, json);
+      spec.backrefs = `backrefs/${spec.shortname}.json`;
+    }
+
+    // Re-generate index.json file
+    // (starting from saved file because we expanded a few properties)
+    const indexFilename = path.join(options.output, 'index.json');
+    const index = JSON.parse(await fs.promises.readFile(indexFilename, 'utf8'));
+    for (const specInIndex of index.results) {
+      const spec = crawl.results.find(spec => spec.shortname === specInIndex.shortname);
+      if (spec.backrefs) {
+        specInIndex.backrefs = spec.backrefs;
+      }
+      else {
+        delete specInIndex.backrefs;
+      }
+    }
+    await fs.promises.writeFile(indexFilename, JSON.stringify(index, null, 2));
+  }
+};
+
+
+
+/**
+ * Index a dfn href and HTML/ECMAScript multipage ↔ single-page aliases.
+ */
+function indexDfnHref(linksIndex, href, entry) {
+  linksIndex.set(href, entry);
+  if (href.startsWith('https://html.spec.whatwg.org/multipage/') ||
+      href.startsWith('https://tc39.es/ecma262/multipage/')) {
+    const singlePageUrl = href.replace(/\/multipage\/[^#]+#/, '/#');
+    linksIndex.set(singlePageUrl, entry);
+  }
+}
+
+
+/**
+ * Expand a referring spec's links extracts into absolute fragment URLs.
+ */
+function expandFragmentLinks(spec) {
+  const links = spec.links;
+  if (!links) {
+    return [];
+  }
+  const bases = new Set([
+    ...Object.keys(links.rawlinks || {}),
+    ...Object.keys(links.autolinks || {})
+  ]);
+  const fullLinks = [];
+  for (const link of bases) {
+    const anchors = [
+      ...(links.rawlinks?.[link]?.anchors || []),
+      ...(links.autolinks?.[link]?.anchors || [])
+    ];
+    for (const frag of anchors) {
+      fullLinks.push(`${link}#${frag}`);
+    }
+  }
+  return [...new Set(fullLinks)];
+}
+
+
+/**
+ * Normalize multipage HTML/ES links to the single-page form used by many dfns.
+ */
+function alternateLinkForms(link) {
+  const forms = [link];
+  if (link.startsWith('https://html.spec.whatwg.org/multipage/') ||
+      link.startsWith('https://tc39.es/ecma262/multipage/')) {
+    forms.push(link.replace(/\/multipage\/[^#]+#/, '/#'));
+  }
+  return forms;
+}

--- a/test/generate-backrefs.js
+++ b/test/generate-backrefs.js
@@ -1,0 +1,326 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import backrefs from '../src/postprocessing/backrefs.js';
+import { getSchemaValidationFunction } from '../src/lib/util.js';
+
+function makeDfn({ id, href, linkingText, type = 'dfn', for: dfnFor = [], access = 'public' }) {
+  return {
+    id,
+    href,
+    linkingText: Array.isArray(linkingText) ? linkingText : [linkingText ?? id],
+    type,
+    for: dfnFor,
+    access
+  };
+}
+
+function makeLinks(fragmentUrls) {
+  const rawlinks = {};
+  for (const url of fragmentUrls) {
+    const [base, frag] = url.split('#');
+    if (!rawlinks[base]) {
+      rawlinks[base] = { anchors: [] };
+    }
+    if (frag) {
+      rawlinks[base].anchors.push(frag);
+    }
+  }
+  return { rawlinks, autolinks: {} };
+}
+
+function makeSpec({ shortname, title, url, dfns = [], links = null }) {
+  return {
+    shortname,
+    title,
+    url,
+    crawled: url,
+    nightly: { url },
+    dfns,
+    links
+  };
+}
+
+describe('The backrefs post-processing module', () => {
+  it('leaves specs without externally referenced dfns without backrefs', async () => {
+    const crawl = {
+      results: [
+        makeSpec({
+          shortname: 'alpha',
+          title: 'Alpha',
+          url: 'https://example.org/alpha/',
+          dfns: [
+            makeDfn({
+              id: 'lonely',
+              href: 'https://example.org/alpha/#lonely',
+              linkingText: 'lonely'
+            })
+          ]
+        }),
+        makeSpec({
+          shortname: 'beta',
+          title: 'Beta',
+          url: 'https://example.org/beta/',
+          links: makeLinks(['https://example.org/beta/#self'])
+        })
+      ]
+    };
+
+    await backrefs.run(crawl, {});
+    assert.equal(crawl.results[0].backrefs, undefined);
+    assert.equal(crawl.results[1].backrefs, undefined);
+  });
+
+  it('records external references and excludes self-references', async () => {
+    const crawl = {
+      results: [
+        makeSpec({
+          shortname: 'streams',
+          title: 'Streams Standard',
+          url: 'https://streams.spec.whatwg.org/',
+          dfns: [
+            makeDfn({
+              id: 'readablestream',
+              href: 'https://streams.spec.whatwg.org/#readablestream',
+              linkingText: 'ReadableStream',
+              type: 'interface'
+            }),
+            makeDfn({
+              id: 'unreferenced',
+              href: 'https://streams.spec.whatwg.org/#unreferenced',
+              linkingText: 'unreferenced'
+            })
+          ],
+          links: makeLinks([
+            'https://streams.spec.whatwg.org/#readablestream'
+          ])
+        }),
+        makeSpec({
+          shortname: 'fetch',
+          title: 'Fetch Standard',
+          url: 'https://fetch.spec.whatwg.org/',
+          links: makeLinks([
+            'https://streams.spec.whatwg.org/#readablestream'
+          ])
+        })
+      ]
+    };
+
+    await backrefs.run(crawl, {});
+
+    assert.equal(crawl.results[1].backrefs, undefined);
+    assert.deepEqual(crawl.results[0].backrefs, [
+      {
+        id: 'readablestream',
+        href: 'https://streams.spec.whatwg.org/#readablestream',
+        linkingText: ['ReadableStream'],
+        type: 'interface',
+        for: [],
+        access: 'public',
+        referencedBy: [
+          {
+            shortname: 'fetch',
+            title: 'Fetch Standard',
+            url: 'https://fetch.spec.whatwg.org/'
+          }
+        ]
+      }
+    ]);
+  });
+
+  it('preserves definition and referrer document order', async () => {
+    const crawl = {
+      results: [
+        makeSpec({
+          shortname: 'defining',
+          title: 'Defining Spec',
+          url: 'https://example.org/defining/',
+          dfns: [
+            makeDfn({
+              id: 'zebra',
+              href: 'https://example.org/defining/#zebra',
+              linkingText: 'zebra'
+            }),
+            makeDfn({
+              id: 'apple',
+              href: 'https://example.org/defining/#apple',
+              linkingText: 'apple'
+            })
+          ]
+        }),
+        makeSpec({
+          shortname: 'zeta',
+          title: 'Zeta',
+          url: 'https://example.org/zeta/',
+          links: makeLinks([
+            'https://example.org/defining/#zebra',
+            'https://example.org/defining/#apple'
+          ])
+        }),
+        makeSpec({
+          shortname: 'alpha',
+          title: 'Alpha',
+          url: 'https://example.org/alpha/',
+          links: makeLinks([
+            'https://example.org/defining/#zebra',
+            'https://example.org/defining/#apple'
+          ])
+        })
+      ]
+    };
+
+    await backrefs.run(crawl, {});
+    const terms = crawl.results[0].backrefs;
+    assert.deepEqual(terms.map(t => t.id), ['zebra', 'apple']);
+    assert.deepEqual(
+      terms[0].referencedBy.map(r => r.shortname),
+      ['zeta', 'alpha']
+    );
+  });
+
+  it('includes private dfns and copies for/access fields', async () => {
+    const crawl = {
+      results: [
+        makeSpec({
+          shortname: 'defining',
+          title: 'Defining Spec',
+          url: 'https://example.org/defining/',
+          dfns: [
+            makeDfn({
+              id: 'secret-method',
+              href: 'https://example.org/defining/#secret-method',
+              linkingText: 'secret()',
+              type: 'method',
+              for: ['SecretInterface'],
+              access: 'private'
+            })
+          ]
+        }),
+        makeSpec({
+          shortname: 'referrer',
+          title: 'Referrer Spec',
+          url: 'https://example.org/referrer/',
+          links: makeLinks(['https://example.org/defining/#secret-method'])
+        })
+      ]
+    };
+
+    await backrefs.run(crawl, {});
+    assert.deepEqual(crawl.results[0].backrefs, [
+      {
+        id: 'secret-method',
+        href: 'https://example.org/defining/#secret-method',
+        linkingText: ['secret()'],
+        type: 'method',
+        for: ['SecretInterface'],
+        access: 'private',
+        referencedBy: [
+          {
+            shortname: 'referrer',
+            title: 'Referrer Spec',
+            url: 'https://example.org/referrer/'
+          }
+        ]
+      }
+    ]);
+  });
+
+  it('matches multipage HTML links against single-page dfn hrefs', async () => {
+    const crawl = {
+      results: [
+        makeSpec({
+          shortname: 'html',
+          title: 'HTML Standard',
+          url: 'https://html.spec.whatwg.org/multipage/',
+          dfns: [
+            makeDfn({
+              id: 'dom-document',
+              href: 'https://html.spec.whatwg.org/multipage/dom.html#dom-document',
+              linkingText: 'Document',
+              type: 'interface'
+            })
+          ]
+        }),
+        makeSpec({
+          shortname: 'dom',
+          title: 'DOM Standard',
+          url: 'https://dom.spec.whatwg.org/',
+          links: makeLinks(['https://html.spec.whatwg.org/#dom-document'])
+        })
+      ]
+    };
+
+    await backrefs.run(crawl, {});
+    assert.equal(crawl.results[0].backrefs.length, 1);
+    assert.equal(
+      crawl.results[0].backrefs[0].referencedBy[0].shortname,
+      'dom'
+    );
+  });
+
+  it('saves per-spec extracts and updates index.json', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'reffy-backrefs-'));
+    try {
+      const crawl = {
+        results: [
+          makeSpec({
+            shortname: 'streams',
+            title: 'Streams Standard',
+            url: 'https://streams.spec.whatwg.org/',
+            dfns: [
+              makeDfn({
+                id: 'readablestream',
+                href: 'https://streams.spec.whatwg.org/#readablestream',
+                linkingText: 'ReadableStream',
+                type: 'interface'
+              })
+            ]
+          }),
+          makeSpec({
+            shortname: 'fetch',
+            title: 'Fetch Standard',
+            url: 'https://fetch.spec.whatwg.org/',
+            links: makeLinks([
+              'https://streams.spec.whatwg.org/#readablestream'
+            ])
+          })
+        ]
+      };
+
+      await backrefs.run(crawl, {});
+      await fs.writeFile(
+        path.join(tmp, 'index.json'),
+        JSON.stringify({
+          results: crawl.results.map(spec => ({
+            shortname: spec.shortname,
+            title: spec.title
+          }))
+        }, null, 2)
+      );
+
+      await backrefs.save(crawl, { output: tmp });
+
+      const extractPath = path.join(tmp, 'backrefs', 'streams.json');
+      const extract = JSON.parse(await fs.readFile(extractPath, 'utf8'));
+      assert.deepEqual(extract.spec, {
+        title: 'Streams Standard',
+        url: 'https://streams.spec.whatwg.org/'
+      });
+      assert.equal(extract.backrefs.length, 1);
+      assert.equal(crawl.results[0].backrefs, 'backrefs/streams.json');
+
+      const index = JSON.parse(await fs.readFile(path.join(tmp, 'index.json'), 'utf8'));
+      assert.equal(index.results[0].backrefs, 'backrefs/streams.json');
+      assert.equal(index.results[1].backrefs, undefined);
+
+      const validate = await getSchemaValidationFunction('backrefs');
+      assert.equal(typeof validate, 'function');
+      assert.equal(validate(extract), null);
+    }
+    finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add a crawl-level `backrefs` post-processing module that builds per-spec back-reference extracts from curated `dfns` and `links` (terms defined in a spec that other specs reference).
- Reuses the algorithm from [w3c/webref#1997](https://github.com/w3c/webref/pull/1997) / Webdex, preserving document order (no `.sort()`).
- Adds the JSON schema under `schemas/postprocessing/backrefs.json`, wires it into `getSchemaValidationFunction`, and covers the module with unit tests.

This completes the work sketched in [w3c/reffy#2127](https://github.com/w3c/reffy/pull/2127) (schema + tests). Once released, Webref can drop `prepare-backrefs.js` and invoke the module via `crawlSpecs({ post: [..., 'backrefs'] })`.

Related: [w3c/webref#1934](https://github.com/w3c/webref/issues/1934)

Run against an existing crawl:

```bash
node reffy.js --use-crawl [path] --output [folder] --post backrefs
```

## Test plan
- [ ] `node --test test/generate-backrefs.js`
- [ ] Spot-check a generated extract (e.g. Streams) for external referrers only, and that term/referrer order matches dfn/document order
- [ ] Confirm schema validation succeeds for a sample `backrefs/*.json` via `getSchemaValidationFunction('backrefs')`