### PR TITLE
Extract SVGNameList shared list-interface dfns

### DIFF
--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -930,7 +930,7 @@ function preProcessSVG2() {
     if (containername && membername) {
       let container = idlTree.find(i => i.name === containername);
       if (container) {
-        let member = container.members.find(m => m.name === membername);
+        let member = findSvgMember(container, membername);
         if (member) {
           const dfn = document.createElement("dfn");
           dfn.id = el.id;
@@ -961,6 +961,22 @@ function preProcessSVG2() {
     }
   });
 
+}
+
+
+/**
+ * Find an IDL member matching an SVG `__svg__*` anchor member name.
+ * Indexed property setters are encoded as `__svg__…__setter` and appear in
+ * the IDL AST as unnamed operations with `special: "setter"`.
+ */
+function findSvgMember(container, membername) {
+  if (!container?.members) {
+    return null;
+  }
+  if (membername === 'setter') {
+    return container.members.find(m => m.special === 'setter') || null;
+  }
+  return container.members.find(m => m.name === membername) || null;
 }
 
 /**

--- a/src/browserlib/extract-dfns.mjs
+++ b/src/browserlib/extract-dfns.mjs
@@ -928,17 +928,28 @@ function preProcessSVG2() {
   document.querySelectorAll('b[id^="__svg__"]').forEach(el => {
     const [,, containername, membername] = el.id.split('__');
     if (containername && membername) {
-      let container = idlTree.find(i => i.name === containername);
-      if (container) {
-        let member = findSvgMember(container, membername);
-        if (member) {
-          const dfn = document.createElement("dfn");
-          dfn.id = el.id;
-          dfn.textContent = el.textContent;
-          dfn.dataset.dfnFor = containername;
-          dfn.dataset.dfnType = member.type === "operation" ? "method" : member.type;
-          el.replaceWith(dfn);
-        }
+      // Most SVG member anchors name the IDL interface directly
+      // (__svg__SVGElement__className). Shared list-interface members are
+      // instead defined once under the SVGNameList template ID, while the
+      // concrete interfaces (SVGLengthList, SVGNumberList, ...) are the ones
+      // that actually exist in IDL. A mixin would be a poor fit here because
+      // the member signatures differ per concrete interface.
+      // See https://github.com/w3c/reffy/issues/2102
+      let containers = idlTree.filter(i => i.name === containername);
+      if (containers.length === 0 && containername === 'SVGNameList') {
+        containers = idlTree.filter(i =>
+          i.type === 'interface' &&
+          /^SVG\w+List$/.test(i.name) &&
+          findSvgMember(i, membername));
+      }
+      const member = containers.map(c => findSvgMember(c, membername)).find(Boolean);
+      if (member && containers.length) {
+        const dfn = document.createElement("dfn");
+        dfn.id = el.id;
+        dfn.textContent = el.textContent;
+        dfn.dataset.dfnFor = containers.map(c => c.name).join(',');
+        dfn.dataset.dfnType = member.type === "operation" ? "method" : member.type;
+        el.replaceWith(dfn);
       }
     }
   });
@@ -962,7 +973,6 @@ function preProcessSVG2() {
   });
 
 }
-
 
 /**
  * Find an IDL member matching an SVG `__svg__*` anchor member name.

--- a/test/extract-dfns.js
+++ b/test/extract-dfns.js
@@ -48,14 +48,36 @@ enum CanPlayTypeResult { ""};
 const baseSVG2 = `
 <!-- we use the IDL declarations to find the type of attribute vs methods -->
 <pre class=idl>
-interface SVGNameList {
-
+[Exposed=Window]
+interface SVGNumberList {
   readonly attribute unsigned long length;
   readonly attribute unsigned long numberOfItems;
 
-  void clear();
-  Type initialize(Type newItem);
+  undefined clear();
+  SVGNumber initialize(SVGNumber newItem);
+  getter SVGNumber getItem(unsigned long index);
+  SVGNumber insertItemBefore(SVGNumber newItem, unsigned long index);
+  SVGNumber replaceItem(SVGNumber newItem, unsigned long index);
+  SVGNumber removeItem(unsigned long index);
+  SVGNumber appendItem(SVGNumber newItem);
+  setter undefined (unsigned long index, SVGNumber newItem);
 };
+
+[Exposed=Window]
+interface SVGLengthList {
+  readonly attribute unsigned long length;
+  readonly attribute unsigned long numberOfItems;
+
+  undefined clear();
+  SVGLength initialize(SVGLength newItem);
+  getter SVGLength getItem(unsigned long index);
+  SVGLength insertItemBefore(SVGLength newItem, unsigned long index);
+  SVGLength replaceItem(SVGLength newItem, unsigned long index);
+  SVGLength removeItem(unsigned long index);
+  SVGLength appendItem(SVGLength newItem);
+  setter undefined (unsigned long index, SVGLength newItem);
+};
+
 [Exposed=Window]
 interface SVGAnimatedLengthList {
 };
@@ -479,25 +501,49 @@ const tests = [
     spec: "SVG2"
   },
   {
-    title: "identifies IDL attributes and methods defined in SVG2 spec",
+    title: "identifies shared SVG list-interface members under SVGNameList IDs",
     html: `<p>The <b id="__svg__SVGNameList__length">length</b> IDL attribute
 represents the length of the list, and on getting simply return
 the length of the list.</p>
 <p>The <b id="__svg__SVGNameList__initialize">initialize</b> method
 is used to clear the list and add a single, specified value to it.
-When initialize(<var>newItem</var>) is called, the following steps are run:</p>`,
+When initialize(<var>newItem</var>) is called, the following steps are run:</p>
+<p>The behavior of the <b id="__svg__SVGNameList__setter">indexed property setter</b>
+is the same as that for the <a href="#__svg__SVGNameList__replaceItem">replaceItem</a>
+method.</p>`,
     changesToBaseDfn: [{
       id: "__svg__SVGNameList__length",
       linkingText: ["length"],
       type: "attribute",
-      for: ["SVGNameList"],
+      for: ["SVGNumberList", "SVGLengthList"],
       access: "public"
     },
                        {
       id: "__svg__SVGNameList__initialize",
       linkingText: ["initialize"],
       type: "method",
-      for: ["SVGNameList"],
+      for: ["SVGNumberList", "SVGLengthList"],
+      access: "public"
+    },
+                       {
+      id: "__svg__SVGNameList__setter",
+      linkingText: ["indexed property setter"],
+      type: "method",
+      for: ["SVGNumberList", "SVGLengthList"],
+      access: "public"
+    }],
+    spec: "SVG2"
+  },
+  {
+    title: "identifies regular SVG IDL members scoped to a single interface",
+    html: `<p>The <b id="__svg__SVGLengthList__length">length</b> IDL attribute
+should remain scoped to SVGLengthList when the interface is named
+directly in the anchor.</p>`,
+    changesToBaseDfn: [{
+      id: "__svg__SVGLengthList__length",
+      linkingText: ["length"],
+      type: "attribute",
+      for: ["SVGLengthList"],
       access: "public"
     }],
     spec: "SVG2"


### PR DESCRIPTION
## Summary
- Fix SVG2 preprocessing so shared list-interface members under `__svg__SVGNameList__*` anchors are extracted as dfns.
- When `SVGNameList` is not in the IDL (it is only a prose template), scope those dfns to the concrete `SVG*List` interfaces that define the member (`SVGLengthList`, `SVGNumberList`, `SVGPointList`, `SVGStringList`, `SVGTransformList`).
- Also handle indexed property setters (`__svg__…__setter`), which appear in IDL as unnamed operations with `special: "setter"`.

Regular `__svg__$Interface__$member` anchors are unchanged.

Fixes #2102

## Test plan
- [x] `PUPPETEER_CACHE_DIR="$HOME/.cache/puppeteer" node --test --test-name-pattern 'SVG' test/extract-dfns.js`
- [x] Spot-check a crawl of SVG2 for dfns such as `__svg__SVGNameList__appendItem` with `for` listing the concrete list interfaces
- [x] Confirm single-interface anchors like `__svg__SVGElement__className` are still scoped to one interface only