### PR TITLE
Dependencies: cooldown, group updates, check actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,27 @@ updates:
   schedule:
     interval: daily
     time: '10:00'
-  open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
+    exclude:
+      # W3C-maintained packages are excluded from cooldowns, since we usually
+      # want them as soon as possible
+      - "fetch-filecache-for-crawling"
+      - "web-specs"
+      - "webidl2"
+  groups:
+    npm-dependencies:
+      exclude-patterns:
+        # Don't group W3C-maintained packages
+        - "fetch-filecache-for-crawling"
+        - "web-specs"
+        - "webidl2"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '10:00'
+  groups:
+    actions-dependencies:
+      patterns:
+        - "*"


### PR DESCRIPTION
This creates a default cooldown period of 7 days (compared to the 3 days that Dependabot uses), excluding W3C-maintained dependencies (browser-specs, webidl2 and fetch-filecache-for-crawling) from cooldown.

This also instructs Dependabot to group dependencies updates by default. Development and production dependencies are treated in the same group. W3C-maintained dependencies are again excluded so that they may be treated separately.

And this instructs Dependabot to look into GitHub Actions as well.