### PR TITLE
[headings] Extract annex headings in TC39 specs

### DIFF
--- a/src/browserlib/extract-headings.mjs
+++ b/src/browserlib/extract-headings.mjs
@@ -8,13 +8,15 @@ export default function (spec, idToHeading) {
   const singlePage = !document.querySelector('[data-reffy-page]');
 
   // Headings using the markup convention of the EcmaScript spec
-  const esHeadings = [...document.querySelectorAll('emu-clause[id] > h1')].map(n => {
-    const headingNumber = n.querySelector(".secnum")?.textContent;
+  const esHeadings = [...document.querySelectorAll(':is(emu-clause, emu-annex)[id] > h1')].map(n => {
+    const fullHeadingNumber = n.querySelector(".secnum")?.textContent;
+    const match = fullHeadingNumber?.match(/^Annex (\w)/);
+    const headingNumber = match ? match[1] : fullHeadingNumber;
     const headingLevel = headingNumber ? headingNumber.split(".").length : undefined;
     return {
       id: n.parentNode.id,
       href: getAbsoluteUrl(n.parentNode, { singlePage }),
-      title: n.textContent.replace(headingNumber, '').trim(),
+      title: n.textContent.replace(fullHeadingNumber, '').trim(),
       level: headingLevel,
       number: headingNumber
     };

--- a/test/extract-headings.js
+++ b/test/extract-headings.js
@@ -102,6 +102,30 @@ const testHeadings = [
       </h2>
     `,
     res: [{id: "5.2", href: "about:blank#5.2", title: "WebGLContextAttributes", number: "5.2", level: 2, alternateIds: ["WEBGLCONTEXTATTRIBUTES"]}]
+  },
+  {
+    title: "extracts headings from TC39 specs",
+    html: `
+      <emu-clause id="sec-memory-model">
+        <h1><span class="secnum">29</span> Memory Model</h1>
+        <p>The memory consistency model, blah.</p>
+      </emu-clause>`,
+    res: [{id: "sec-memory-model", href: "about:blank#sec-memory-model", title: "Memory Model", number: "29", level: 1}]
+  },
+  {
+    title: "extracts annex headings from TC39 specs",
+    html: `
+      <emu-annex id="sec-grammar-summary">
+        <h1><span class="secnum">Annex A <span class="annex-kind">(informative)</span></span> Grammar Summary</h1>
+        <emu-annex id="sec-lexical-grammar">
+          <h1><span class="secnum">A.1</span> Lexical Grammar</h1>
+          <p>Foo</p>
+        </emu-annex>
+      </emu-annex>`,
+    res: [
+      {id: "sec-grammar-summary", href: "about:blank#sec-grammar-summary", title: "Grammar Summary", number: "A", level: 1},
+      {id: "sec-lexical-grammar", href: "about:blank#sec-lexical-grammar", title: "Lexical Grammar", number: "A.1", level: 2},
+    ]
   }
 ];
 


### PR DESCRIPTION
Fixes #2154.

Headings extraction has some hardcoded logic to extract headings from TC39 specs such as the ECMAScript spec, because the spec uses custom elements such as `<emu-clause>`.

That logic overlooked the fact that annex headings actually use `<emu-annex>`. Some of the annex heading numbers also start with `Annex` and include a note about the informative nature of the section. Extraction strips them to get back to a regular heading "number" (more a string such as "A", "B", "C" here).

Checked with the ECMAScript spec to validate the fact that it completes the extract as expected without affecting the rest.

<details>
<summary>Diff compared to the current headings extract for the ECMAScript spec</summary>

```diff
15862a15863,16374
>   },
>   {
>     "id": "sec-grammar-summary",
>     "href": "https://tc39.es/ecma262/multipage/grammar-summary.html#sec-grammar-summary",
>     "title": "Grammar Summary",
>     "level": 1,
>     "number": "A"
>   },
>   {
>     "id": "sec-lexical-grammar",
>     "href": "https://tc39.es/ecma262/multipage/grammar-summary.html#sec-lexical-grammar",
>     "title": "Lexical Grammar",
>     "level": 2,
>     "number": "A.1"
>   },
>   {
>     "id": "sec-expressions",
>     "href": "https://tc39.es/ecma262/multipage/grammar-summary.html#sec-expressions",
>     "title": "Expressions",
>     "level": 2,
>     "number": "A.2"
>   },
>   {
>     "id": "sec-statements",
>     "href": "https://tc39.es/ecma262/multipage/grammar-summary.html#sec-statements",
>     "title": "Statements",
>     "level": 2,
>     "number": "A.3"
>   },
>   {
>     "id": "sec-functions-and-classes",
>     "href": "https://tc39.es/ecma262/multipage/grammar-summary.html#sec-functions-and-classes",
>     "title": "Functions and Classes",
>     "level": 2,
>     "number": "A.4"
>   },
>   {
>     "id": "sec-scripts-and-modules",
>     "href": "https://tc39.es/ecma262/multipage/grammar-summary.html#sec-scripts-and-modules",
>     "title": "Scripts and Modules",
>     "level": 2,
>     "number": "A.5"
>   },
>   {
>     "id": "sec-number-conversions",
>     "href": "https://tc39.es/ecma262/multipage/grammar-summary.html#sec-number-conversions",
>     "title": "Number Conversions",
>     "level": 2,
>     "number": "A.6"
>   },
>   {
>     "id": "sec-time-zone-offset-string-format",
>     "href": "https://tc39.es/ecma262/multipage/grammar-summary.html#sec-time-zone-offset-string-format",
>     "title": "Time Zone Offset String Format",
>     "level": 2,
>     "number": "A.7"
>   },
>   {
>     "id": "sec-regular-expressions",
>     "href": "https://tc39.es/ecma262/multipage/grammar-summary.html#sec-regular-expressions",
>     "title": "Regular Expressions",
>     "level": 2,
>     "number": "A.8"
>   },
>   {
>     "id": "sec-additional-ecmascript-features-for-web-browsers",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-additional-ecmascript-features-for-web-browsers",
>     "title": "Additional ECMAScript Features for Web Browsers",
>     "level": 1,
>     "number": "B"
>   },
>   {
>     "id": "sec-additional-syntax",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-additional-syntax",
>     "title": "Additional Syntax",
>     "level": 2,
>     "number": "B.1"
>   },
>   {
>     "id": "sec-html-like-comments",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-html-like-comments",
>     "title": "HTML-like Comments",
>     "level": 3,
>     "number": "B.1.1"
>   },
>   {
>     "id": "sec-regular-expressions-patterns",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-regular-expressions-patterns",
>     "title": "Regular Expressions Patterns",
>     "level": 3,
>     "number": "B.1.2"
>   },
>   {
>     "id": "sec-patterns-static-semantics-early-errors-annexb",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-patterns-static-semantics-early-errors-annexb",
>     "title": "Static Semantics: Early Errors",
>     "level": 4,
>     "number": "B.1.2.1"
>   },
>   {
>     "id": "sec-countleftcapturingparens-annexb",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-countleftcapturingparens-annexb",
>     "title": "Static Semantics: CountLeftCapturingParensWithin and CountLeftCapturingParensBefore",
>     "level": 4,
>     "number": "B.1.2.2"
>   },
>   {
>     "id": "sec-patterns-static-semantics-is-character-class-annexb",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-patterns-static-semantics-is-character-class-annexb",
>     "title": "Static Semantics: IsCharacterClass",
>     "level": 4,
>     "number": "B.1.2.3"
>   },
>   {
>     "id": "sec-patterns-static-semantics-character-value-annexb",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-patterns-static-semantics-character-value-annexb",
>     "title": "Static Semantics: CharacterValue",
>     "level": 4,
>     "number": "B.1.2.4"
>   },
>   {
>     "id": "sec-compilesubpattern-annexb",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-compilesubpattern-annexb",
>     "title": "Runtime Semantics: CompileSubpattern",
>     "level": 4,
>     "number": "B.1.2.5"
>   },
>   {
>     "id": "sec-compileassertion-annexb",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-compileassertion-annexb",
>     "title": "Runtime Semantics: CompileAssertion",
>     "level": 4,
>     "number": "B.1.2.6"
>   },
>   {
>     "id": "sec-compileatom-annexb",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-compileatom-annexb",
>     "title": "Runtime Semantics: CompileAtom",
>     "level": 4,
>     "number": "B.1.2.7"
>   },
>   {
>     "id": "sec-compiletocharset-annexb",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-compiletocharset-annexb",
>     "title": "Runtime Semantics: CompileToCharSet",
>     "level": 4,
>     "number": "B.1.2.8"
>   },
>   {
>     "id": "sec-runtime-semantics-characterrangeorunion-abstract-operation",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-runtime-semantics-characterrangeorunion-abstract-operation",
>     "title": "CharacterRangeOrUnion ( regexpRecord, charSet, otherSet )",
>     "level": 5,
>     "number": "B.1.2.8.1"
>   },
>   {
>     "id": "sec-parsepattern-annexb",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-parsepattern-annexb",
>     "title": "Static Semantics: ParsePattern ( patternText, u, v )",
>     "level": 4,
>     "number": "B.1.2.9"
>   },
>   {
>     "id": "sec-additional-built-in-properties",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-additional-built-in-properties",
>     "title": "Additional Built-in Properties",
>     "level": 2,
>     "number": "B.2"
>   },
>   {
>     "id": "sec-additional-properties-of-the-global-object",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-additional-properties-of-the-global-object",
>     "title": "Additional Properties of the Global Object",
>     "level": 3,
>     "number": "B.2.1"
>   },
>   {
>     "id": "sec-escape-string",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-escape-string",
>     "title": "escape ( string )",
>     "level": 4,
>     "number": "B.2.1.1"
>   },
>   {
>     "id": "sec-unescape-string",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-unescape-string",
>     "title": "unescape ( string )",
>     "level": 4,
>     "number": "B.2.1.2"
>   },
>   {
>     "id": "sec-additional-properties-of-the-string.prototype-object",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-additional-properties-of-the-string.prototype-object",
>     "title": "Additional Properties of the String.prototype Object",
>     "level": 3,
>     "number": "B.2.2"
>   },
>   {
>     "id": "sec-string.prototype.substr",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.substr",
>     "title": "String.prototype.substr ( start, length )",
>     "level": 4,
>     "number": "B.2.2.1"
>   },
>   {
>     "id": "sec-string.prototype.anchor",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.anchor",
>     "title": "String.prototype.anchor ( name )",
>     "level": 4,
>     "number": "B.2.2.2"
>   },
>   {
>     "id": "sec-createhtml",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-createhtml",
>     "title": "CreateHTML ( contents, tag, attr, attrValue )",
>     "level": 5,
>     "number": "B.2.2.2.1"
>   },
>   {
>     "id": "sec-string.prototype.big",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.big",
>     "title": "String.prototype.big ( )",
>     "level": 4,
>     "number": "B.2.2.3"
>   },
>   {
>     "id": "sec-string.prototype.blink",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.blink",
>     "title": "String.prototype.blink ( )",
>     "level": 4,
>     "number": "B.2.2.4"
>   },
>   {
>     "id": "sec-string.prototype.bold",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.bold",
>     "title": "String.prototype.bold ( )",
>     "level": 4,
>     "number": "B.2.2.5"
>   },
>   {
>     "id": "sec-string.prototype.fixed",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.fixed",
>     "title": "String.prototype.fixed ( )",
>     "level": 4,
>     "number": "B.2.2.6"
>   },
>   {
>     "id": "sec-string.prototype.fontcolor",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.fontcolor",
>     "title": "String.prototype.fontcolor ( colour )",
>     "level": 4,
>     "number": "B.2.2.7"
>   },
>   {
>     "id": "sec-string.prototype.fontsize",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.fontsize",
>     "title": "String.prototype.fontsize ( size )",
>     "level": 4,
>     "number": "B.2.2.8"
>   },
>   {
>     "id": "sec-string.prototype.italics",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.italics",
>     "title": "String.prototype.italics ( )",
>     "level": 4,
>     "number": "B.2.2.9"
>   },
>   {
>     "id": "sec-string.prototype.link",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.link",
>     "title": "String.prototype.link ( url )",
>     "level": 4,
>     "number": "B.2.2.10"
>   },
>   {
>     "id": "sec-string.prototype.small",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.small",
>     "title": "String.prototype.small ( )",
>     "level": 4,
>     "number": "B.2.2.11"
>   },
>   {
>     "id": "sec-string.prototype.strike",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.strike",
>     "title": "String.prototype.strike ( )",
>     "level": 4,
>     "number": "B.2.2.12"
>   },
>   {
>     "id": "sec-string.prototype.sub",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.sub",
>     "title": "String.prototype.sub ( )",
>     "level": 4,
>     "number": "B.2.2.13"
>   },
>   {
>     "id": "sec-string.prototype.sup",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.sup",
>     "title": "String.prototype.sup ( )",
>     "level": 4,
>     "number": "B.2.2.14"
>   },
>   {
>     "id": "String.prototype.trimleft",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#String.prototype.trimleft",
>     "title": "String.prototype.trimLeft ( )",
>     "level": 4,
>     "number": "B.2.2.15"
>   },
>   {
>     "id": "String.prototype.trimright",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#String.prototype.trimright",
>     "title": "String.prototype.trimRight ( )",
>     "level": 4,
>     "number": "B.2.2.16"
>   },
>   {
>     "id": "sec-additional-properties-of-the-date.prototype-object",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-additional-properties-of-the-date.prototype-object",
>     "title": "Additional Properties of the Date.prototype Object",
>     "level": 3,
>     "number": "B.2.3"
>   },
>   {
>     "id": "sec-date.prototype.getyear",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-date.prototype.getyear",
>     "title": "Date.prototype.getYear ( )",
>     "level": 4,
>     "number": "B.2.3.1"
>   },
>   {
>     "id": "sec-date.prototype.setyear",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-date.prototype.setyear",
>     "title": "Date.prototype.setYear ( year )",
>     "level": 4,
>     "number": "B.2.3.2"
>   },
>   {
>     "id": "sec-date.prototype.togmtstring",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-date.prototype.togmtstring",
>     "title": "Date.prototype.toGMTString ( )",
>     "level": 4,
>     "number": "B.2.3.3"
>   },
>   {
>     "id": "sec-additional-properties-of-the-regexp.prototype-object",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-additional-properties-of-the-regexp.prototype-object",
>     "title": "Additional Properties of the RegExp.prototype Object",
>     "level": 3,
>     "number": "B.2.4"
>   },
>   {
>     "id": "sec-regexp.prototype.compile",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-regexp.prototype.compile",
>     "title": "RegExp.prototype.compile ( pattern, flags )",
>     "level": 4,
>     "number": "B.2.4.1"
>   },
>   {
>     "id": "sec-other-additional-features",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-other-additional-features",
>     "title": "Other Additional Features",
>     "level": 2,
>     "number": "B.3"
>   },
>   {
>     "id": "sec-labelled-function-declarations",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-labelled-function-declarations",
>     "title": "Labelled Function Declarations",
>     "level": 3,
>     "number": "B.3.1"
>   },
>   {
>     "id": "sec-block-level-function-declarations-web-legacy-compatibility-semantics",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics",
>     "title": "Block-Level Function Declarations Web Legacy Compatibility Semantics",
>     "level": 3,
>     "number": "B.3.2"
>   },
>   {
>     "id": "sec-functiondeclarations-in-ifstatement-statement-clauses",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-functiondeclarations-in-ifstatement-statement-clauses",
>     "title": "FunctionDeclarations in IfStatement Statement Clauses",
>     "level": 3,
>     "number": "B.3.3"
>   },
>   {
>     "id": "sec-variablestatements-in-catch-blocks",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-variablestatements-in-catch-blocks",
>     "title": "VariableStatements in Catch Blocks",
>     "level": 3,
>     "number": "B.3.4"
>   },
>   {
>     "id": "sec-initializers-in-forin-statement-heads",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-initializers-in-forin-statement-heads",
>     "title": "Initializers in ForIn Statement Heads",
>     "level": 3,
>     "number": "B.3.5"
>   },
>   {
>     "id": "sec-IsHTMLDDA-internal-slot",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-IsHTMLDDA-internal-slot",
>     "title": "The [[IsHTMLDDA]] Internal Slot",
>     "level": 3,
>     "number": "B.3.6"
>   },
>   {
>     "id": "sec-web-compat-host-make-job-callback",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-web-compat-host-make-job-callback",
>     "title": "Non-default behaviour in HostMakeJobCallback",
>     "level": 3,
>     "number": "B.3.7"
>   },
>   {
>     "id": "sec-web-compat-host-ensure-can-add-private-field",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-web-compat-host-ensure-can-add-private-field",
>     "title": "Non-default behaviour in HostEnsureCanAddPrivateElement",
>     "level": 3,
>     "number": "B.3.8"
>   },
>   {
>     "id": "sec-runtime-errors-for-function-call-assignment-targets",
>     "href": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-runtime-errors-for-function-call-assignment-targets",
>     "title": "Runtime Errors for Function Call Assignment Targets",
>     "level": 3,
>     "number": "B.3.9"
>   },
>   {
>     "id": "sec-strict-mode-of-ecmascript",
>     "href": "https://tc39.es/ecma262/multipage/strict-mode-of-ecmascript.html#sec-strict-mode-of-ecmascript",
>     "title": "The Strict Mode of ECMAScript",
>     "level": 1,
>     "number": "C"
>   },
>   {
>     "id": "sec-host-layering-points",
>     "href": "https://tc39.es/ecma262/multipage/host-layering-points.html#sec-host-layering-points",
>     "title": "Host Layering Points",
>     "level": 1,
>     "number": "D"
>   },
>   {
>     "id": "sec-host-hooks-summary",
>     "href": "https://tc39.es/ecma262/multipage/host-layering-points.html#sec-host-hooks-summary",
>     "title": "Host Hooks",
>     "level": 2,
>     "number": "D.1"
>   },
>   {
>     "id": "sec-host-defined-fields-summary",
>     "href": "https://tc39.es/ecma262/multipage/host-layering-points.html#sec-host-defined-fields-summary",
>     "title": "Host-defined Fields",
>     "level": 2,
>     "number": "D.2"
>   },
>   {
>     "id": "sec-host-defined-objects-summary",
>     "href": "https://tc39.es/ecma262/multipage/host-layering-points.html#sec-host-defined-objects-summary",
>     "title": "Host-defined Objects",
>     "level": 2,
>     "number": "D.3"
>   },
>   {
>     "id": "sec-host-running-jobs",
>     "href": "https://tc39.es/ecma262/multipage/host-layering-points.html#sec-host-running-jobs",
>     "title": "Running Jobs",
>     "level": 2,
>     "number": "D.4"
>   },
>   {
>     "id": "sec-host-internal-methods-of-exotic-objects",
>     "href": "https://tc39.es/ecma262/multipage/host-layering-points.html#sec-host-internal-methods-of-exotic-objects",
>     "title": "Internal Methods of Exotic Objects",
>     "level": 2,
>     "number": "D.5"
>   },
>   {
>     "id": "sec-host-built-in-objects-and-methods",
>     "href": "https://tc39.es/ecma262/multipage/host-layering-points.html#sec-host-built-in-objects-and-methods",
>     "title": "Built-in Objects and Methods",
>     "level": 2,
>     "number": "D.6"
>   },
>   {
>     "id": "sec-corrections-and-clarifications-in-ecmascript-2015-with-possible-compatibility-impact",
>     "href": "https://tc39.es/ecma262/multipage/corrections-and-clarifications-in-ecmascript-2015-with-possible-compatibility-impact.html#sec-corrections-and-clarifications-in-ecmascript-2015-with-possible-compatibility-impact",
>     "title": "Corrections and Clarifications in ECMAScript 2015 with Possible Compatibility Impact",
>     "level": 1,
>     "number": "E"
>   },
>   {
>     "id": "sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions",
>     "href": "https://tc39.es/ecma262/multipage/additions-and-changes-that-introduce-incompatibilities-with-prior-editions.html#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions",
>     "title": "Additions and Changes That Introduce Incompatibilities with Prior Editions",
>     "level": 1,
>     "number": "F"
>   },
>   {
>     "id": "sec-bibliography",
>     "href": "https://tc39.es/ecma262/multipage/bibliography.html#sec-bibliography",
>     "title": "Bibliography"
>   },
>   {
>     "id": "sec-colophon",
>     "href": "https://tc39.es/ecma262/multipage/colophon.html#sec-colophon",
>     "title": "Colophon"
>   },
>   {
>     "id": "sec-copyright-and-software-license",
>     "href": "https://tc39.es/ecma262/multipage/copyright-and-software-license.html#sec-copyright-and-software-license",
>     "title": "Copyright & Software License"

```

</details>