### PR TITLE
Support alternate heading IDs from empty spans and oldids

### DIFF
--- a/src/browserlib/extract-headings.mjs
+++ b/src/browserlib/extract-headings.mjs
@@ -11,13 +11,19 @@ export default function (spec, idToHeading) {
   const esHeadings = [...document.querySelectorAll('emu-clause[id] > h1')].map(n => {
     const headingNumber = n.querySelector(".secnum")?.textContent;
     const headingLevel = headingNumber ? headingNumber.split(".").length : undefined;
-    return {
-      id: n.parentNode.id,
-      href: getAbsoluteUrl(n.parentNode, { singlePage }),
+    const clause = n.parentNode;
+    const res = {
+      id: clause.id,
+      href: getAbsoluteUrl(clause, { singlePage }),
       title: n.textContent.replace(headingNumber, '').trim(),
       level: headingLevel,
       number: headingNumber
     };
+    const alternateIds = idToHeading[res.href]?.alternateIds;
+    if (alternateIds?.length) {
+      res.alternateIds = alternateIds;
+    }
+    return res;
   });
 
   // Headings using spans in www.rfc-editor.org RFCs

--- a/src/browserlib/map-ids-to-headings.mjs
+++ b/src/browserlib/map-ids-to-headings.mjs
@@ -25,6 +25,36 @@ function getCleanTextContent(node) {
   return cleanedNode.textContent.trim().replace(/\s+/g, ' ');
 }
 
+
+/**
+ * Collect alternate IDs carried by empty <span id> elements that appear at the
+ * start of a section, before its heading. Specs such as WebAssembly (Bikeshed)
+ * and ECMAScript (Ecmarkup) use these spans to preserve historical fragment
+ * identifiers. See https://github.com/w3c/reffy/issues/2088
+ */
+function collectEmptySpanAlternateIds(root, heading) {
+  const ids = [];
+  if (!root) {
+    return ids;
+  }
+  for (const child of root.children) {
+    if (child === heading) {
+      break;
+    }
+    const tag = child.nodeName;
+    if (['H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'HGROUP'].includes(tag)) {
+      break;
+    }
+    if (['ARTICLE', 'ASIDE', 'NAV', 'SECTION', 'EMU-INTRO', 'EMU-CLAUSE', 'EMU-ANNEX'].includes(tag)) {
+      break;
+    }
+    if (tag === 'SPAN' && child.id && !getCleanTextContent(child)) {
+      ids.push(child.id);
+    }
+  }
+  return ids;
+}
+
 /**
  * Generate a mapping between elements that have an ID (or a "name") and the
  * closest heading (that also has an ID) under which these elements appear in
@@ -114,8 +144,13 @@ export default function () {
       }
       mapping.href = href;
       mapping.title = trimmedText.replace(reNumber, '');
-      if (ids.length) {
-        mapping.alternateIds = ids;
+
+      // Empty <span id> aliases before the heading are never the primary ID.
+      const spanIds = collectEmptySpanAlternateIds(parentSection.root, heading)
+        .filter(id => id && id !== mapping.id && !ids.includes(id));
+      const alternateIds = ids.concat(spanIds);
+      if (alternateIds.length) {
+        mapping.alternateIds = alternateIds;
       }
       mappingTable[nodeid] = mapping;
 

--- a/src/browserlib/map-ids-to-headings.mjs
+++ b/src/browserlib/map-ids-to-headings.mjs
@@ -25,7 +25,6 @@ function getCleanTextContent(node) {
   return cleanedNode.textContent.trim().replace(/\s+/g, ' ');
 }
 
-
 /**
  * Collect alternate IDs carried by empty <span id> elements that appear at the
  * start of a section, before its heading. Specs such as WebAssembly (Bikeshed)
@@ -196,6 +195,12 @@ function esMapIdToHeadings() {
       }
       mapping.href = href;
       mapping.title = trimmedText.replace(reNumber, '');
+
+      const alternateIds = collectEcmascriptAlternateIds(section, heading)
+        .filter(id => id && id !== mapping.id);
+      if (alternateIds.length) {
+        mapping.alternateIds = alternateIds;
+      }
       mappingTable[nodeid] = mapping;
 
       if (number) {
@@ -205,4 +210,21 @@ function esMapIdToHeadings() {
 
     });
   return mappingTable;
+}
+
+/**
+ * Collect alternate IDs for an Ecmarkup clause from its `oldids` attribute and
+ * from empty <span id> aliases placed before the clause heading.
+ */
+function collectEcmascriptAlternateIds(section, heading) {
+  const ids = [];
+  if (section.hasAttribute('oldids')) {
+    ids.push(...section.getAttribute('oldids').split(/\s+/).filter(Boolean));
+  }
+  for (const id of collectEmptySpanAlternateIds(section, heading)) {
+    if (!ids.includes(id)) {
+      ids.push(id);
+    }
+  }
+  return ids;
 }

--- a/test/extract-dfns.js
+++ b/test/extract-dfns.js
@@ -269,7 +269,7 @@ const tests = [
   {
     title: 'extracts abstract operations from ecmascript spec',
     html: '<emu-clause id="sec-toprimitive" oldids="table-9" aoid="ToPrimitive"><span id="table-9"></span><h1><span class="secnum">7.1.1</span> ToPrimitive ( <var>input</var> [ , <var>preferredType</var> ] )</h1>',
-    changesToBaseDfn: [{linkingText: [ "ToPrimitive", "ToPrimitive(input, preferredType)"], type: "abstract-op", access: "public", definedIn: "heading", id: "sec-toprimitive", heading: { number: "7.1.1", id: "sec-toprimitive", href: "about:blank#sec-toprimitive", title: "ToPrimitive ( input [ , preferredType ] )"}}],
+    changesToBaseDfn: [{linkingText: [ "ToPrimitive", "ToPrimitive(input, preferredType)"], type: "abstract-op", access: "public", definedIn: "heading", id: "sec-toprimitive", heading: { number: "7.1.1", id: "sec-toprimitive", href: "about:blank#sec-toprimitive", title: "ToPrimitive ( input [ , preferredType ] )", alternateIds: ["table-9"]}}],
     spec: "ecmascript"
   },
   {

--- a/test/extract-headings.js
+++ b/test/extract-headings.js
@@ -102,6 +102,47 @@ const testHeadings = [
       </h2>
     `,
     res: [{id: "5.2", href: "about:blank#5.2", title: "WebGLContextAttributes", number: "5.2", level: 2, alternateIds: ["WEBGLCONTEXTATTRIBUTES"]}]
+  },
+  {
+    title: "documents empty span alternate IDs before a section heading",
+    html: `
+      <section id="globals">
+        <span id="syntax-global"></span>
+        <span id="index-4①"></span>
+        <h4 class="heading settled" id="globals①">
+          <span class="secno">2.5.4. </span>
+          <span class="content">Globals</span>
+        </h4>
+      </section>
+    `,
+    res: [{
+      id: "globals",
+      href: "about:blank#globals",
+      title: "Globals",
+      number: "2.5.4",
+      level: 4,
+      alternateIds: ["globals①", "syntax-global", "index-4①"]
+    }]
+  },
+  {
+    title: "documents oldids and empty span alternate IDs in ECMAScript clauses",
+    html: `
+      <emu-clause id="sec-%iterator.prototype%-object" oldids="sec-%iteratorprototype%-object">
+        <span id="sec-%iteratorprototype%-object"></span>
+        <h1>
+          <span class="secnum">27.1.3.3</span>
+          Properties of the Iterator Prototype Object
+        </h1>
+      </emu-clause>
+    `,
+    res: [{
+      id: "sec-%iterator.prototype%-object",
+      href: "about:blank#sec-%25iterator.prototype%25-object",
+      title: "Properties of the Iterator Prototype Object",
+      number: "27.1.3.3",
+      level: 4,
+      alternateIds: ["sec-%iteratorprototype%-object"]
+    }]
   }
 ];
 


### PR DESCRIPTION
## Summary
- Collect empty `<span id>` aliases placed before a section heading into `alternateIds` (WebAssembly/Bikeshed pattern such as `syntax-global`).
- For ECMAScript/Ecmarkup clauses, also include historical IDs from the `oldids` attribute and matching empty spans.
- Keep the section/clause ID as the primary heading `id`; empty-span / `oldids` values are alternates only.

This helps tools like BCD resolve older fragment links to the correct section.

Fixes #2088

## Test plan
- [ ] `PUPPETEER_CACHE_DIR="$HOME/.cache/puppeteer" node --test test/extract-headings.js`
- [ ] `PUPPETEER_CACHE_DIR="$HOME/.cache/puppeteer" node --test --test-name-pattern 'abstract operations from ecmascript|alternate heading IDs' test/extract-dfns.js`
- [ ] Spot-check a WebAssembly core headings extract for `globals` including `syntax-global` (and any `index-*` aliases) in `alternateIds`
- [ ] Spot-check an ECMAScript headings/dfns extract for an `emu-clause` with `oldids`