### PR TITLE
Bump web-specs from 4.7.0 to 4.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "fetch-filecache-for-crawling": "5.1.1",
         "puppeteer": "25.7.0",
         "semver": "^7.3.5",
-        "web-specs": "4.7.0",
+        "web-specs": "4.9.0",
         "webidl2": "24.5.0"
       },
       "bin": {
@@ -30,9 +30,6 @@
       "engines": {
         "node": ">=22.19.0"
       }
-    },
-    "../../fetch-filecache-for-crawling": {
-      "extraneous": true
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -1531,9 +1528,10 @@
       }
     },
     "node_modules/web-specs": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-4.7.0.tgz",
-      "integrity": "sha512-+dxYBNTqR+m9yRLmuTiqvpFOomSJPojFM1+baYat4lIW1/58XBiAxwYwSKExqBhYMBGNoNo1Anu+yTLjexReKA=="
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-4.9.0.tgz",
+      "integrity": "sha512-lKFX/woE+Zco4d58J1s3w9WASWcGMxft+O5M5D6a+O9bPLZ32iK8xW5vJW2luNwS7qddAmnOcH3kgaHs9X480Q==",
+      "license": "CC0-1.0"
     },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.2",
@@ -2713,9 +2711,9 @@
       "dev": true
     },
     "web-specs": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-4.7.0.tgz",
-      "integrity": "sha512-+dxYBNTqR+m9yRLmuTiqvpFOomSJPojFM1+baYat4lIW1/58XBiAxwYwSKExqBhYMBGNoNo1Anu+yTLjexReKA=="
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-4.9.0.tgz",
+      "integrity": "sha512-lKFX/woE+Zco4d58J1s3w9WASWcGMxft+O5M5D6a+O9bPLZ32iK8xW5vJW2luNwS7qddAmnOcH3kgaHs9X480Q=="
     },
     "webdriver-bidi-protocol": {
       "version": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "fetch-filecache-for-crawling": "5.1.1",
     "puppeteer": "25.7.0",
     "semver": "^7.3.5",
-    "web-specs": "4.7.0",
+    "web-specs": "4.9.0",
     "webidl2": "24.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Done manually because dependabot now waits 3 days before it proposes to bump a dependency.