### PR TITLE
Allow Puppeteer's post-install script by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "test": "node --test"
   },
   "allowScripts": {
-    "puppeteer@25.3.0": true
+    "puppeteer": true
   }
 }


### PR DESCRIPTION
Npm now defaults to blocking post-install scripts of dependencies. This adds Puppeteer (any version) to the allow-list as described in: https://pptr.dev/troubleshooting#blocked-install-scripts