### PR TITLE
Detect nested headings linked to an element definition

### DIFF
--- a/src/browserlib/extract-elements.mjs
+++ b/src/browserlib/extract-elements.mjs
@@ -24,9 +24,17 @@ export default function (spec) {
   // Extract HTML elements
   const htmlElements = [...document.querySelectorAll('dl.element')]
     .map(el => {
-      // Get back to heading that defines the element(s)
+      // Get back to the heading that defines the element(s)
+      // Note: heading is at the same level as the <dl> in most specs, except
+      // in the "Install Element" spec where the heading is nested under a
+      // <div>, see: https://wicg.github.io/install-element/#install-element
       let heading = el.previousElementSibling;
       while (heading && !heading.nodeName.match(/^H\d$/)) {
+        if (heading.nodeName === 'DIV' &&
+            heading.querySelector('h1,h2,h3,h4,h5,h6')) {
+          heading = heading.querySelector('h1,h2,h3,h4,h5,h6');
+          break;
+        }
         heading = heading.previousElementSibling;
       }
       if (!heading) {

--- a/test/extract-elements.js
+++ b/test/extract-elements.js
@@ -241,6 +241,29 @@ const tests = [
         href: "about:blank#elementdef-geolocation"
       }
     ]
+  },
+
+  {
+    title: "detects a nested heading next to an element definition",
+    spec: "install-element",
+    html: `<main>
+      <div class="header-wrapper">
+        <h2 id="x13-the-install-element"><bdi class="secno">13.<!---0.197291%--> </bdi>
+        The <code>&lt;<dfn data-dfn-type="element" data-export="" id="dfn-install" tabindex="0" aria-haspopup="dialog">install</dfn>&gt;</code> element
+        </h2>
+      </div>
+      <dl class="element">
+        <dt>DOM interface:</dt>
+        <dd><a data-xref-type="_IDL_" data-link-type="idl" data-lt="HTMLInstallElement" href="#dom-htmlinstallelement" class="internalDFN" id="ref-for-dom-htmlinstallelement-2"><code>HTMLInstallElement<!---0.197291%--></code></a><!---0.197291%-->.</dd>
+      </dl>
+    </main>`,
+    res: [
+      {
+        name: "install",
+        interface: "HTMLInstallElement",
+        href: "about:blank#dfn-install"
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Via https://github.com/w3c/browser-specs/issues/2255

The "Install Element" spec nests the heading that defines the `<install>` element, while the code expected the heading to always be at the same level as the definition list that describes the element.

This update makes the code more flexible when it looks for the heading.

Note: I ran Reffy locally across all specs to confirm that it wouldn't create any false positive.